### PR TITLE
docs(rfc): import egl/utils foundation design as RFC-0001

### DIFF
--- a/.specs/d4np-php.md
+++ b/.specs/d4np-php.md
@@ -1,0 +1,178 @@
+# Software Specification: d4np-php (PHP Enterprise Utilities Library)
+
+> **Imported into `egl-util-php`** (EADOS design phase, 2026-08-03). The naming in this document
+> reflects the original project name `d4np-php`; the authoritative rename record is the naming
+> mapping table of [RFC-0001](../docs/rfc/0001-egl-utils-library.md) (package `egl/utils`,
+> PSR-4 root `D4np\Utils\`, bridge `egl/utils-psr7-bridge`, root exception `UtilsException`).
+
+| | |
+|---|---|
+| **Version** | 2.0 (addresses spec-review issue #11) |
+| **Date** | 2026-07-14 |
+| **Status** | Reviewed draft |
+| **ADRs** | [ADR-001: DI container](d4np_php_adr_001_di_container.md) · [ADR-002: HTTP wrappers vs PSR-7](d4np_php_adr_002_http_psr7.md) |
+
+## 1. Description & Design Philosophy
+`d4np-php` is a modern PHP library (**PHP 8.1+**, Composer/Packagist, vendor namespace `D4np\Php\`) providing security helpers, typed DTOs, and a minimal PSR-11 DI container for framework-based and native projects.
+
+Design principles:
+* **Strong typing:** immutable `readonly` DTOs instead of unstructured associative arrays.
+* **Clean code:** strict PSR-1/4/11/12 compliance; PHPStan at max level as a CI gate (§8).
+* **Security by explicit mechanism** *(v1's "all I/O sanitizes automatically" is withdrawn — blanket input sanitization is the magic_quotes anti-pattern)*. The security model, stated precisely:
+  1. **Persistence (values):** parameterized queries, always (items 6–7).
+  2. **Persistence (identifiers):** allowlist + strict quoting, because prepared statements do not cover table/column names (item 7).
+  3. **Output:** context-aware escaping at render time (item 9), never input mutilation.
+  4. **Rich HTML:** allowlist sanitization delegated to a proven sanitizer (item 9b).
+
+Each security feature in §2 names its mechanism, its scope, and its test (§7).
+
+---
+
+## 2. Functional Specification (25 items)
+
+### DTO & Data Mapping
+1. **`DataTransferObject`** — hydrates typed DTOs from associative arrays via Reflection with **per-class metadata caching** (reflection cost paid once per class, NFR-01). **Contract (v1 unspecified):** properties are `readonly` (promoted constructor); **strict mode by default** — unknown keys throw `UnknownKeyException` (mass-assignment safety for a security-oriented library); `lenient()` opt-in ignores extras; nested DTOs and `Collection<T>` properties hydrate recursively; type mismatches throw `TypeMismatchException` naming the path.
+2. **`WithersTrait`** — *(rescoped: v1's `ReadOnlyPropertyTrait` "for earlier PHP versions" contradicted the 8.1+ floor where `readonly` is native)*: `with(...)` wither semantics producing modified **clones** of readonly DTOs — the actual 8.1-era gap (readonly properties cannot be reassigned during `clone` until PHP 8.3's readonly-clone change, which the trait absorbs per version).
+3. **`Collection<T>`** — functional array wrapper (`map`, `filter`, `reduce`). **Genericity is static-analysis-level only** *(stated explicitly — PHP has no runtime generics)*: `@template T` docblocks enforced by PHPStan max level in CI; at runtime the collection checks nothing beyond an optional `instanceof` guard flag.
+
+### Dependency Injection
+4. **`Container`** — minimal PSR-11 container: constructor autowiring, singletons/factories, no compilation — scope limits and the build-vs-adopt decision recorded in [ADR-001](adr/d4np_php_adr_001_di_container.md).
+5. **`ServiceProvider`** — abstract base for registering definitions.
+
+### Database & PDO
+6. **`DatabaseConnection`** — PDO wrapper with **pinned safe defaults** *(v1's "silent error mode" contradicted item 8's exception-driven rollback and reverses the PHP 8.0 default; v1's "UTF-8" charset is a 3-byte subset on MySQL)*:
+
+   | Option | Value | Why |
+   |---|---|---|
+   | `ATTR_ERRMODE` | `ERRMODE_EXCEPTION` | failures must throw — item 8's rollback depends on it; PHP 8.0+ default restored |
+   | charset (MySQL) | **`utf8mb4`** | MySQL `utf8` cannot store all of Unicode (4-byte code points) |
+   | `ATTR_EMULATE_PREPARES` | `false` | real server-side prepares; types preserved |
+   | `ATTR_DEFAULT_FETCH_MODE` | `FETCH_ASSOC` | explicit, no dual-key waste |
+7. **`QueryBuilder`** — fluent SQL builder. **Injection defense fully scoped** *(v1 claimed prepared statements prevent SQL injection — they cover values only)*: values bind as parameters; **identifiers** (table/column names) must match `^[A-Za-z_][A-Za-z0-9_]*$` and are driver-quoted (backticks/double quotes); `ORDER BY` direction is an enum (`Sort::Asc|Desc`), never a string; `LIMIT`/`OFFSET` cast to non-negative int. §7 T-02 proves identifier-injection attempts are rejected.
+8. **`Transaction`** — closure-scoped transactions with automatic rollback on any exception (consistent with item 6's error mode) and rethrow; nested calls use savepoints.
+
+### Security
+9. **`Escaper`** — *(replaces v1's blocklist `Sanitizer::html()`, a weak XSS defense)*: context-aware **output escaping** — `html()` (`htmlspecialchars` `ENT_QUOTES|ENT_SUBSTITUTE`, UTF-8), `attr()`, `js()` (hex-encoding), `url()` (`rawurlencode`). Scope: rendering untrusted text into each context.
+   **9b. Rich-HTML sanitization** — for user-authored HTML, the library **delegates** to `symfony/html-sanitizer` (optional dependency, W3C-spec-based allowlist) behind `Sanitizer::richText()` with a curated profile; no hand-rolled tag stripper exists in the package.
+10. **`Sanitizer::sqlLikePattern()`** — escapes `%`/`_`/escape-char in user input used inside `LIKE` patterns (wildcard-injection defense; values still bind as parameters — this only neutralizes wildcards).
+11. **`Hash::make()` / `Hash::verify()`** — `password_hash` wrapper, **Argon2id default**. **Platform constraint handled** *(v1 omitted it)*: Argon2id requires PHP built with libargon2 — availability detected via `defined('PASSWORD_ARGON2ID')`; policy: explicit `bcryptFallback: true` default (logged at WARNING) or `false` to fail fast; hashes are self-describing so `verify` works regardless; `needsRehash()` upgrades on login.
+12. **`CsrfToken`** — CSPRNG token generation + constant-time validation (`hash_equals`), per-session storage, optional per-form scoping.
+
+### HTTP & Session
+13. **`Request`** — typed superglobal reader (`$_GET/$_POST/$_SERVER/$_FILES`); optional **PSR-7 bridge** per [ADR-002](adr/d4np_php_adr_002_http_psr7.md).
+14. **`Response`** — headers/JSON/status helpers; same bridge.
+15. **`Session`** — secure session API: `cookie_httponly`, `cookie_secure`, `cookie_samesite=Lax` set at start; `regenerate()` wraps `session_regenerate_id(true)` for login transitions (fixation defense — testable criterion in T-03).
+
+### Errors & Logging
+16. **`Result`** — success/failure wrapper for application services (`map/flatMap/orElseThrow`).
+17. **`Logger`** — PSR-3 file/console logger.
+18. **`ExceptionHandler`** — fatal-error capture, JSON problem responses for API calls; never leaks traces in production mode (env-gated).
+**Exception hierarchy (referenced across 16–18, 25 — v1 never defined it):** `D4npException` ← `DatabaseException`, `HydrationException` (← `UnknownKeyException`, `TypeMismatchException`), `HttpException`, `FileException`, `JsonException`.
+
+### String & File Utilities
+19. **`Str::slug()`** — URL-friendly slugs (transliteration via `ext-intl` when present).
+20. **`Str::uuid()`** — UUID v4 from `random_bytes` (CSPRNG).
+21. **`Str::random()`** — CSPRNG alphanumeric tokens.
+22. **`File::write()` / `File::read()`** — `flock`-guarded I/O; atomic write via temp + `rename`.
+23. **`File::mime()`** — Fileinfo-based MIME detection (never trusts extensions).
+24. **`Env::get()`** — env reads with correct boolean coercion (`"false"` → `false`).
+25. **`Json::encode()` / `Json::decode()`** — wrappers with `JSON_THROW_ON_ERROR`, typed `JsonException`.
+
+---
+
+## 3. Architecture (C4 Component View)
+```
+ ┌─ d4np-php (Composer package, namespace D4np\Php\) ────────────────────────┐
+ │                                                                           │
+ │  Http: Request ─ Response ─ Session ─ CsrfToken     ──►  Support          │
+ │  Database: DatabaseConnection ─ QueryBuilder ─       ──►  Support          │
+ │            Transaction                                                    │
+ │  Security: Escaper ─ Sanitizer ─ Hash               ──►  Support          │
+ │  Dto: DataTransferObject ─ WithersTrait ─           ──►  Support          │
+ │       Collection<T>                                                       │
+ │  Container: Container(PSR-11) ─ ServiceProvider     ──►  Support          │
+ │  Errors: Result ─ Logger(PSR-3) ─ ExceptionHandler  ──►  Support          │
+ │                                                                           │
+ │  Support (bottom layer): Str ─ File ─ Env ─ Json ─ exception hierarchy    │
+ │                                                                           │
+ │  Optional deps: symfony/html-sanitizer (9b) · psr/http-message bridge     │
+ │  (ADR-002) — core requires only php>=8.1 + ext-pdo + ext-fileinfo         │
+ │  Rule: groups depend downward on Support only; no cross-group imports     │
+ │  (enforced by deptrac in CI)                                              │
+ └───────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Non-Functional Requirements & Benchmark Methodology
+**Methodology:** phpbench (10 iterations × 100 revs, retry-threshold 5%), PHP 8.3 CLI with OPcache + JIT off (library-consumer realism), reference machine Ryzen 7 5800X; harness in `bench/`; nightly CI, > 10% regression fails.
+
+| ID | Target |
+|---|---|
+| NFR-01 | DTO hydration (10 scalar props): ≤ 5 µs/DTO warm (cached reflection) and ≤ 3× manual constructor assignment |
+| NFR-02 | Container: singleton resolve ≤ 2 µs warm; first autowired resolve ≤ 30 µs |
+| NFR-03 | QueryBuilder: SELECT with 5 conditions builds in ≤ 10 µs, 0 queries executed at build time |
+| NFR-04 | Memory: hydrating 10 000 DTOs ≤ 16 MB peak delta |
+| NFR-05 | `Hash::make` Argon2id defaults complete in 50–200 ms on the reference machine (deliberately slow; documented for capacity planning) |
+
+---
+
+## 5. Security Test Criteria (one per feature, per acceptance criteria)
+| Feature | Testable criterion |
+|---|---|
+| QueryBuilder values | fuzzed value payloads (`' OR 1=1--`) reach the driver only as bound parameters (query-log assertion) |
+| QueryBuilder identifiers (T-02) | `orderBy("name; DROP TABLE users")` throws `DatabaseException`; only allowlisted identifiers pass |
+| Escaper | OWASP XSS cheat-sheet corpus escaped per context (snapshot suite) |
+| `Sanitizer::richText()` | DOM-based bypass corpus (event handlers, `javascript:` URIs, SVG) neutralized by the profile |
+| Session (T-03) | session id changes across `regenerate()`; cookies carry HttpOnly/Secure/SameSite in integration test |
+| CSRF | token validation is `hash_equals`-based (timing test) and rejects cross-session tokens |
+| Hash | verify works for both argon2id and bcrypt-fallback hashes; `needsRehash` triggers on policy change |
+
+---
+
+## 6. API Example (DTO — consistent with the §1 immutability philosophy; v1's example used mutable props, an app namespace, and undefined extra-key behavior)
+```php
+use D4np\Php\Dto\DataTransferObject;
+use D4np\Php\Dto\UnknownKeyException;
+
+final class UserDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly string $email,
+        public readonly string $name,
+    ) {}
+}
+
+$data = ['email' => 'daniel@polo.com', 'name' => 'Daniel', 'role' => 'admin'];
+
+try {
+    $userDto = UserDto::fromArray($data);          // strict mode (default)
+} catch (UnknownKeyException $e) {
+    // 'role' is not declared on UserDto -> rejected: mass-assignment safety.
+}
+
+$userDto = UserDto::lenient()->fromArray($data);   // opt-in: unknown keys ignored
+echo $userDto->email;                              // daniel@polo.com
+```
+
+---
+
+## 7. Verification & Test Strategy
+* **T-01 DTO suite:** hydration matrix (nested DTOs, collections, nullables, enums), strict/lenient behavior, wither clones.
+* **T-02 injection suite:** value + identifier + LIKE-wildcard injection attempts (see §5).
+* **T-03 session/CSRF integration:** real `php -S` process, cookie-flag and regeneration assertions.
+* **T-04 transaction semantics:** exception → rollback → rethrow; savepoint nesting.
+* **T-05 property tests:** `Json` round-trips, `Str::slug` idempotence, `Env` boolean coercion table.
+
+## 8. CI/CD & Release Engineering
+* **Matrix:** PHP 8.1 / 8.2 / 8.3 (floor documented in `composer.json`), lowest + highest dependency sets (`composer update --prefer-lowest` job).
+* **Static gates:** PHPStan **max level** (enforcing `@template` generics of item 3), `deptrac` layer rules (§3), `composer-normalize`, `composer audit`.
+* **Quality gates:** PHPUnit coverage ≥ 90% lines; **Infection mutation score ≥ 70%** on Security/Database/Dto namespaces.
+* **BC policy:** SemVer; `roave/backward-compatibility-check` against the previous tag on every release PR; deprecations live one minor before removal.
+* **Release flow:** tagged release → GitHub Action validates gates → Packagist webhook publish; signed tags.
+
+---
+
+## 9. Decision Log
+* [ADR-001 — Ship a minimal PSR-11 container instead of depending on PHP-DI](d4np_php_adr_001_di_container.md)
+* [ADR-002 — Native lightweight HTTP wrappers with optional PSR-7 bridge](d4np_php_adr_002_http_psr7.md)

--- a/.specs/d4np_php_adr_001_di_container.md
+++ b/.specs/d4np_php_adr_001_di_container.md
@@ -1,0 +1,34 @@
+# ADR-001: Ship a minimal PSR-11 container instead of depending on PHP-DI
+
+| | |
+|---|---|
+| **Status** | Accepted |
+| **Date** | 2026-07-14 |
+| **Related spec** | [d4np-php.md](d4np-php.md) (§2 items 4–5, NFR-02) |
+
+## Context
+The library promises a "minimal DI container" (v1 item 4) without deciding the obvious question: why not depend on PHP-DI, Symfony DI, or league/container, all mature PSR-11 implementations? A utilities library imposing a full DI framework on consumers is heavy; shipping a naive container that silently underperforms mature ones is worse. The decision needed recording with its scope limits.
+
+## Options considered
+
+**A. Minimal custom PSR-11 container with explicit scope limits** *(chosen)*
+- ✅ Zero dependencies for the core package (a design goal); consumers embedding the library in legacy/native projects get working DI with one class.
+- ✅ **PSR-11 is the escape hatch by construction:** everything in the library consumes `Psr\Container\ContainerInterface`, so swapping in PHP-DI/Symfony DI is a one-line change — the custom container is a default, not a lock-in.
+- ✅ Scope is deliberately small and documented: constructor autowiring via reflection (cached), singleton/factory definitions, `ServiceProvider` registration. **Non-goals stated:** no compilation, no attribute/annotation config, no lazy proxies, no circular-dependency resolution (throws with the dependency path).
+- ❌ Will never match compiled-container performance for huge graphs. Bounded honestly by NFR-02 (≤ 30 µs first autowire, ≤ 2 µs warm) — adequate for the target use (small/medium service graphs).
+
+**B. Depend on PHP-DI**
+- ✅ Mature, feature-complete.
+- ❌ Forces a framework-sized dependency on every consumer including those using the library *inside* Symfony/Laravel apps that already have a container — dependency-conflict surface for negative value.
+
+**C. Suggest-only (no container shipped)**
+- ✅ Cleanest dependency story.
+- ❌ Guts item 4's promise; native-PHP consumers (the stated audience) lose the batteries-included experience.
+
+## Decision
+**Option A.** The container implements `Psr\Container\ContainerInterface`, documents its non-goals, and fails loudly where mature containers add features (circular deps, union-typed parameters without definitions). The spec's own components resolve through the interface, never the concrete class.
+
+## Consequences
+- NFR-02 keeps the container honest; if consumer graphs outgrow it, migration is interface-compatible by design.
+- Container feature requests (compilation, attributes) are answered by this ADR: adopt a mature container instead — the library will not grow one.
+- The reflection cache used by the container is shared infrastructure with the DTO hydrator (one metadata cache, spec §2 item 1).

--- a/.specs/d4np_php_adr_002_http_psr7.md
+++ b/.specs/d4np_php_adr_002_http_psr7.md
@@ -1,0 +1,34 @@
+# ADR-002: HTTP — native lightweight wrappers with optional PSR-7 bridge
+
+| | |
+|---|---|
+| **Status** | Accepted |
+| **Date** | 2026-07-14 |
+| **Related spec** | [d4np-php.md](d4np-php.md) (§2 items 13–15) |
+
+## Context
+v1 specified custom `Request`/`Response` wrappers over superglobals without addressing the ecosystem standard: PSR-7 (`psr/http-message`) plus PSR-15 middleware is how interoperable PHP HTTP code is written, with mature implementations (nyholm/psr7, guzzle/psr7). The question: are the custom wrappers a parallel universe (bad) or a deliberate lightweight tier with a bridge (defensible)?
+
+## Options considered
+
+**A. Native lightweight wrappers + optional PSR-7 bridge** *(chosen)*
+- ✅ The target audience includes framework-less/legacy PHP apps where superglobals are the reality; a typed, security-defaulted reader over `$_GET/$_POST/$_FILES` (with the §2 item 15 session hardening) is immediate value with zero dependencies.
+- ✅ Interop preserved: `Request::toPsr7()` / `Request::fromPsr7()` (and the Response equivalents) live in an optional bridge that depends on `psr/http-message` + `psr/http-factory`, letting the library's HTTP types cross into PSR-15 middleware stacks when the consumer has one.
+- ✅ Immutability semantics stay simple (the wrappers are read-mostly facades), avoiding PSR-7's with-er cloning cost where it buys nothing.
+- ❌ Two HTTP vocabularies exist. Contained: the bridge is the only sanctioned crossing point, and the wrappers deliberately mirror PSR-7 naming (`getQueryParams`-style) to keep the mental model aligned.
+
+**B. Implement PSR-7 directly**
+- ✅ One standard vocabulary.
+- ❌ Implementing PSR-7 well (streams, immutability, uploaded-file abstraction) is a real project already solved by nyholm/guzzle; doing it again adds maintenance without differentiation, and forces stream semantics on users who just want `$request->postString('email')`.
+
+**C. Depend on nyholm/psr7 and expose PSR-7 types only**
+- ✅ Standards-pure.
+- ❌ Framework-less users now need factory wiring and stream handling for a form read; the library's session/CSRF integration would still need helper facades — ending in the same wrapper layer plus a mandatory dependency.
+
+## Decision
+**Option A.** Core ships `Request`/`Response`/`Session` with no HTTP dependencies; the `d4np/php-psr7-bridge` optional package provides bidirectional conversion using any PSR-17 factory. Naming mirrors PSR-7 conventions; the spec documents the bridge as the integration path for middleware stacks.
+
+## Consequences
+- Framework-less consumers get typed, hardened HTTP handling out of the box; PSR-15 shops lose nothing.
+- The wrappers must never grow middleware ambitions — routing/middleware requests are answered by "use a PSR-15 stack via the bridge" per this ADR.
+- Bridge conversion fidelity (headers, uploaded files, immutability boundaries) gets its own contract tests in CI.

--- a/docs/rfc/0001-egl-utils-library.md
+++ b/docs/rfc/0001-egl-utils-library.md
@@ -1,0 +1,317 @@
+# RFC-0001: EGL PHP Utilities Library (`egl/utils`) — foundation design
+
+- **Status:** Accepted
+- **Author:** tech-lead (agent-drafted) · **Reviewers:** reviewer, enterprise-architect · **Approver:** tech-lead
+- **Date:** 2026-08-03
+- **Related:** imported spec [.specs/d4np-php.md](../../.specs/d4np-php.md) (v2.0, reviewed draft) ·
+  imported [ADR-001 (DI container)](../../.specs/d4np_php_adr_001_di_container.md) ·
+  imported [ADR-002 (HTTP / PSR-7)](../../.specs/d4np_php_adr_002_http_psr7.md) ·
+  manifest [orchestrator/project.yaml](../../orchestrator/project.yaml)
+
+> Imported design (interview Q5.0 = import): the reviewed v2.0 specification was authored under the
+> project's earlier name `d4np-php`. This RFC validates it into the EADOS pipeline for
+> `egl-util-php` with the naming mapping below. Content is carried over, not re-invented; the spec
+> document remains the detailed source and is frozen into `docs/specs/` at scaffold with the
+> mapping preamble (A-7).
+
+## Naming mapping (import decision, 2026-08-03)
+
+| Surface | Spec (d4np) | This project | Provenance |
+|---|---|---|---|
+| Repository | `d4np-php` | `egl-util-php` | manifest (init) |
+| Composer package | `d4np-php` (informal §3 label; not a valid vendor/name pair) | `egl/utils` | asked |
+| PSR-4 root namespace | `D4np\Php\` | `D4np\Utils\` | asked — **deliberate mixed-vendor choice** (see Alternatives #5) |
+| PSR-7 bridge package | `d4np/php-psr7-bridge` | `egl/utils-psr7-bridge` | asked |
+| Root exception | `D4npException` | `UtilsException` | endorsed at review (R-9): avoids the `D4np\Utils\D4npException` stutter; child exception names carry over unchanged |
+
+## Context
+
+PHP teams at EGL ship both framework-based and native/legacy applications. Recurring needs —
+typed data transfer, explicit security mechanisms, safe PDO access, hardened session/CSRF
+handling, small-scale DI — are today solved ad hoc per project, with the classic failure modes:
+associative-array "DTOs", blocklist sanitizers, string-built SQL, silent PDO error modes.
+
+`egl/utils` is a modern PHP library (**PHP 8.1+**, Composer/Packagist) providing security
+helpers, typed DTOs, and a minimal PSR-11 DI container. Design principles (spec §1):
+
+- **Strong typing** — immutable `readonly` DTOs instead of unstructured arrays.
+- **Clean code** — strict PSR-1/4/11/12; PHPStan max level as a CI gate.
+- **Security by explicit mechanism** — the v1 idea "all I/O sanitizes automatically" is
+  withdrawn (the `magic_quotes` anti-pattern). Each security feature names its mechanism, its
+  scope, and its test:
+  1. Persistence (values): parameterized queries, always.
+  2. Persistence (identifiers): allowlist + strict driver quoting (prepared statements do not
+     cover table/column names).
+  3. Output: context-aware escaping at render time, never input mutilation.
+  4. Rich HTML: allowlist sanitization delegated to `symfony/html-sanitizer` (optional dep).
+
+Constraints: **no third-party *implementation* dependencies in the core** — `php>=8.1` +
+`ext-pdo` + `ext-fileinfo`, with the interface-only PSR packages `psr/container` and `psr/log`
+excepted, since a package implementing PSR-11/PSR-3 necessarily requires them (R-3: an RFC-level
+correction of spec §3's literal "zero-dependency" claim, which is mechanically false).
+Optional dependencies for rich-HTML sanitization and the PSR-7 bridge. Governance posture
+**enterprise** (manifest) — security-relevant decisions carry ADRs (see Follow-up).
+
+## Decision
+
+Ship the library as **six component groups over a Support layer** (spec §3, C4 component view),
+25 functional items (spec §2), with the dependency rule *groups depend downward on Support only;
+no cross-group imports* — enforced by `deptrac` in CI.
+
+| Group | Namespace | Components (spec §2 items) |
+|---|---|---|
+| Dto | `D4np\Utils\Dto\` | `DataTransferObject` (1), `WithersTrait` (2), `Collection<T>` (3) |
+| Container | `D4np\Utils\Container\` | PSR-11 `Container` (4), `ServiceProvider` (5) — scope per imported ADR-001 |
+| Database | `D4np\Utils\Database\` | `DatabaseConnection` (6, pinned safe PDO defaults), `QueryBuilder` (7), `Transaction` (8) |
+| Security | `D4np\Utils\Security\` | `Escaper` (9), rich-HTML `Sanitizer::richText()` (9b), `Sanitizer::sqlLikePattern()` (10), `Hash` (11, Argon2id + bcrypt fallback policy) |
+| Http | `D4np\Utils\Http\` | `Request` (13), `Response` (14), `Session` (15), `CsrfToken` (12) — PSR-7 via optional bridge per imported ADR-002 |
+| Errors | `D4np\Utils\Errors\` | `Result` (16), PSR-3 `Logger` (17), `ExceptionHandler` (18) |
+| Support | `D4np\Utils\Support\` | `Str` (19–21), `File` (22–23), `Env` (24), `Json` (25), exception hierarchy, **shared reflection-metadata cache** |
+
+**Placement notes (resolved at review):**
+
+- **`CsrfToken` lives in Http, not Security (R-1).** The spec is internally split — §2 lists
+  item 12 under a "Security" heading while §3's C4 view draws it in the Http box. This RFC
+  follows §3: `CsrfToken` requires per-session storage (item 12) and therefore sits beside
+  `Session`; placing it in Security would force a Security→Http import that the layering rule
+  forbids. Recorded here as a resolved spec-internal conflict so deptrac and T-03 stay
+  satisfiable.
+- **The shared reflection-metadata cache is Support (R-2).** Imported ADR-001 commits to *one*
+  metadata cache shared by the DTO hydrator and the Container (NFR-01/NFR-02 hinge on it); under
+  the no-cross-group-imports rule its only legal home is Support. This deliberately extends spec
+  §3's Support enumeration.
+- **Source tree (A-9).** The factory renders `src/main/php/d4np/utils/` (the manifest-derived
+  `SRC_MAIN`); `composer.json`'s PSR-4 base dir (`"D4np\\Utils\\": "src/main/php/d4np/utils/"`)
+  and the deptrac layer globs are defined against that exact tree, with the group directories
+  (`Dto/`, `Container/`, …) case-exact below it — milestone item 1.x pins this so a hand-authored
+  `composer.json` cannot drift to a bare `src/`.
+
+### API contract (`api` / `systemdesign`)
+
+- **Operations** — the 25 items of spec §2 are the public surface; signatures follow the spec
+  verbatim under the mapped namespace (e.g. `D4np\Utils\Dto\DataTransferObject::fromArray()`,
+  `QueryBuilder::orderBy(string $column, Sort $direction)`, `Hash::make()/verify()/needsRehash()`,
+  `Session::regenerate()`, `Str::slug()/uuid()/random()`).
+- **Payloads** — typed `readonly` promoted-constructor DTOs; **strict hydration by default**
+  (unknown keys throw `UnknownKeyException`; mass-assignment safety), `lenient()` opt-in; nested
+  DTOs and `Collection<T>` hydrate recursively; `Collection<T>` genericity is
+  **static-analysis-level only** (`@template T` + PHPStan max; no runtime generics — stated
+  honestly, optional `instanceof` guard flag at runtime).
+- **Error model** — one hierarchy consumers can catch coarsely or finely:
+  `UtilsException` ← `DatabaseException`, `HydrationException` (← `UnknownKeyException`,
+  `TypeMismatchException`, `MissingKeyException`), `HttpException`, `FileException`,
+  `JsonException`. Service-level outcomes use `Result` (`map`/`flatMap`/`orElseThrow`) instead
+  of boolean/null returns. Two review additions:
+  - **`MissingKeyException` (R-4):** thrown in *both* strict and lenient modes when the input
+    lacks a declared property that is neither nullable nor defaulted; a nullable or defaulted
+    property absent from the input hydrates to `null`/its default. The imported spec was silent
+    on the missing-key case; T-01's matrix gains these cases.
+  - **`JsonException` shadowing (R-7):** the library `JsonException` wraps and rethrows PHP's
+    native `\JsonException` (which is what `JSON_THROW_ON_ERROR`, item 25, raises). The name
+    collision is deliberate — same failure domain — and is resolved in consumer-facing docs with
+    an import alias example.
+- **Versioning** — SemVer on Packagist. **MAJOR** = any BC break of: the PSR-4 namespace, public
+  signatures, the exception hierarchy shape, pinned `DatabaseConnection` defaults semantics, or
+  strict-mode hydration behavior. Mechanically enforced:
+  `roave/backward-compatibility-check` against the previous tag on every release PR;
+  deprecations live one full minor before removal (spec §8).
+
+### Data & schema (`database`) — omitted
+
+The library owns no persistent state: `Database` components wrap **consumer-owned** PDO
+connections (SQL is a secondary surface in ADR-0004's frame). No entities, no migrations.
+
+### Scalability budgets (`scalability`)
+
+The `software` domain declares no hard NFR axes
+([domains/software.yaml](../../.eados-core/orchestrator/domains/software.yaml): all
+`hard_budget: false`), but the imported spec commits **numeric** targets (spec §4) — carried
+over as stated budgets the audit phase can evaluate, and recorded in the manifest as
+`spec.nonfunctional_reqs` NFR-01…NFR-05:
+
+| ID | Budget |
+|---|---|
+| NFR-01 | DTO hydration (10 scalar props): ≤ 5 µs/DTO warm (cached reflection), ≤ 3× manual assignment |
+| NFR-02 | Container: singleton resolve ≤ 2 µs warm; first autowired resolve ≤ 30 µs |
+| NFR-03 | QueryBuilder: 5-condition SELECT builds in ≤ 10 µs; 0 queries executed at build time |
+| NFR-04 | Memory: hydrating 10 000 DTOs ≤ 16 MB peak delta |
+| NFR-05 | `Hash::make` (Argon2id defaults): 50–200 ms on the reference machine — deliberately slow, documented for capacity planning |
+
+Methodology (spec §4): phpbench, 10 iterations × 100 revs, 5% retry threshold, PHP 8.3 CLI with
+OPcache + JIT **off** (library-consumer realism), reference machine Ryzen 7 5800X, harness in
+`bench/`, nightly CI; a regression > 10% fails the run.
+
+### Algorithm sketch (`pseudocode`)
+
+The one non-obvious core path — DTO hydration with the shared per-class metadata cache
+(NFR-01 hinges on it; the cache is Support-layer shared infrastructure per imported ADR-001
+and placement note R-2):
+
+```
+hydrate(class, data, mode):
+    meta ← cache[class]                     # reflection cost paid once per class
+      or cache[class] ← reflect(class)      # (props, types, defaults, nested-DTO / Collection<T> markers)
+    for each key in data:
+        if key ∉ meta.props:
+            strict mode → throw UnknownKeyException(path)
+            lenient mode → skip
+    for each prop in meta.props:
+        if prop ∉ data:
+            nullable or defaulted → hydrate to null / default value
+            otherwise → throw MissingKeyException(path)          # R-4, both modes
+        value ← data[prop]
+        nested DTO      → hydrate(prop.class, value, mode)      # recurse
+        Collection<T>   → map hydrate over elements
+        scalar          → type-check; mismatch → throw TypeMismatchException(path)
+    return new class(...values)             # readonly promoted constructor
+```
+
+### Cross-cutting
+
+**Security** — every §2 security feature carries a per-feature testable criterion (spec §5),
+mechanical rather than aspirational: fuzzed value payloads reach the driver only as bound
+parameters (query-log assertion); `orderBy("name; DROP TABLE users")` throws
+`DatabaseException` (T-02); OWASP XSS cheat-sheet corpus escaped per context (snapshot suite);
+DOM-bypass corpus neutralized by the `richText()` profile; session id changes across
+`regenerate()` and cookies carry HttpOnly/Secure/SameSite (T-03); CSRF validation is
+`hash_equals`-based (timing test) and rejects cross-session tokens; `Hash::verify` works for
+argon2id and bcrypt-fallback hashes, `needsRehash` triggers on policy change. The Argon2id
+platform constraint is handled explicitly: availability via `defined('PASSWORD_ARGON2ID')`,
+`bcryptFallback: true` default logged at WARNING, `false` to fail fast.
+
+**Performance** — the NFR table above; benchmarks are first-class (`bench/`, phpbench, nightly).
+
+**Quality gates** (spec §8) — PHP 8.1/8.2/8.3 matrix with `--prefer-lowest` job; PHPStan max
+level (enforces `@template` generics); `deptrac` layer rules; `composer-normalize`;
+`composer audit`; PHPUnit coverage ≥ 90% lines; **Infection mutation score ≥ 70%** on
+Security/Database/Dto namespaces; **bridge conversion-fidelity contract tests** (headers,
+uploaded files, immutability boundaries) in `egl/utils-psr7-bridge`'s own CI (imported ADR-002
+commitment, R-5); signed tags; Packagist publish via validated release action. **Psalm is not
+adopted** — the profile default pairs PHPStan with Psalm, but the design keeps a single
+static-analysis authority (PHPStan max) to avoid double-baseline maintenance; recorded as a
+toolchain override for the scaffold interview (A-4).
+
+## Alternatives
+
+1. **Depend on PHP-DI (or Symfony DI / league/container) instead of shipping a container** —
+   rejected (imported ADR-001): framework-sized dependency forced on every consumer, including
+   apps that already have a container; dependency-conflict surface for negative value. The
+   minimal PSR-11 container is a **default, not a lock-in** — everything consumes
+   `Psr\Container\ContainerInterface`, so swapping in PHP-DI is a one-line change. The core keeps
+   **no implementation dependencies** (interface-only `psr/container` excepted, R-3). Non-goals
+   stated: no compilation, no attributes, no lazy proxies, no circular-dependency resolution
+   (throws with the dependency path). NFR-02 keeps it honest.
+2. **Ship no container ("suggest-only")** — rejected (imported ADR-001): guts the DI promise for
+   native-PHP consumers, the stated audience.
+3. **Implement PSR-7 directly, or depend on nyholm/psr7 and expose PSR-7 types only** — rejected
+   (imported ADR-002): implementing PSR-7 well is a solved project (streams, immutability,
+   uploaded files) and re-doing it adds maintenance without differentiation; PSR-7-only forces
+   factory wiring and stream handling on framework-less users who want
+   `$request->postString('email')`. Chosen: native lightweight wrappers mirroring PSR-7 naming +
+   an **optional bridge** (`egl/utils-psr7-bridge`, bidirectional via any PSR-17 factory) as the
+   only sanctioned crossing point. The wrappers never grow middleware ambitions — PSR-15 stacks
+   via the bridge, per the imported ADR.
+4. **Blanket automatic input sanitization** (spec v1's stance) — rejected in the spec's own v2
+   review: input mutilation is the `magic_quotes` anti-pattern and a weak XSS defense; replaced
+   by the four-mechanism model (parameterized values, identifier allowlist, context-aware output
+   escaping, delegated rich-HTML sanitization).
+5. **Full-EGL namespace `Egl\Utils\`** — rejected by **maintainer decision at import
+   (2026-08-03, precedence layer 1)** in favor of retaining the personal vendor namespace
+   `D4np\Utils\` inside the `egl/utils` package. Recorded dissent (tech-lead): the mixed-vendor
+   surface (package vendor `egl` ≠ namespace vendor `D4np`) is consumer-visible and expensive to
+   reverse — changing the namespace later is a MAJOR break of every consumer `use` statement;
+   discoverability suffers (Packagist search vs code search disagree on vendor). Mitigation:
+   `composer.json` `autoload.psr-4` and the README state the pairing explicitly, and the BC
+   policy pins the namespace as MAJOR-protected surface. The decision stands; this entry is the
+   record, and it is transcribed into the generated repo's decision ledger as a seeded ADR (A-2).
+
+## Consequences
+
+**Easier:** typed, mass-assignment-safe data transfer for native and framework apps alike;
+security mechanisms that are testable per feature instead of asserted; drop-in PDO safety
+(exception mode, `utf8mb4`, real prepares); PSR-11/PSR-7 interop without mandatory
+dependencies; migration to mature containers stays one line by construction.
+
+**Harder / accepted costs:** two HTTP vocabularies exist (contained: bridge is the only
+crossing, wrapper naming mirrors PSR-7); the custom container will never match compiled
+containers on huge graphs (bounded honestly by NFR-02); readonly-clone semantics differ across
+PHP 8.1→8.3 and `WithersTrait` must absorb the difference per version; the mixed-vendor naming
+(Alternative 5) must be documented wherever consumers first meet the package.
+
+**Manifest write-back (A-1) — done at design entry, not deferred:** the identity facts this RFC
+decides are already recorded in [orchestrator/project.yaml](../../orchestrator/project.yaml)
+with honest provenance (`language.group_path: d4np`, `group_dotted: d4np`,
+`namespace: D4np\Utils`, `lang_standard: PHP 8.1 (minimum …)` — provenance `asked`; the spec
+section — provenance `imported`), because the `manifest-valid` gate evaluates the full manifest
+before the `init → design` checkpoint can be recorded. The Composer identity is pinned as
+milestone-1 item text so item 1.1 cannot mis-create `composer.json`.
+
+**Scaffold handoff (A-3, A-4) — overrides the scaffold interview must record** (the renderer
+reads profile + manifest, not spec §8; without these the rendered gates are weaker than the
+approved design):
+
+- `ci`: 3-cell matrix **PHP 8.1/8.2/8.3** with an **explicit** toolchain→version map — the
+  profile's 2-way ternary (`php.yaml` `setup_steps`) silently maps an added `php-8.1` cell to
+  PHP 8.3, so it must be rewritten, not extended — plus the `composer update --prefer-lowest`
+  job. *(Factory-side note, advisory: the profile ternary is not extensible to 3+ versions.)*
+- `toolchain`: `linter: PHPStan (max level)` (Psalm not adopted — single static-analysis
+  authority), `coverage_target: 90` (template default is 80).
+- `governance.capabilities`: `bench: true` (phpbench harness + nightly), `packaging: true`
+  (Packagist + signed tags).
+- `ci.extra_jobs`: deptrac layer check, Infection (≥ 70% on Security/Database/Dto),
+  composer-normalize, composer audit.
+
+**Seeded ADRs for the generated repo (A-2)** — the enterprise posture mandates ADRs for
+security-relevant decisions; the imported pair (DI container, HTTP/PSR-7) lands in `docs/adr/`
+at scaffold, joined by three ADRs this RFC commits to seeding:
+
+1. **Security mechanism model** — the four mechanisms, the identifier allowlist + driver
+   quoting, and the pinned PDO defaults (spec §1, items 6–7).
+2. **Password-hashing policy** — Argon2id detection, the `bcryptFallback` default and its
+   WARNING, `needsRehash` upgrade-on-login (item 11).
+3. **Namespace decision** — the Alternative-5 record (decision, dissent, mitigation)
+   transcribed so it lives in the repo's own decision ledger, not only in this RFC.
+
+**Follow-up (feeds `/eados plan`):** Milestone 1 is the universal bootstrap (Composer skeleton,
+CI, quality gates) with the two pinned items above. Component milestones follow the dependency
+order the layering dictates — Support → Dto → Database → Security → Http/Container/Errors →
+release engineering — recorded up front as `spec.milestones` 2–7 in the manifest for `/eados
+plan` to negotiate. The **PSR-7 bridge** (`egl/utils-psr7-bridge`) is a separate-package
+decision (subtree vs second repository — possibly a second EADOS run) **deferred to plan**; its
+milestone follows the Http group and carries ADR-002's conversion contract tests (A-8). The
+test suites land with their components (T-01…T-05, spec §7 — T-02/T-03 are the
+security-critical pair, R-6).
+
+## Approval
+
+approved-by: tech-lead (2026-08-03)
+
+Approval confirmed by the owner (`danielPoloWork`) in the design-phase session of 2026-08-03;
+the tech-lead record above encodes that human decision (review protocol: no RFC self-approves).
+
+Reviewers (structured findings addressed): reviewer — resolved (R-1…R-9) ·
+enterprise-architect — resolved (A-1…A-9).
+
+Findings resolution map: R-1/R-2 → Decision placement notes; R-3 → Context constraints +
+Alternatives #1; R-4/R-7 → API contract error model + pseudocode; R-5 → quality gates; R-6 →
+Follow-up wording; R-8/R-9 → naming-mapping table; A-1 → manifest write-back (recorded, rev 1);
+A-2 → seeded-ADRs list; A-3/A-4 → scaffold handoff; A-5 → design-phase PR commits RFC +
+`.specs/` together (References note); A-6 → `init → design` checkpoint recorded
+(`orchestrator/project.yaml`, manifest_rev 1); A-7 → `.specs` link fixes + import preamble;
+A-8 → bridge follow-up; A-9 → source-tree placement note.
+
+On acceptance the **state_writer** (`enterprise-architect`, ADR-0025 — not the acting
+tech-lead) records `delivery_state.refs.rfcs += 0001`.
+
+## References
+
+- Imported specification: [.specs/d4np-php.md](../../.specs/d4np-php.md) (v2.0, 2026-07-14, reviewed draft)
+- Imported decisions: [ADR-001 — minimal PSR-11 container](../../.specs/d4np_php_adr_001_di_container.md) · [ADR-002 — HTTP wrappers + PSR-7 bridge](../../.specs/d4np_php_adr_002_http_psr7.md)
+- Committed-revision note (A-5): the design-phase PR commits this RFC **together with** the
+  imported `.specs/` sources and the manifest, so the approval binds to a committed spec
+  revision rather than untracked files; the `docs/specs/` freeze at scaffold carries the
+  naming-mapping preamble (A-7).
+- Manifest: [orchestrator/project.yaml](../../orchestrator/project.yaml) (delivery_state: `init → design` recorded 2026-08-03, manifest_rev 1)
+- Domain profile: [.eados-core/orchestrator/domains/software.yaml](../../.eados-core/orchestrator/domains/software.yaml)
+- Language profile: [.eados-core/orchestrator/profiles/php.yaml](../../.eados-core/orchestrator/profiles/php.yaml)
+- Protocol: [.eados-core/orchestrator/os/rfc/review-protocol.md](../../.eados-core/orchestrator/os/rfc/review-protocol.md)

--- a/orchestrator/project.yaml
+++ b/orchestrator/project.yaml
@@ -1,0 +1,185 @@
+# project.yaml — the single source of truth for this project (egl-util-php).
+#
+# Filled at /eados design (import path, Q5.0 = import): identity/domain/posture from the
+# init interview (2026-08-03); ownership from repository facts (git remote, LICENSE);
+# language from the maintainer's naming decisions at RFC-0001 import; spec from the
+# imported specification .specs/d4np-php.md (v2.0) as validated by RFC-0001.
+# toolchain / ci / i18n / announce are left for their phases (scaffold interview);
+# blanks fall through to profiles/php.yaml. Template:
+# .eados-core/orchestrator/project.yaml.template
+
+schema_version: 1
+manifest_rev: 3
+domain: software             # Q0.4 development target -> .eados-core/orchestrator/domains/software.yaml
+
+delivery_state:
+  phase: plan                # init|design|plan|scaffold|audit|migrate
+  checkpoints:               # transition ledger — written by the phase runner on legal moves
+    - { from: init, to: design, gates: ['manifest-valid'], at: 2026-08-03, confirmed_by: danielPoloWork, gate_results: { manifest-valid: OK } }
+    - { from: design, to: plan, gates: ['rfc-approved'], at: 2026-08-03, confirmed_by: danielPoloWork, gate_results: { rfc-approved: OK } }
+  refs: { rfcs: ['RFC-0001'], milestones: [], prs: [], releases: [] }
+
+identity:
+  project_name:    "egl-util-php"        # carried from the existing GitHub repository
+  project_slug:    "utils"               # single-word id for paths/namespace (maintainer's choice)
+  project_title:   "EGL PHP Utility Library"
+  project_tagline: "General-purpose PHP utility helpers shared across EGL projects"
+  project_series:  ""                    # no project family (maintainer: EGL is a prefix, not a series)
+  project_kind:    library               # Q0.2
+
+ownership:
+  owner:           "danielPoloWork"      # git remote origin (github.com/danielPoloWork/egl-util-php)
+  maintainer:      "Daniel Polo"         # git config user.name
+  author:          "Daniel Polo"         # LICENSE copyright line
+  year:            "2026"                # LICENSE copyright year
+  license_id:      MIT                   # LICENSE file (MIT License header)
+  default_branch:  master                # actual repo default branch (differs from the `main` template default)
+  assignee:        "danielPoloWork"      # Q4.5 rule: the owner, never @me
+
+language:
+  lang:            php
+  lang_name:       "PHP 8.1+"
+  lang_standard:   "PHP 8.1 (minimum version floor; tested on 8.1/8.2/8.3)"
+  secondary_lang:  ""
+  group_path:      "d4np"                # from the maintainer's namespace decision (RFC-0001 Alternatives #5)
+  group_dotted:    "d4np"
+  namespace:       'D4np\Utils'          # PSR-4 root — {group_dotted}\{slug} in StudlyCase (profiles/php.yaml)
+  src_ext:         php
+  comment_lang:    "en"
+  public_include_hint: 'use D4np\Utils\Dto\DataTransferObject;'
+
+governance:
+  posture: enterprise        # Q0.5 — asked; deliberately raised from the `standard` default (ADR-0015)
+
+spec:                        # Imported (Q5.0 = import) from .specs/d4np-php.md v2.0, validated by RFC-0001.
+  provenance: import
+  objective: "Provide EGL PHP projects (framework-based and native/legacy) with a modern utilities library — Composer package egl/utils, PSR-4 namespace D4np\\Utils\\, PHP 8.1+ — offering typed readonly DTOs, explicit-mechanism security helpers, safe PDO access, hardened session/CSRF handling, and a minimal PSR-11 DI container, replacing ad-hoc per-project solutions (associative-array DTOs, blocklist sanitizers, string-built SQL, silent PDO error modes)."
+  functional_reqs:
+    - "FR-01 DataTransferObject: hydrate typed readonly DTOs from arrays via reflection with per-class metadata caching; strict mode default (unknown key -> UnknownKeyException), lenient() opt-in; missing non-nullable key -> MissingKeyException (RFC-0001 R-4 addition); nested DTOs and Collection<T> hydrate recursively; type mismatch -> TypeMismatchException naming the path"
+    - "FR-02 WithersTrait: with(...) wither semantics producing modified clones of readonly DTOs, absorbing the PHP 8.1->8.3 readonly-clone difference per version"
+    - "FR-03 Collection<T>: functional array wrapper (map/filter/reduce); genericity static-analysis-level only (@template + PHPStan max); optional runtime instanceof guard flag"
+    - "FR-04 Container: minimal PSR-11 container — constructor autowiring (cached reflection), singletons/factories, no compilation; non-goals per imported ADR-001 (no attributes, no lazy proxies, circular deps throw with path)"
+    - "FR-05 ServiceProvider: abstract base for registering container definitions"
+    - "FR-06 DatabaseConnection: PDO wrapper with pinned safe defaults — ERRMODE_EXCEPTION, utf8mb4 on MySQL, real prepares (EMULATE_PREPARES=false), FETCH_ASSOC"
+    - "FR-07 QueryBuilder: fluent SQL builder — values always bound as parameters; identifiers allowlisted (^[A-Za-z_][A-Za-z0-9_]*$) and driver-quoted; ORDER BY direction is an enum; LIMIT/OFFSET cast to non-negative int"
+    - "FR-08 Transaction: closure-scoped transactions — automatic rollback on any exception and rethrow; nested calls use savepoints"
+    - "FR-09 Escaper: context-aware output escaping — html() (ENT_QUOTES|ENT_SUBSTITUTE, UTF-8), attr(), js() (hex), url() (rawurlencode)"
+    - "FR-09b Sanitizer::richText(): user-authored HTML delegated to symfony/html-sanitizer (optional dependency) with a curated allowlist profile; no hand-rolled tag stripper"
+    - "FR-10 Sanitizer::sqlLikePattern(): escape %/_/escape-char in user input used inside LIKE patterns (wildcard-injection defense; values still bind as parameters)"
+    - "FR-11 Hash: password_hash wrapper, Argon2id default; availability via defined('PASSWORD_ARGON2ID'); bcryptFallback: true default logged at WARNING or false to fail fast; self-describing hashes; needsRehash() upgrades on login"
+    - "FR-12 CsrfToken: CSPRNG token generation + constant-time validation (hash_equals), per-session storage, optional per-form scoping (lives in the Http group per RFC-0001 R-1 placement note)"
+    - "FR-13 Request: typed superglobal reader ($_GET/$_POST/$_SERVER/$_FILES); optional PSR-7 bridge per imported ADR-002"
+    - "FR-14 Response: headers/JSON/status helpers; same bridge"
+    - "FR-15 Session: secure session API — cookie_httponly, cookie_secure, cookie_samesite=Lax at start; regenerate() wraps session_regenerate_id(true) for login transitions"
+    - "FR-16 Result: success/failure wrapper for application services (map/flatMap/orElseThrow)"
+    - "FR-17 Logger: PSR-3 file/console logger"
+    - "FR-18 ExceptionHandler: fatal-error capture, JSON problem responses for API calls; never leaks traces in production mode (env-gated)"
+    - "FR-19..21 Str: slug() (transliteration via ext-intl when present), uuid() (v4 from random_bytes), random() (CSPRNG alphanumeric tokens)"
+    - "FR-22..23 File: write()/read() flock-guarded, atomic write via temp+rename; mime() via Fileinfo (never trusts extensions)"
+    - "FR-24 Env::get(): env reads with correct boolean coercion ('false' -> false)"
+    - "FR-25 Json: encode()/decode() with JSON_THROW_ON_ERROR; library JsonException wraps and rethrows PHP's native \\JsonException (RFC-0001 R-7)"
+    - "FR-26 Exception hierarchy: UtilsException <- DatabaseException, HydrationException (<- UnknownKeyException, TypeMismatchException, MissingKeyException), HttpException, FileException, JsonException"
+  nonfunctional_reqs:
+    - "NFR-01 DTO hydration (10 scalar props): <= 5 us/DTO warm (cached reflection) and <= 3x manual constructor assignment"
+    - "NFR-02 Container: singleton resolve <= 2 us warm; first autowired resolve <= 30 us"
+    - "NFR-03 QueryBuilder: 5-condition SELECT builds in <= 10 us; 0 queries executed at build time"
+    - "NFR-04 Memory: hydrating 10 000 DTOs <= 16 MB peak delta"
+    - "NFR-05 Hash::make (Argon2id defaults): 50-200 ms on the reference machine (deliberately slow; documented for capacity planning)"
+    - "NFR-06 Benchmark methodology: phpbench, 10 iterations x 100 revs, 5% retry threshold, PHP 8.3 CLI with OPcache+JIT off, reference machine Ryzen 7 5800X, harness in bench/, nightly CI; regression > 10% fails"
+    - "NFR-07 Quality gates: PHPUnit line coverage >= 90%; Infection mutation score >= 70% on Security/Database/Dto namespaces; PHPStan max level; deptrac layer rules; composer-normalize; composer audit; roave/backward-compatibility-check on release PRs"
+    - "NFR-08 Dependency policy: no third-party implementation dependencies in the core (php>=8.1 + ext-pdo + ext-fileinfo; interface-only psr/container and psr/log excepted — RFC-0001 R-3 correction); symfony/html-sanitizer and the PSR-7 bridge are optional"
+  architecture: |
+    Six component groups over a Support layer (C4 component view, spec s3), rule: groups depend
+    downward on Support only, no cross-group imports — enforced by deptrac in CI.
+    Groups (PSR-4 sub-namespaces of D4np\Utils\): Dto (DataTransferObject, WithersTrait,
+    Collection<T>), Container (PSR-11 Container, ServiceProvider), Database (DatabaseConnection,
+    QueryBuilder, Transaction), Security (Escaper, Sanitizer, Hash), Http (Request, Response,
+    Session, CsrfToken — placement per RFC-0001 R-1: CsrfToken needs per-session storage),
+    Errors (Result, Logger, ExceptionHandler), Support (Str, File, Env, Json, exception
+    hierarchy, shared reflection-metadata cache — the hydrator and the Container both consume it;
+    RFC-0001 R-2). Source tree: PSR-4 base dir is the rendered src/main/php/d4np/utils/ and
+    deptrac layer globs are defined against that exact tree (RFC-0001 A-9). Mixed-vendor naming
+    (package egl/utils, namespace D4np\Utils\) is a recorded maintainer decision (RFC-0001
+    Alternatives #5) and must be stated in composer.json and the README.
+  architecture_style: "Layered"
+  patterns: []
+  pattern_discipline: advisory
+  layers: []
+  public_api:
+    - "D4np\\Utils\\Dto\\ — DataTransferObject::fromArray()/lenient(), WithersTrait::with(), Collection<T>"
+    - "D4np\\Utils\\Container\\ — PSR-11 Container (get/has, autowire, singleton/factory), ServiceProvider"
+    - "D4np\\Utils\\Database\\ — DatabaseConnection (pinned PDO defaults), QueryBuilder (fluent, Sort enum), Transaction::run(closure)"
+    - "D4np\\Utils\\Security\\ — Escaper::html/attr/js/url, Sanitizer::richText/sqlLikePattern, Hash::make/verify/needsRehash"
+    - "D4np\\Utils\\Http\\ — Request (typed superglobal reader), Response, Session::regenerate(), CsrfToken; PSR-7 via optional egl/utils-psr7-bridge"
+    - "D4np\\Utils\\Errors\\ — Result::map/flatMap/orElseThrow, PSR-3 Logger, ExceptionHandler"
+    - "D4np\\Utils\\Support\\ — Str::slug/uuid/random, File::write/read/mime, Env::get, Json::encode/decode, UtilsException hierarchy"
+  verification: "Five suites (spec s7): T-01 DTO hydration matrix (nested, collections, nullables, enums, strict/lenient, withers, missing-key cases per RFC-0001 R-4); T-02 injection suite (fuzzed value payloads reach the driver only as bound parameters via query-log assertion; identifier injection throws DatabaseException; LIKE-wildcard escapes); T-03 session/CSRF integration against a real php -S process (cookie flags HttpOnly/Secure/SameSite, session id changes across regenerate(), hash_equals timing, cross-session token rejection); T-04 transaction semantics (exception -> rollback -> rethrow; savepoint nesting); T-05 property tests (Json round-trips, Str::slug idempotence, Env boolean coercion table). Plus: OWASP XSS cheat-sheet corpus per Escaper context (snapshot suite); DOM-bypass corpus for richText(); Hash argon2id/bcrypt-fallback matrix; bridge conversion-fidelity contract tests in egl/utils-psr7-bridge CI (imported ADR-002). CI proves failure via the NFR-07 gate set."
+  milestone1_items:
+    - "Pin composer.json identity: name egl/utils, PSR-4 'D4np\\Utils\\' -> src/main/php/d4np/utils/, require php>=8.1 + ext-pdo + ext-fileinfo + psr/container + psr/log (RFC-0001 naming mapping + R-3)"
+    - "CI matrix covers PHP 8.1/8.2/8.3 with an explicit toolchain->version map (the profile's 2-way ternary must not silently map 8.1 to 8.3 — RFC-0001 A-3) plus a composer --prefer-lowest job"
+  milestones:
+    - number: 2
+      title: "Support layer"
+      goal: "The foundation every group depends on (deptrac-legal bottom layer)"
+      items:
+        - "2.1 Exception hierarchy: UtilsException root + Database/Hydration/Http/File/Json children (incl. MissingKeyException)"
+        - "2.2 Str: slug() with ext-intl transliteration fallback, uuid() v4, random() CSPRNG"
+        - "2.3 File: flock-guarded write()/read(), atomic write via temp+rename, Fileinfo mime()"
+        - "2.4 Env::get() with boolean coercion; Json::encode()/decode() wrapping native \\JsonException"
+        - "2.5 Shared reflection-metadata cache (consumed by Dto hydrator and Container)"
+        - "2.6 T-05 property tests (Json round-trips, slug idempotence, Env coercion table)"
+    - number: 3
+      title: "DTO & data mapping"
+      goal: "Typed, mass-assignment-safe data transfer"
+      items:
+        - "3.1 DataTransferObject: strict/lenient hydration, nested DTOs, Collection<T> properties"
+        - "3.2 WithersTrait with per-version readonly-clone handling"
+        - "3.3 Collection<T> with @template discipline enforced by PHPStan max"
+        - "3.4 T-01 hydration matrix suite"
+        - "3.5 phpbench: NFR-01 hydration and NFR-04 memory benchmarks"
+    - number: 4
+      title: "Database"
+      goal: "Safe-by-default PDO access"
+      items:
+        - "4.1 DatabaseConnection with pinned defaults (ERRMODE_EXCEPTION, utf8mb4, real prepares, FETCH_ASSOC)"
+        - "4.2 QueryBuilder: bound values, identifier allowlist + driver quoting, Sort enum, int-cast LIMIT/OFFSET"
+        - "4.3 Transaction: closure scope, rollback+rethrow, savepoints"
+        - "4.4 T-02 injection suite (values, identifiers, LIKE wildcards) + T-04 transaction semantics"
+        - "4.5 phpbench: NFR-03 build-time benchmark"
+    - number: 5
+      title: "Security"
+      goal: "Explicit-mechanism security helpers"
+      items:
+        - "5.1 Escaper: html/attr/js/url context escaping"
+        - "5.2 Sanitizer::richText() over symfony/html-sanitizer (optional dep) + sqlLikePattern()"
+        - "5.3 Hash: Argon2id default, bcryptFallback policy, needsRehash()"
+        - "5.4 OWASP XSS corpus snapshot suite + DOM-bypass corpus for richText()"
+        - "5.5 Hash matrix tests (argon2id/bcrypt fallback, rehash triggers) + NFR-05 timing"
+    - number: 6
+      title: "HTTP, container, errors"
+      goal: "The application-facing groups"
+      items:
+        - "6.1 Request/Response typed wrappers (PSR-7-mirroring naming)"
+        - "6.2 Session hardening + regenerate(); CsrfToken (CSPRNG, hash_equals, per-form scoping)"
+        - "6.3 T-03 session/CSRF integration suite against real php -S"
+        - "6.4 Container (PSR-11) + ServiceProvider; NFR-02 benchmarks"
+        - "6.5 Result, PSR-3 Logger, ExceptionHandler (env-gated trace policy)"
+    - number: 7
+      title: "Release engineering & bridge"
+      goal: "Ship egl/utils 1.0 and settle the bridge"
+      items:
+        - "7.1 phpbench nightly CI harness (NFR-06 methodology) with >10% regression failure"
+        - "7.2 roave/backward-compatibility-check wired to release PRs; deprecation policy documented"
+        - "7.3 Signed tags -> validated release action -> Packagist publish"
+        - "7.4 egl/utils-psr7-bridge packaging decision (subtree vs second repository — possibly a second EADOS run) + ADR-002 conversion contract tests (RFC-0001 A-8)"
+
+# Interview provenance (#169) — recorded as each phase settles, never retrospectively.
+interview:
+  questionnaire_version: 1
+  provenance:
+    domain: asked          # Q0.4 (init, 2026-08-03)
+    identity: asked        # Q0.1-Q0.3 (init) + slug/series confirmation
+    governance: asked      # Q0.5 posture (init)
+    ownership: imported    # git remote, git config, LICENSE (design, 2026-08-03)
+    language: asked        # package/namespace/bridge naming decisions at RFC-0001 import
+    spec: imported         # Q5.0 = import; .specs/d4np-php.md v2.0 validated by RFC-0001


### PR DESCRIPTION
## Context

`egl-util-php` entered the EADOS delivery pipeline on 2026-08-03: `/eados init` framed the
project (library, domain `software`, posture **enterprise**) and `/eados design` imported the
pre-existing reviewed specification (`.specs/d4np-php.md`, v2.0, 25 functional items + 2
accepted ADRs) rather than re-interviewing it. The spec was authored under the project's
earlier name `d4np-php`; the maintainer decided the naming mapping at import (package
`egl/utils`, PSR-4 root `D4np\Utils\` — a deliberate mixed-vendor choice recorded with the
tech-lead's dissent — bridge `egl/utils-psr7-bridge`).

## Change

- **`docs/rfc/0001-egl-utils-library.md`** — RFC-0001, the foundation design: naming mapping,
  six component groups over a Support layer (deptrac-enforced), API contract (operations,
  payloads, error model incl. `MissingKeyException`/`JsonException` wrap semantics, SemVer
  surface), numeric NFR budgets (NFR-01…05 + phpbench methodology), DTO-hydration algorithm
  sketch, security cross-cutting criteria, scaffold handoff overrides (CI matrix 8.1/8.2/8.3
  with explicit version map, PHPStan-only, coverage 90, Infection/deptrac/audit), three seeded
  ADRs for the generated repo, and the follow-up roadmap. Reviewed by the `reviewer` and
  `enterprise-architect` roles (18 structured findings, 0 blockers, all resolved in-text);
  **approved** `approved-by: tech-lead (2026-08-03)` — approval confirmed by the owner.
- **`.specs/`** — the imported spec + 2 ADRs committed alongside the RFC so the approval binds
  to a committed revision (finding A-5); broken internal relative links fixed and an import
  preamble added pointing at RFC-0001's naming mapping (finding A-7).
- **`orchestrator/project.yaml`** — manifest filled for the import path with recorded
  provenance (ownership `imported` from repo facts; language `asked` — the naming decisions;
  spec `imported` from the v2.0 document; roadmap seed M2–M7); delivery state advanced through
  two human-confirmed checkpoints: `init → design` (gate `manifest-valid: OK`) and
  `design → plan` (gate `rfc-approved: OK`), `manifest_rev 3`.

## Verification

- `python .eados-core/tools/render.py --check orchestrator/project.yaml` → OK (manifest valid)
- `python .eados-core/tools/rfc_check.py docs/rfc/0001-egl-utils-library.md` → OK (`rfc-approved` gate)
- `python .eados-core/tools/phase_runner.py orchestrator/project.yaml` → `current phase: plan (manifest_rev 3)`; next legal move `-> scaffold` (gate `roadmap-covers-rfcs`)
- Run record: `.eados-core/learning/runs/2026-08-03-utils.yaml` (outcome ok — in the working
  tree; lands with the EADOS bundle commit, see note)

**Cross-links:** RFC-0001 (this PR); roadmap milestones are seeded as `spec.milestones` M2–M7
in the manifest — no GitHub milestone exists in the repository yet (fresh repo; `/eados plan`
will negotiate the roadmap and the release milestones).

**Note:** the vendored EADOS bundle (`.eados-core/`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
`.claude/commands/`) is deliberately **not** in this PR — one logical change per PR; it can
follow as a separate `chore` PR if the owner wants the machinery in history. Until then the
RFC's `.eados-core/...` reference links resolve only in a local working copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
