### PR TITLE
ci(ci): harden the benchmark job — guard, interpreter, instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,24 @@ jobs:
         run: vendor/bin/infection --min-msi=70 --only-covered
 
   # Reproducible performance gate — runs only when the project has a benchmark suite.
+  #
+  # Self-enables when the phpbench harness lands (roadmap 3.5 / 7.1), via the same step-level
+  # config guard as `layering` and `mutation`: hashFiles() is runner-only and cannot gate a
+  # job-level `if` without failing the whole workflow at startup.
+  #
+  # The PHP setup below is written FOR THIS JOB rather than inherited from the build matrix.
+  # The generated version injected the matrix's setup steps verbatim into a job that declares
+  # no matrix, leaving two defects (roadmap 1.9):
+  #   - `php-version: ${{ matrix.toolchain == 'php-8.1' && ... || '8.3' }}` — `matrix` is null
+  #     here, so the ternary always fell through to '8.3'. Verified on run 30811447268: the job
+  #     installed PHP 8.3.33. That happens to match the methodology below, which is worse than
+  #     a visible error — it was right by accident, and would have silently selected the wrong
+  #     interpreter the moment anyone gave this job a matrix.
+  #   - `coverage: pcov` — coverage instrumentation distorts the very measurements this job
+  #     exists to take.
+  # Spec NFR-06 pins the benchmark interpreter to PHP 8.3; the rest of that methodology
+  # (10 iterations x 100 revs, 5% retry threshold, OPcache + JIT off, >10% regression fails)
+  # lands with the harness in roadmap item 7.1.
   benchmark:
     name: benchmark / reproducible perf
     needs: bootstrap
@@ -185,14 +203,27 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check for a phpbench config (job self-enables when the harness lands)
+        id: cfg
+        shell: bash
+        run: |
+          if [ -f phpbench.json ] || [ -f phpbench.json.dist ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Benchmarks pending::No phpbench config yet, so the benchmark suite is skipped. It starts running by itself once roadmap item 3.5 lands the harness."
+          fi
       - name: Set up PHP
+        if: steps.cfg.outputs.present == 'true'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.toolchain == 'php-8.1' && '8.1' || matrix.toolchain == 'php-8.2' && '8.2' || '8.3' }}
-          coverage: pcov
+          php-version: '8.3'   # spec NFR-06 benchmark methodology — not the build matrix
+          coverage: none       # instrumentation would distort the measurements
       - name: Install dependencies
+        if: steps.cfg.outputs.present == 'true'
         run: composer install --no-interaction --prefer-dist
       - name: Run the benchmark suite
+        if: steps.cfg.outputs.present == 'true'
         shell: bash
         run: vendor/bin/phpbench run --report=aggregate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Changed
 
+- CI `benchmark` job hardened: it now self-enables on the presence of a phpbench config (the
+  same step-level guard as the `deptrac` and `Infection` jobs) instead of failing until the
+  harness lands, pins its interpreter to PHP 8.3 per spec NFR-06 rather than through a
+  matrix expression the job never had, and runs without coverage instrumentation.
+
 ### Deprecated
 
 ### Removed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,7 +62,12 @@ The thinnest slice that compiles, tests, and ships under the full quality bar (R
 - [ ] 1.7 CI toolchain→version map written explicitly (the profile's 2-way ternary must not
       silently map 8.1 to 8.3 — RFC-0001 A-3) plus the `composer update --prefer-lowest` job —
       route: standard / medium
-- [ ] 1.9 Harden the `benchmark / reproducible perf` CI job, which went red on item 1.1 and is
+- [ ] 1.8 Fix the doubled `version_file` path in `tools/consistency_lint.py` `CONFIG`
+      (`src/main/php/d4np/utils/src/main/php/d4np/utils/Version.php` — the scaffold manifest
+      passed a full path where the template prepends `SRC_MAIN`). Benign while the file is
+      absent, but it silently disarms `version-lockstep` the moment 1.5 lands — the lesson
+      L-0008 failure class. Fix with 1.5 and prove the gate can fail — route: standard / medium
+- [x] 1.9 Harden the `benchmark / reproducible perf` CI job, which went red on item 1.1 and is
       **not** fixed by 1.2/1.3: (a) it runs `vendor/bin/phpbench`, a dev dependency no M1 item
       introduces — give it the same step-level config guard as `layering`/`mutation` so it
       self-enables when the benchmark suite lands (3.5 / 7.1); (b) its `php-version` expression
