### PR TITLE
docs(roadmap): negotiate M1-M7 roadmap from RFC-0001

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,189 @@
+# Roadmap — egl-util-php
+
+The project's plan as a numbered, checkbox-driven list. When an item completes in a PR,
+flip its checkbox (`- [ ]` → `- [x]`) **in the same PR**. New work goes at the bottom of
+its section with a fresh `<milestone>.<task>` number; never renumber.
+
+Negotiated at the `plan` phase (2026-08-03) from **RFC-0001** — the only approved RFC
+([docs/rfc/0001-egl-utils-library.md](docs/rfc/0001-egl-utils-library.md)) — by the
+`product-manager` (priorities) / `tech-lead` (sizes + routes) / `producer` (reconciliation)
+protocol; scope confirmed in full by the owner. Milestones are **sequential** (solo-owner
+capacity; no parallel streams; no calendar dates by decision).
+
+- **Versioning start:** pre-1.0 milestone-driven — one minor per milestone
+  (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
+  API-freeze review**, not an automatic bump.
+- **Session journal:** see `docs/journal/` (seeded at scaffold). Latest checkpoint: _none yet_.
+
+## Model & effort routing (advisory)
+
+An item may carry an advisory **route** — `route: <tier> / <effort>` — derived from its intake
+signals through the `os/routing` policy's only-raise resolution (ADR-0017: start at the floor;
+matched signals only ever raise, never lower). Tiers, cheapest → most capable:
+`fast`, `standard`, `frontier-reasoning`. Efforts: `low`, `medium`, `high`, `extra`, `max`.
+An item with no route takes the floor (`fast / low`). The route *recommends*; **the human keeps
+final model authority** — switch with your host's own model control, never mid-session by the
+agent. Signals in parentheses are asserted from RFC-0001/spec today and firm up as tracker
+labels when items are filed as issues.
+
+Tiers map to concrete models only through the dated catalog (as of **2026-07-27**;
+a stale date is the review cue):
+
+| Tier | Model (host: claude-code / Anthropic) |
+|---|---|
+| frontier-reasoning | Fable 5 |
+| standard | Opus 5 |
+| fast | Sonnet 5 |
+
+Where the EADOS core is vendored (`.eados-core/`), the authoritative per-issue call once tracker
+labels exist is `python .eados-core/tools/route_advice.py --issue <N>`.
+
+---
+
+## Milestone 1 — Project bootstrap & CI (`v0.1.0`) · size: M
+
+The thinnest slice that compiles, tests, and ships under the full quality bar (RFC-0001).
+
+- [ ] 1.1 Lay down the build system (Composer, PSR-4 autoload) and a buildable skeleton under
+      `src/main/php/d4np/utils/` (RFC-0001) — route: standard / medium
+- [ ] 1.2 Wire the test framework (PHPUnit) with one passing smoke test under
+      `src/test/php/d4np/utils/` (RFC-0001) — route: fast / low
+- [ ] 1.3 Add formatter + linter configs (PHP-CS-Fixer PSR-12; PHPStan max level — Psalm not
+      adopted per RFC-0001) at the repo root — route: fast / low
+- [ ] 1.4 Stand up the CI matrix (Linux: PHP 8.1, 8.2, 8.3) with build + test + format + lint
+      (RFC-0001) — route: standard / medium
+- [ ] 1.5 Seed the version constant (`public const VERSION = 'X.Y.Z'`) in `Version.php`
+      (RFC-0001) — route: fast / low
+- [ ] 1.6 Pin composer.json identity: name `egl/utils`, PSR-4 `D4np\Utils\` →
+      `src/main/php/d4np/utils/`, require `php>=8.1` + `ext-pdo` + `ext-fileinfo` +
+      `psr/container` + `psr/log` (RFC-0001 naming mapping + R-3) — route: standard / medium
+- [ ] 1.7 CI toolchain→version map written explicitly (the profile's 2-way ternary must not
+      silently map 8.1 to 8.3 — RFC-0001 A-3) plus the `composer update --prefer-lowest` job —
+      route: standard / medium
+
+---
+
+## Milestone 2 — Support layer (`v0.2.0`) · size: M
+
+The foundation every group depends on — the deptrac-legal bottom layer (RFC-0001).
+
+- [ ] 2.1 Exception hierarchy: `UtilsException` root + Database/Hydration/Http/File/Json
+      children, incl. `MissingKeyException` (RFC-0001) (sets-pattern) —
+      route: frontier-reasoning / high
+- [ ] 2.2 `Str`: `slug()` with ext-intl transliteration fallback, `uuid()` v4, `random()`
+      CSPRNG (RFC-0001) — route: fast / low
+- [ ] 2.3 `File`: flock-guarded `write()`/`read()`, atomic write via temp+rename, Fileinfo
+      `mime()` (RFC-0001) (severity:medium — concurrency/atomicity semantics) —
+      route: standard / medium
+- [ ] 2.4 `Env::get()` with boolean coercion; `Json::encode()/decode()` wrapping native
+      `\JsonException` (RFC-0001 R-7) — route: fast / low
+- [ ] 2.5 Shared reflection-metadata cache, consumed by the Dto hydrator and the Container
+      (RFC-0001 R-2) (sets-pattern) — route: frontier-reasoning / high
+- [ ] 2.6 T-05 property tests: Json round-trips, slug idempotence, Env coercion table
+      (RFC-0001) — route: fast / low
+
+---
+
+## Milestone 3 — DTO & data mapping (`v0.3.0`) · size: L
+
+Typed, mass-assignment-safe data transfer (RFC-0001).
+
+- [ ] 3.1 `DataTransferObject`: strict/lenient hydration, `MissingKeyException` semantics,
+      nested DTOs, `Collection<T>` properties (RFC-0001 R-4) (sets-pattern) —
+      route: frontier-reasoning / high
+- [ ] 3.2 `WithersTrait` with per-version readonly-clone handling 8.1→8.3 (RFC-0001)
+      (severity:medium) — route: standard / medium
+- [ ] 3.3 `Collection<T>` with `@template` discipline enforced by PHPStan max (RFC-0001)
+      (severity:medium) — route: standard / medium
+- [ ] 3.4 T-01 hydration matrix suite (RFC-0001) — route: fast / low
+- [ ] 3.5 phpbench: NFR-01 hydration + NFR-04 memory benchmarks (RFC-0001) (step:optimize) —
+      route: fast / medium
+
+---
+
+## Milestone 4 — Database (`v0.4.0`) · size: L
+
+Safe-by-default PDO access (RFC-0001).
+
+- [ ] 4.1 `DatabaseConnection` with pinned defaults: ERRMODE_EXCEPTION, utf8mb4, real prepares,
+      FETCH_ASSOC (RFC-0001) (severity:high — core guarantee) — route: standard / high
+- [ ] 4.2 `QueryBuilder`: bound values, identifier allowlist + driver quoting, `Sort` enum,
+      int-cast LIMIT/OFFSET (RFC-0001) (security — protected floor) —
+      route: frontier-reasoning / extra
+- [ ] 4.3 `Transaction`: closure scope, rollback+rethrow, savepoints (RFC-0001)
+      (severity:medium) — route: standard / medium
+- [ ] 4.4 T-02 injection suite (values / identifiers / LIKE wildcards) + T-04 transaction
+      semantics (RFC-0001) (security — the protected floor holds in the test step) —
+      route: frontier-reasoning / extra
+- [ ] 4.5 phpbench: NFR-03 build-time benchmark (RFC-0001) (step:optimize) — route: fast / medium
+
+---
+
+## Milestone 5 — Security (`v0.5.0`) · size: M
+
+Explicit-mechanism security helpers (RFC-0001; every item carries the protected `security` floor).
+
+- [ ] 5.1 `Escaper`: html/attr/js/url context escaping (RFC-0001) (security) —
+      route: frontier-reasoning / extra
+- [ ] 5.2 `Sanitizer::richText()` over symfony/html-sanitizer (optional dep) +
+      `sqlLikePattern()` (RFC-0001) (security) — route: frontier-reasoning / extra
+- [ ] 5.3 `Hash`: Argon2id default, `bcryptFallback` policy, `needsRehash()` (RFC-0001)
+      (security) — route: frontier-reasoning / extra
+- [ ] 5.4 OWASP XSS corpus snapshot suite + DOM-bypass corpus for `richText()` (RFC-0001)
+      (security) — route: frontier-reasoning / extra
+- [ ] 5.5 Hash matrix tests (argon2id/bcrypt fallback, rehash triggers) + NFR-05 timing
+      (RFC-0001) (security) — route: frontier-reasoning / extra
+
+---
+
+## Milestone 6 — HTTP, container, errors (`v0.6.0`) · size: L
+
+The application-facing groups (RFC-0001).
+
+- [ ] 6.1 `Request`/`Response` typed wrappers, PSR-7-mirroring naming (RFC-0001)
+      (severity:medium) — route: standard / medium
+- [ ] 6.2 `Session` hardening + `regenerate()`; `CsrfToken` — CSPRNG, `hash_equals`, per-form
+      scoping; Http placement per RFC-0001 R-1 (security) — route: frontier-reasoning / extra
+- [ ] 6.3 T-03 session/CSRF integration suite against a real `php -S` process (RFC-0001)
+      (security) — route: frontier-reasoning / extra
+- [ ] 6.4 `Container` (PSR-11) + `ServiceProvider`; NFR-02 benchmarks (RFC-0001, imported
+      ADR-001) (severity:medium) — route: standard / medium
+- [ ] 6.5 `Result`, PSR-3 `Logger`, `ExceptionHandler` with env-gated trace policy (RFC-0001)
+      (severity:medium) — route: standard / medium
+
+---
+
+## Milestone 7 — Release engineering & bridge (`v0.7.0`) · size: M
+
+Ship `egl/utils` and settle the bridge (RFC-0001). The **1.0.0 decision** follows as a
+dedicated post-M7 API-freeze review.
+
+- [ ] 7.1 phpbench nightly CI harness (NFR-06 methodology) with >10% regression failure
+      (RFC-0001) (severity:medium) — route: standard / medium
+- [ ] 7.2 `roave/backward-compatibility-check` wired to release PRs; deprecation policy
+      documented (RFC-0001) (severity:medium) — route: standard / medium
+- [ ] 7.3 Signed tags → validated release action → Packagist publish (RFC-0001)
+      (severity:high — supply-chain surface) — route: standard / high
+- [ ] 7.4 `egl/utils-psr7-bridge` packaging decision: subtree vs second repository (possibly a
+      second EADOS run) + ADR-002's conversion contract tests (RFC-0001 A-8)
+      (adr, decision-heavy) — route: frontier-reasoning / extra
+
+---
+
+## Spec Coverage Map
+
+Tracks which spec section is fulfilled by which roadmap item(s). Sections follow the frozen
+spec shape (scaffold renders `docs/specs/`; source: `.specs/d4np-php.md` v2.0 via RFC-0001).
+Legend: ⏳ not started · 🚧 in progress · ✅ done · ❎ N/A.
+
+| Spec § | Requirement | Roadmap items | Status |
+|--------|-------------|---------------|--------|
+| §1 | Objective & design philosophy | 1.1, 1.6 | ⏳ |
+| §2 | Functional items 1–25 (+9b) | 2.1–2.5, 3.1–3.3, 4.1–4.3, 5.1–5.3, 6.1–6.2, 6.4–6.5 | ⏳ |
+| §3 | Architecture & layering (deptrac) | 1.1, 1.6, 2.1, 2.5 | ⏳ |
+| §4 | NFR budgets & benchmark methodology | 3.5, 4.5, 5.5, 6.4, 7.1 | ⏳ |
+| §5 | Security test criteria | 4.4, 5.4, 5.5, 6.3 | ⏳ |
+| §6 | API example / public interface | 1.6, 3.1 | ⏳ |
+| §7 | Verification & test strategy | 1.2, 2.6, 3.4, 4.4, 6.3 | ⏳ |
+| §8 | CI/CD & release engineering | 1.4, 1.7, 7.1–7.3 | ⏳ |
+| §9 | Decision log (imported + seeded ADRs) | 2.1, 5.3, 7.4 | ⏳ |

--- a/orchestrator/project.yaml
+++ b/orchestrator/project.yaml
@@ -9,15 +9,16 @@
 # .eados-core/orchestrator/project.yaml.template
 
 schema_version: 1
-manifest_rev: 3
+manifest_rev: 5
 domain: software             # Q0.4 development target -> .eados-core/orchestrator/domains/software.yaml
 
 delivery_state:
-  phase: plan                # init|design|plan|scaffold|audit|migrate
+  phase: scaffold            # init|design|plan|scaffold|audit|migrate
   checkpoints:               # transition ledger — written by the phase runner on legal moves
     - { from: init, to: design, gates: ['manifest-valid'], at: 2026-08-03, confirmed_by: danielPoloWork, gate_results: { manifest-valid: OK } }
     - { from: design, to: plan, gates: ['rfc-approved'], at: 2026-08-03, confirmed_by: danielPoloWork, gate_results: { rfc-approved: OK } }
-  refs: { rfcs: ['RFC-0001'], milestones: [], prs: [], releases: [] }
+    - { from: plan, to: scaffold, gates: ['roadmap-covers-rfcs'], at: 2026-08-03, confirmed_by: danielPoloWork, gate_results: { roadmap-covers-rfcs: OK } }
+  refs: { rfcs: ['RFC-0001'], milestones: ['M1', 'M2', 'M3', 'M4', 'M5', 'M6', 'M7'], prs: [1], releases: [] }
 
 identity:
   project_name:    "egl-util-php"        # carried from the existing GitHub repository


### PR DESCRIPTION
## Context

With RFC-0001 approved and merged (PR #1), the `plan` phase turns the approved design into a
**negotiated** milestone roadmap per the EADOS negotiation protocol: `product-manager` proposed
priorities, `tech-lead` attached T-shirt sizes and model/effort routes (resolved through the
`os/routing` policy with `route_advice.py` — tiers, never model names), and the `producer`
reconciled against real capacity (solo owner + agent ⇒ sequential milestones, no calendar
dates by decision). The owner confirmed scope in full and the release mapping.

## Change

- **`ROADMAP.md`** — the negotiated roadmap: Milestone 1 (bootstrap & CI, 7 items incl. the
  RFC-pinned `composer.json` identity and the explicit CI version map) through Milestone 7
  (release engineering & bridge). Every item references RFC-0001 (the traceability gate's
  anchor), carries an advisory `route: <tier> / <effort>` with its asserted signals in
  parentheses (security floors protected per ADR-0017), and the file carries the routing
  legend + dated catalog and a spec coverage map over the imported spec's §1–§9.
  Release mapping: one minor per milestone (M1 → v0.1.0 … M7 → v0.7.0); the 1.0.0 decision
  is a dedicated post-M7 API-freeze review.
- **`orchestrator/project.yaml`** — cross-links `refs.milestones: M1–M7`, `refs.prs: [1]`;
  delivery state advanced `plan → scaffold` via a human-confirmed checkpoint
  (gate `roadmap-covers-rfcs: OK`), `manifest_rev 5`.
- **GitHub milestones** `v0.1.0`–`v0.7.0` created; PR #1 retro-assigned to `v0.1.0`
  (its metadata check now reports complete).

## Verification

- `python .eados-core/tools/traceability.py ROADMAP.md RFC-0001` → OK
  (`RFC-0001 -> M1, M2, M3, M4, M5, M6, M7`)
- `python .eados-core/tools/phase_runner.py orchestrator/project.yaml` →
  `current phase: scaffold (manifest_rev 5)`; next legal move `-> audit`
  (gates `consistency-lint`, `self-review` — evaluated after the scaffold render)
- `python .eados-core/tools/pr_metadata_check.py --pr 1` → complete
- Run record: `.eados-core/learning/runs/2026-08-03-utils-2.yaml` (outcome ok; lands with the
  EADOS bundle commit)

**Cross-links:** RFC-0001 (approved, PR #1, merged `4fc7b55`) · milestones M1–M7 / GitHub
`v0.1.0`–`v0.7.0` · this PR belongs to milestone `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
