### PR TITLE
docs(adr): pin CI actions by commit SHA (ADR-0003)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.toolchain == 'php-8.1' && '8.1' || matrix.toolchain == 'php-8.2' && '8.2' || '8.3' }}
           coverage: pcov
@@ -108,8 +108,8 @@ jobs:
     needs: bootstrap
     if: needs.bootstrap.outputs.ready == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with: { php-version: '8.3' }
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/php-cs-fixer fix --dry-run --diff
@@ -120,8 +120,8 @@ jobs:
     needs: bootstrap
     if: needs.bootstrap.outputs.ready == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with: { php-version: '8.3' }
       - run: composer install --no-interaction --prefer-dist
       - run: composer normalize --dry-run
@@ -132,8 +132,8 @@ jobs:
     needs: bootstrap
     if: needs.bootstrap.outputs.ready == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with: { php-version: '8.1' }
       - run: composer update --no-interaction --prefer-lowest
       - run: vendor/bin/phpunit
@@ -146,11 +146,11 @@ jobs:
     needs: bootstrap
     if: needs.bootstrap.outputs.ready == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check for deptrac.yaml (job self-enables when it lands)
         id: cfg
         run: echo "present=$([ -f deptrac.yaml ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         if: steps.cfg.outputs.present == 'true'
         with: { php-version: '8.3' }
       - if: steps.cfg.outputs.present == 'true'
@@ -164,11 +164,11 @@ jobs:
     needs: bootstrap
     if: needs.bootstrap.outputs.ready == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check for infection.json5 (job self-enables when it lands)
         id: cfg
         run: echo "present=$([ -f infection.json5 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         if: steps.cfg.outputs.present == 'true'
         with: { php-version: '8.3', coverage: pcov }
       - if: steps.cfg.outputs.present == 'true'
@@ -215,7 +215,7 @@ jobs:
           fi
       - name: Set up PHP
         if: steps.cfg.outputs.present == 'true'
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.3'   # spec NFR-06 benchmark methodology — not the build matrix
           coverage: none       # instrumentation would distort the measurements

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.toolchain == 'php-8.1' && '8.1' || matrix.toolchain == 'php-8.2' && '8.2' || '8.3' }}
           coverage: pcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Security
 
+- Every GitHub Actions `uses:` reference in `.github/workflows/` is now pinned to an immutable
+  commit SHA with a truthful version comment, per **ADR-0003**. Previously the same action was
+  pinned two ways in one file — SHA in the generated steps, floating tag (`@v7`, `@v2`) in the
+  quality jobs — so a re-pointed upstream tag could have changed what CI executes with no diff
+  here. Dependabot (already configured for the `github-actions` ecosystem) keeps the pins and
+  their comments current.
+
 ---
 
 ## Released versions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,7 +75,7 @@ The thinnest slice that compiles, tests, and ships under the full quality bar (R
       through to `'8.3'` — a rendering artifact of the profile setup steps being injected into a
       non-matrix job. Correct by hand (ADR-0003: this repo is never re-rendered) —
       route: standard / medium
-- [ ] 1.10 Decide and record the **CI action-pinning policy** as an ADR, then make
+- [x] 1.10 Decide and record the **CI action-pinning policy** as an ADR, then make
       `.github/workflows/*.yml` consistent with it. Today the same action is pinned two ways in
       one file: the template-generated steps use a commit SHA with a version comment
       (`actions/checkout@3d3c42e5… # v7.0.1`) while the manifest-authored quality jobs use a