@@ -70,11 +75,16 @@ The thinnest slice that compiles, tests, and ships under the full quality bar (R
       through to `'8.3'` — a rendering artifact of the profile setup steps being injected into a
       non-matrix job. Correct by hand (ADR-0003: this repo is never re-rendered) —
       route: standard / medium
-- [ ] 1.8 Fix the doubled `version_file` path in `tools/consistency_lint.py` `CONFIG`
-      (`src/main/php/d4np/utils/src/main/php/d4np/utils/Version.php` — the scaffold manifest
-      passed a full path where the template prepends `SRC_MAIN`). Benign while the file is
-      absent, but it silently disarms `version-lockstep` the moment 1.5 lands — the lesson
-      L-0008 failure class. Fix with 1.5 and prove the gate can fail — route: standard / medium
+- [ ] 1.10 Decide and record the **CI action-pinning policy** as an ADR, then make
+      `.github/workflows/*.yml` consistent with it. Today the same action is pinned two ways in
+      one file: the template-generated steps use a commit SHA with a version comment
+      (`actions/checkout@3d3c42e5… # v7.0.1`) while the manifest-authored quality jobs use a
+      floating tag (`actions/checkout@v7`). Under the enterprise posture a supply-chain choice
+      is a security-relevant decision and needs an ADR (§7) — including whether
+      `shivammathur/setup-php@v2` stays deliberately tag-pinned and Dependabot-managed.
+      Checked first (lesson L-0004): no ADR in this repo decides it — EADOS's own ADR-0009
+      governs the factory, not this self-governing repository — so it is genuinely open, not a
+      re-discovered trade-off — route: standard / medium
 
 ---
 

--- a/docs/journal/2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md
+++ b/docs/journal/2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md
@@ -107,13 +107,43 @@ dependency was first added. `symfony/*` relocked from `v7.4.x` to `v6.4.x`; full
 verification (PHPUnit, PHPStan, PHP-CS-Fixer, `composer validate`/`normalize`/`audit`)
 re-ran clean.
 
+## Item 1.9 — the benchmark job hardened, and the CI matrix finally all green
+
+The last red from item 1.1. Three defects, one root cause: the profile's *matrix-oriented*
+setup steps were injected verbatim into a job that declares no matrix.
+
+- **It failed instead of waiting.** `vendor/bin/phpbench` is a dev dependency no M1 item
+  introduces, so the job could only go red until the harness lands (3.5 / 7.1). Now guarded
+  the same way as `layering` and `mutation` — a first step probes for `phpbench.json`
+  (or `.dist`) and every later step is conditional on it, emitting a `::notice` while pending.
+  Lesson L-0010's rule, applied to the one job that had escaped it.
+- **`php-version` read `matrix.toolchain` in a job with no matrix.** Verified rather than
+  reasoned: on run 30811447268 the job installed **PHP 8.3.33** — the ternary had fallen
+  through to its final branch, because `matrix` is null here. The value it landed on happens
+  to be the one spec NFR-06 requires, which is *worse* than a visible error: right by
+  accident, and it would have silently selected the wrong interpreter the moment anyone gave
+  this job a matrix. Now a literal `'8.3'` citing NFR-06.
+- **`coverage: pcov` on a performance job.** Coverage instrumentation distorts the very
+  measurements the job exists to take. Now `coverage: none`.
+
+The remaining NFR-06 methodology (10 iterations × 100 revs, 5% retry threshold, OPcache + JIT
+off, >10% regression fails) belongs to the harness in item 7.1 and is noted in the job's own
+comment so it is not silently forgotten.
+
+**Filed, not fixed here (§10):** item **1.10** — the same action is pinned two ways in one
+workflow (`actions/checkout` by SHA in the template-generated steps, by floating tag `@v7` in
+the manifest-authored quality jobs). Under the enterprise posture a supply-chain choice is a
+security-relevant decision and needs an ADR. Checked first per lesson L-0004 (before filing an
+apparent inconsistency, see whether a governing ADR already decided it): this repo has only
+ADR-0001 and ADR-0002, and EADOS's ADR-0009 governs the *factory*, not this self-governing
+repository — so it is genuinely open, not a re-discovered trade-off.
+
 ## How the next session resumes
 
 1. **Item 1.5 + 1.8 together** — the version constant and the doubled `version_file` path in
    `tools/consistency_lint.py` `CONFIG`. Fixing 1.5 without 1.8 leaves `version-lockstep`
    silently disarmed (it would keep falling back to the README badge). Prove the gate can fail.
-2. **Item 1.9** — the `benchmark` job; the only red from item 1.1 that 1.2 and 1.3 do not clear.
-   At that point the CI matrix should be fully green.
+2. **Item 1.10** — the action-pinning ADR + making the workflows consistent with it.
 3. **Bookkeeping** — items 1.4 and 1.7 were delivered by PR #3 (the CI matrix, the explicit
    toolchain→version map, the `--prefer-lowest` job) but their checkboxes are unflipped; the
    maintainer's call whether "stood up but never executed" counts as done.


### PR DESCRIPTION
## Context

Roadmap item **1.9** — the last red CI job from item 1.1. `benchmark / reproducible perf` was
the one failure that neither 1.2 (PHPUnit) nor 1.3 (cs-fixer/PHPStan) could clear, because
`vendor/bin/phpbench` is a dev dependency no M1 item introduces.

## Change — three defects, one root cause

The profile's **matrix-oriented** setup steps were injected verbatim into a job that declares
**no matrix**. Corrected by hand in `.github/workflows/ci.yml` (ADR-0003: this repository is
self-governing and never re-rendered).

1. **It failed instead of waiting.** The job could only be red until the benchmark harness
   lands (items 3.5 / 7.1). Now guarded exactly like `layering` and `mutation`: a first step
   probes for `phpbench.json` (or `.dist`), every later step is conditional on it, and a
   `::notice` explains the skip while pending. This is lesson **L-0010**'s rule — *a generated
   artifact must be green for the work not yet done* — applied to the one job that had escaped
   it at scaffold.

2. **`php-version` read `matrix.toolchain` in a job with no matrix.** Verified rather than
   reasoned: on run `30811447268` the job installed **PHP 8.3.33** — the ternary fell through
   to its final branch, because `matrix` is null here. The value it landed on happens to be
   exactly the one **spec NFR-06** requires, which is *worse* than a visible error: right by
   accident, and it would have silently selected the wrong interpreter the moment anyone gave
   this job a matrix. Now a literal `'8.3'` with the spec citation inline.

3. **`coverage: pcov` on a performance job.** Coverage instrumentation distorts the very
   measurements the job exists to take. Now `coverage: none`.

The rest of NFR-06's methodology (10 iterations × 100 revs, 5% retry threshold, OPcache + JIT
off, >10% regression fails) belongs to the harness in item **7.1** and is named in the job's own
comment so it is not silently forgotten.

## Filed, not fixed here (§10)

**Item 1.10 — the CI action-pinning policy.** The same action is pinned two ways in one
workflow: `actions/checkout@3d3c42e5… # v7.0.1` (SHA + version comment) in the
template-generated steps, `actions/checkout@v7` (floating tag) in the manifest-authored quality
jobs. Under the enterprise posture a supply-chain choice is a security-relevant decision and
requires an ADR (§7), including whether `shivammathur/setup-php@v2` stays deliberately
tag-pinned and Dependabot-managed.

Checked first, per lesson **L-0004** (*before filing an apparent inconsistency, see whether a
governing ADR already decided it*): this repo carries only ADR-0001 and ADR-0002, and EADOS's
own ADR-0009 governs the **factory**, not this self-governing repository. So it is genuinely
open — not a re-discovered trade-off.

## Verification

- Workflow parses as YAML (PyYAML)
- No job-level `if` references a runner-only function or the `matrix` context — the exact trap
  that failed the whole workflow at startup during scaffold
- The `benchmark` job carries no `matrix` reference at all; `matrix.*` now appears only in
  `build`, which actually declares one
- `python tools/consistency_lint.py` → **OK — all congruence invariants hold**

**Expected CI:** with this merged, every job is green or legitimately skipping — the first
fully-green matrix since the build system landed.

**Cross-links:** RFC-0001 · roadmap item 1.9 (done), 1.10 (filed) · milestone `v0.1.0`.
Type label: `ci` (declared in `.github/labels.yml`, not yet imported); `enhancement` set as the
closest available default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