@@ -84,7 +84,15 @@ The thinnest slice that compiles, tests, and ships under the full quality bar (R
       `shivammathur/setup-php@v2` stays deliberately tag-pinned and Dependabot-managed.
       Checked first (lesson L-0004): no ADR in this repo decides it — EADOS's own ADR-0009
       governs the factory, not this self-governing repository — so it is genuinely open, not a
-      re-discovered trade-off — route: standard / medium
+      re-discovered trade-off — route: frontier-reasoning / extra (adr, decision-heavy)
+      *(route corrected when the item was taken: it was filed as `standard / medium`, but an
+      item whose deliverable IS a decision is decision-heavy by definition — `os/routing`
+      resolves `label:adr` to frontier-reasoning/extra. Settled by ADR-0003.)*
+- [ ] 1.11 Gate the ADR-0003 pinning policy mechanically instead of by review: assert every
+      `uses:` in `.github/workflows/*.yml` matches `@[0-9a-f]{40} # <version>`, and that the
+      version comment resolves to that SHA upstream (lesson L-0011 — a label nobody resolves
+      lies for as long as nobody resolves it). Prove the check can fail before trusting it —
+      route: standard / medium
 
 ---
 

--- a/docs/adr/0003-pin-ci-actions-by-commit-sha.md
+++ b/docs/adr/0003-pin-ci-actions-by-commit-sha.md
@@ -1,0 +1,133 @@
+# ADR-0003: Pin CI actions by commit SHA
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as enterprise-architect
+- **Related:** ROADMAP item 1.10 · [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) ·
+  [`.github/workflows/release.yml`](../../.github/workflows/release.yml) ·
+  [`.github/dependabot.yml`](../../.github/dependabot.yml) · `AGENTS.md` §7, §10
+
+## Context
+
+Every GitHub Actions step named with `uses:` executes third-party code inside this
+repository's CI, with access to the workflow token and to whatever secrets the job is granted.
+The reference a step is pinned to therefore decides *what code runs*, and that reference can
+be either immutable or not:
+
+- **A git tag is mutable.** `@v2`, and equally `@v7.0.1`, are ordinary git refs that the
+  publishing repository can move at any time — including after a compromise of a maintainer
+  account. A moved tag changes what this project's CI executes, with no diff here and no
+  signal to anyone reviewing this repository. Verified while writing this ADR:
+  `shivammathur/setup-php@v2` currently resolves to `f3e473d1…`, which is also release
+  `2.37.2` — the *value is fine today*, and that is precisely the property nobody can rely on
+  tomorrow.
+- **A commit SHA is immutable.** It names one tree, permanently.
+
+This repository arrived at a **mixed and undecided** state, which is what forced the decision.
+Steps generated from the EADOS templates were SHA-pinned with a version comment
+(`actions/checkout@3d3c42e5… # v7.0.1`), while the quality jobs authored later through the
+project manifest used floating tags (`actions/checkout@v7`) — the same action pinned two
+different ways in one file, with no recorded rationale for either.
+
+Two constraints shape the choice:
+
+1. **Governance posture.** `governance.posture: enterprise` (manifest, ADR-0015 upstream):
+   a security-relevant decision — and a supply-chain execution boundary is one — carries an
+   ADR rather than being an undocumented judgment call (`AGENTS.md` §7, §10).
+2. **The obvious objection is already answered.** SHA pins are said to freeze projects on
+   stale, unpatched actions. Dependabot is already configured here for the `github-actions`
+   ecosystem (weekly, grouped, `ci` prefix) and it updates SHA pins *and* rewrites their
+   version comments — it opened PR #4 against this repository on day one. The maintenance
+   cost the objection assumes is already automated away.
+
+Prior art was checked before treating this as an open question (per the upstream lessons
+ledger, `L-0004`: a re-discovered trade-off is an addendum, not a new decision). EADOS's own
+ADR-0009 decides pinning **for the factory**, and its §3 addendum deliberately leaves
+profile-supplied actions tag-pinned there. That decision does not reach this repository:
+ADR-0003 upstream makes a generated project self-governing, and no ADR here had decided the
+question. It is genuinely open, so it is decided here.
+
+## Decision
+
+**Every `uses:` reference in this repository's workflows is pinned to a full 40-character
+commit SHA, followed by a comment naming the human-readable version that SHA corresponds to.**
+The policy admits no exceptions by publisher: GitHub-owned actions (`actions/*`) and
+community actions (`shivammathur/*`, `softprops/*`) are pinned identically, because the
+execution privilege they receive is identical.
+
+```yaml
+- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+```
+
+Two rules govern the comment, which exists to make the pin reviewable:
+
+1. **It must be true.** The comment is a claim about the SHA, and a claim nobody resolves lies
+   for exactly as long as nobody resolves it. When a pin is introduced or changed by hand, the
+   SHA is resolved from the **upstream repository** (`gh api repos/<owner>/<repo>/git/ref/tags/<tag>`,
+   dereferencing annotated tags), never copied from another file in this repository that
+   happens to look canonical.
+2. **Dependabot owns the routine updates.** The `github-actions` ecosystem entry in
+   `.github/dependabot.yml` keeps both halves current; a Dependabot PR is the normal way a pin
+   moves, and it is reviewed like any other change.
+
+## Alternatives Considered
+
+- **Floating major tags (`@v2`, `@v7`)** — what the quality jobs used. Rejected: the reference
+  is mutable, so what CI executes can change without any diff in this repository. It is the
+  convenience option, and the convenience it buys — automatic patch uptake — is exactly what
+  Dependabot already provides against SHA pins, without handing the publisher a live channel
+  into this project's CI.
+- **Exact version tags (`@v7.0.1`)** — the intuitive middle ground, and the one worth naming
+  explicitly because it *looks* immutable and is not. A version tag is still an ordinary git
+  ref that the publishing repository can force-push. It narrows the window compared to `@v2`
+  but does not close it, while giving up the property that made SHA pinning worth adopting.
+- **Keep the mixed state, decide per action** (e.g. SHA-pin `actions/*`, trust community
+  actions on tags) — rejected on two grounds. It inverts the risk: a community action is the
+  *more* exposed dependency, not the less. And an unstated per-action rule is not reviewable —
+  the next contributor cannot tell a deliberate exception from an oversight, which is the
+  state this ADR exists to end.
+- **Vendor the actions into this repository** — maximal control, rejected as
+  disproportionate: it transfers the full maintenance and security-patching burden of every
+  action onto this project to close a gap that an immutable reference plus Dependabot already
+  closes.
+
+## Consequences
+
+**What this makes easier**
+
+- What CI executes is now determined entirely by content committed here. A compromised or
+  re-pointed upstream tag cannot change it.
+- Every change to executed CI code appears as a reviewable diff, in a PR, like any other
+  dependency change.
+- The policy is uniform, so a reviewer needs no per-action knowledge: any `uses:` without a
+  40-character SHA is a policy violation on sight.
+
+**What this costs**
+
+- Adding an action by hand now requires one API call to resolve its SHA, rather than typing a
+  tag. The commands are in this ADR and in `docs/workflow/github-setup.md`.
+- Dependabot PRs become slightly noisier to read (a SHA diff rather than `v7` → `v8`) — the
+  version comment is what keeps them legible, which is why its truthfulness is a rule above
+  and not a convention.
+- The policy is currently enforced by **review, not by a gate**. `tools/consistency_lint.py`
+  checks cross-artifact congruence and does not inspect workflow files. Stating this honestly
+  matters more than implying coverage that does not exist: a mechanical check
+  (assert every `uses:` matches `@[0-9a-f]{40} # .+`) is a natural follow-up, filed as roadmap
+  item **1.11** rather than left as an unwritten intention.
+
+**Risks and limits**
+
+- A SHA pin freezes *behavior*, not *trust*: it guarantees the same code runs, not that the
+  code was good. It defends against post-publication tampering, not against a malicious
+  release that was already malicious when pinned.
+- Dependabot updating a pin is still a supply-chain event. Its PRs are reviewed, not
+  auto-merged.
+
+## References
+
+- ROADMAP item 1.10 (this decision) and item 1.11 (the mechanical check it defers)
+- [GitHub — Security hardening for GitHub Actions: *use commit SHA*](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
+- [OpenSSF Scorecard — *Pinned-Dependencies* check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+- EADOS ADR-0009 (upstream, governs the factory) and the upstream lessons `L-0004`
+  (check the governing ADR before filing) and `L-0011` (gate a label's truth, resolve toward
+  the external source)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 |-----|-------|--------|
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
 | [0002](0002-adopt-cross-language-source-layout.md) | Adopt the cross-language source layout | Accepted |
+| [0003](0003-pin-ci-actions-by-commit-sha.md) | Pin CI actions by commit SHA | Accepted |

--- a/docs/journal/2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md
+++ b/docs/journal/2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md
@@ -167,12 +167,54 @@ runs for real, `lowest-deps` passes) — closing the open question from the last
 **Milestone 1 is complete**: every M1 item is checked except **1.10** (the action-pinning ADR,
 filed, deliberately open).
 
+## Item 1.10 — ADR-0003, the CI action-pinning policy
+
+The first ADR this project decided for itself (0001 and 0002 came seeded from the factory).
+
+**Route mismatch, recorded rather than quietly accepted.** The item was *filed* as
+`standard / medium` — wrong, and corrected in the roadmap when it was taken: `os/routing`
+resolves `label:adr` to **frontier-reasoning / extra**, because an item whose deliverable *is*
+a decision is decision-heavy by definition. `route_advice.py --check` confirmed the session
+model (`opus-5`, standard tier) sits below that route. Surfaced to the maintainer, who holds
+model authority (ADR-0017); work proceeded on their standing decision.
+
+**The decision:** every `uses:` in this repository's workflows is pinned to a 40-character
+commit SHA with a comment naming the version, no exceptions by publisher. The comment must be
+**true** — resolved from the upstream repository, never copied from another local file — and
+Dependabot (already configured for `github-actions`, and already exercised: PR #4) owns the
+routine updates.
+
+The argument that settled it is that **a version tag is not immutable either**. The intuitive
+middle ground `@v7.0.1` *looks* pinned and is an ordinary git ref the publisher can force-push;
+it narrows the window without closing it. Verified while writing the ADR:
+`shivammathur/setup-php@v2` resolves today to `f3e473d1…`, the same commit as release
+`2.37.2` — the value is fine *today*, which is exactly the property nobody can rely on
+tomorrow.
+
+**Applied and verified, in that order:**
+- 20 `uses:` references across both workflows now carry a SHA; a grep for any `@` reference not
+  matching `[0-9a-f]{40}` returns nothing.
+- Every version comment was then **re-resolved against the GitHub API** and compared to the SHA
+  actually written — all four distinct actions truthful. This is lesson **L-0011**'s rule
+  applied at the moment the pins were introduced, not deferred: a cross-file consistency check
+  cannot see an error applied uniformly, so the check has to resolve toward the external
+  source.
+- Both workflows re-parsed as YAML (9 jobs + 1) to confirm no structural regression from the
+  bulk edit.
+
+**Filed, not claimed:** the policy is enforced by **review, not by a gate** —
+`tools/consistency_lint.py` does not inspect workflow files. The ADR says so in its own
+*Consequences* rather than implying coverage that does not exist, and item **1.11** files the
+mechanical check.
+
 ## How the next session resumes
 
-1. **Item 1.10** — decide and record the CI action-pinning policy as an ADR, then reconcile
-   `.github/workflows/*.yml` with it.
-2. **Milestone 2 (`v0.2.0`) — Support layer**: the exception hierarchy, `Str`, `File`, `Env`,
-   `Json`, and the shared reflection-metadata cache. First items with actual behavior; T-05
-   property tests land alongside.
+1. **Milestone 2 (`v0.2.0`) — Support layer**: the exception hierarchy, `Str`, `File`, `Env`,
+   `Json`, and the shared reflection-metadata cache. The first items with actual behavior to
+   write; T-05 property tests land alongside them.
+2. **Item 1.11** — the mechanical gate for ADR-0003, whenever it is convenient; small, and it
+   turns a review-time rule into a checked one.
 3. **One-time admin** — [`docs/workflow/github-setup.md`](../../workflow/github-setup.md):
-   branch protection on `master`, squash-only, label import from `.github/labels.yml`.
+   branch protection on `master`, squash-only, label import from `.github/labels.yml`. The
+   label import matters more now: every PR in this milestone has carried `enhancement` as a
+   stand-in because the repo's own type labels (`build`, `test`, `ci`, `docs`) do not exist yet.


### PR DESCRIPTION
## Context

Roadmap item **1.10**, filed on PR #8 — the last open Milestone 1 item, and the first ADR this
project decides for itself (0001 and 0002 came seeded from the factory).

The repository held a **mixed, undecided** state: steps generated from the EADOS templates were
SHA-pinned with a version comment (`actions/checkout@3d3c42e5… # v7.0.1`), while the quality
jobs authored later through the manifest used floating tags (`actions/checkout@v7`,
`shivammathur/setup-php@v2`) — the same action pinned two different ways in one file, neither
with a recorded rationale. Under the enterprise posture, a supply-chain execution boundary is a
security-relevant decision and carries an ADR (`AGENTS.md` §7).

## Change

**[ADR-0003 — Pin CI actions by commit SHA](docs/adr/0003-pin-ci-actions-by-commit-sha.md)**:
every `uses:` reference is pinned to a 40-character commit SHA followed by a comment naming the
version. **No exceptions by publisher** — a community action receives the same CI privilege as
a GitHub-owned one, so it is pinned identically. Two rules govern the comment: it must be
**true** (resolved from the upstream repository, never copied from another local file), and
Dependabot — already configured for the `github-actions` ecosystem, and already exercised by
PR #4 — owns routine updates.

**What settled it: a version tag is not immutable either.** The intuitive middle ground
`@v7.0.1` *looks* pinned and is an ordinary git ref the publisher can force-push; it narrows
the window without closing it. Verified while writing the ADR: `shivammathur/setup-php@v2`
resolves today to `f3e473d1…`, the same commit as release `2.37.2` — the value is fine
*today*, which is exactly the property nobody can rely on tomorrow.

Applied across `ci.yml` and `release.yml`: **20 `uses:` references**, 4 distinct actions.

## Verification

- **Policy holds**: a grep for any `@` reference not matching `[0-9a-f]{40}` returns nothing.
- **Every comment is truthful**: each version comment was re-resolved against the GitHub API
  (`gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, dereferencing annotated tags) and compared
  to the SHA actually written — all four actions confirmed. This is lesson **L-0011** applied at
  the moment the pins were introduced rather than deferred: a cross-file consistency check
  *cannot* see an error applied uniformly, so the check has to resolve toward the external
  source. It also confirmed the three pre-existing template pins were already truthful.
- Both workflows re-parsed as YAML (9 jobs + 1) — no structural regression from the bulk edit.
- `python tools/consistency_lint.py` → **OK** (its `adr-index` check covers the new ADR's index
  row and sequential numbering).

## Stated, not implied

The policy is enforced by **review, not by a gate** — `tools/consistency_lint.py` checks
cross-artifact congruence and does not inspect workflow files. The ADR says so in its own
*Consequences* rather than implying coverage that does not exist, and files item **1.11** for
the mechanical check (assert the pin shape *and* that the comment resolves upstream).

## Route correction

The item was **filed** as `route: standard / medium` — wrong, and corrected in the roadmap when
it was taken. `os/routing` resolves `label:adr` to **frontier-reasoning / extra**, because an
item whose deliverable *is* a decision is decision-heavy by definition.
`route_advice.py --check` confirmed the session model (`opus-5`, standard tier) sits below that
route; surfaced to the maintainer, who holds model authority (ADR-0017), and proceeded on their
standing decision.

**Cross-links:** RFC-0001 · ADR-0003 · roadmap item 1.10 (done), 1.11 (filed) · milestone
`v0.1.0` — **Milestone 1 now fully complete**. Type label: `docs` (declared in
`.github/labels.yml`, still not imported); `documentation` set as the closest available default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
