### PR TITLE
ci(ci): gate the ADR-0003 action-pinning policy mechanically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
     name: consistency / lint
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    # The action-pin step resolves each version comment against its upstream repository, so it
+    # needs the API. GITHUB_TOKEN is read-only here (`permissions: contents: read` above) and
+    # only lifts the unauthenticated rate limit.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -98,6 +101,13 @@ jobs:
           python-version: '3.12'
       - name: Run the consistency lint
         run: python tools/consistency_lint.py
+      # ADR-0003's gate. Runs WITH --verify-upstream: the offline half only checks the pin
+      # shape, and a version comment that lies is invisible to any purely local check when the
+      # error is applied uniformly. CI is where the truthful half must run.
+      - name: Enforce the CI action-pinning policy (ADR-0003)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python tools/action_pin_lint.py --verify-upstream
 
   # ---------------------------------------------------------------------------
   # Language-specific quality jobs (format, lint, sanitizers, …) from the profile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ decisions, stricter review, and a maintained compliance-docs surface. The raised
 │   ├── workflow/                   # git, documentation, release & maintenance conventions
 │   ├── journal/                    # dated session checkpoints
 │   └── bugs/                       # in-repo bug ledger
-├── tools/consistency_lint.py       # agent-runnable cross-artifact congruence checker
+├── tools/
+│   ├── consistency_lint.py         # agent-runnable cross-artifact congruence checker
+│   └── action_pin_lint.py          # ADR-0003 gate: CI actions pinned by SHA, comments truthful
 └── .github/                        # CI + release workflows, PR/issue templates, CODEOWNERS, Dependabot
 ```
 
@@ -196,6 +198,18 @@ It asserts cross-artifact congruence (version lockstep, ADR index ↔ files, cat
 patterns backed by an ADR + code, spec coverage map, README ↔ ROADMAP milestone agreement,
 bug-ledger integrity). CI re-runs it; running locally first avoids a red round-trip.
 
+**Pre-PR action-pin check** — required whenever the PR touches `.github/workflows/`:
+
+```bash
+python tools/action_pin_lint.py                    # pin shape, offline
+python tools/action_pin_lint.py --verify-upstream  # + comment truth (network; CI runs this)
+```
+
+It enforces [ADR-0003](docs/adr/0003-pin-ci-actions-by-commit-sha.md). The offline run checks
+only that each `uses:` names a 40-hex SHA with a version comment; whether that comment is
+*true* can only be settled against the upstream repository, and the tool says so in its own
+output rather than letting the cheap half stand in for the whole.
+
 ## 7. Documentation Maintenance
 
 Documentation is part of the deliverable. Every PR ships its own doc updates.
@@ -274,6 +288,7 @@ Every PR must clear, at minimum:
 | Performance claims | backed by a reproducible benchmark under `src/bench/` |
 | Versioning | SemVer; `CHANGELOG.md` updated for user-visible changes |
 | Congruence | `python tools/consistency_lint.py` passes |
+| CI action pinning | `python tools/action_pin_lint.py` passes; CI runs it with `--verify-upstream` (ADR-0003) |
 | Review (enterprise) | **two** approving reviews before merge; a security-relevant change also requires the `security-auditor`'s sign-off |
 | Security ADR (enterprise) | every security-relevant decision carries an ADR (§7) — no undocumented judgment calls |
 | Compliance (enterprise) | `docs/compliance/` control register current; a touched control's row updated in the same PR |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   quality jobs — so a re-pointed upstream tag could have changed what CI executes with no diff
   here. Dependabot (already configured for the `github-actions` ecosystem) keeps the pins and
   their comments current.
+- `tools/action_pin_lint.py` enforces ADR-0003 mechanically in CI: `pin-shape` offline, and
+  `pin-label-truth` resolving every version comment against its upstream repository — the half
+  no purely local check can perform, since a comment that lies uniformly leaves nothing for a
+  cross-file comparison to disagree with.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ The thinnest slice that compiles, tests, and ships under the full quality bar (R
       *(route corrected when the item was taken: it was filed as `standard / medium`, but an
       item whose deliverable IS a decision is decision-heavy by definition — `os/routing`
       resolves `label:adr` to frontier-reasoning/extra. Settled by ADR-0003.)*
-- [ ] 1.11 Gate the ADR-0003 pinning policy mechanically instead of by review: assert every
+- [x] 1.11 Gate the ADR-0003 pinning policy mechanically instead of by review: assert every
       `uses:` in `.github/workflows/*.yml` matches `@[0-9a-f]{40} # <version>`, and that the
       version comment resolves to that SHA upstream (lesson L-0011 — a label nobody resolves
       lies for as long as nobody resolves it). Prove the check can fail before trusting it —

--- a/docs/adr/0003-pin-ci-actions-by-commit-sha.md
+++ b/docs/adr/0003-pin-ci-actions-by-commit-sha.md
@@ -109,11 +109,18 @@ Two rules govern the comment, which exists to make the pin reviewable:
 - Dependabot PRs become slightly noisier to read (a SHA diff rather than `v7` → `v8`) — the
   version comment is what keeps them legible, which is why its truthfulness is a rule above
   and not a convention.
-- The policy is currently enforced by **review, not by a gate**. `tools/consistency_lint.py`
-  checks cross-artifact congruence and does not inspect workflow files. Stating this honestly
-  matters more than implying coverage that does not exist: a mechanical check
-  (assert every `uses:` matches `@[0-9a-f]{40} # .+`) is a natural follow-up, filed as roadmap
-  item **1.11** rather than left as an unwritten intention.
+- The policy is enforced **mechanically**, by
+  [`tools/action_pin_lint.py`](../../tools/action_pin_lint.py) (roadmap item 1.11, landed
+  immediately after this ADR). It runs in the `consistency / lint` CI job and splits into two
+  checks with deliberately different reach: `pin-shape` is offline and always runs;
+  `pin-label-truth` resolves every version comment against its upstream repository and runs
+  only with `--verify-upstream`, which CI passes. A run without it says, in its own output,
+  that comment truthfulness went unverified — partial verification presented as complete would
+  be a dishonest gate.
+
+  *(When this ADR was accepted the policy was enforced by review only, and this section said
+  so rather than implying coverage that did not exist. Item 1.11 closed that gap in the
+  following PR; the paragraph is updated rather than rewritten to hide the interval.)*
 
 **Risks and limits**
 
@@ -125,7 +132,8 @@ Two rules govern the comment, which exists to make the pin reviewable:
 
 ## References
 
-- ROADMAP item 1.10 (this decision) and item 1.11 (the mechanical check it defers)
+- ROADMAP item 1.10 (this decision) and item 1.11 (the mechanical check that now enforces it,
+  [`tools/action_pin_lint.py`](../../tools/action_pin_lint.py))
 - [GitHub — Security hardening for GitHub Actions: *use commit SHA*](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
 - [OpenSSF Scorecard — *Pinned-Dependencies* check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
 - EADOS ADR-0009 (upstream, governs the factory) and the upstream lessons `L-0004`

--- a/docs/journal/2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md
+++ b/docs/journal/2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md
@@ -207,14 +207,50 @@ tomorrow.
 *Consequences* rather than implying coverage that does not exist, and item **1.11** files the
 mechanical check.
 
+## Item 1.11 — the gate for ADR-0003, and what it can honestly observe
+
+`tools/action_pin_lint.py`, stdlib-only, wired into the `consistency / lint` CI job. Kept as
+its own tool rather than folded into `consistency_lint.py`: that file is generated from the
+EADOS templates and is about cross-artifact congruence, while this is a supply-chain policy
+check with an entirely different failure mode.
+
+The design point worth recording is **the split in observability**:
+
+- `pin-shape` is **offline and always runs** — every `uses:` names a 40-hex SHA and carries a
+  version comment. Pure text.
+- `pin-label-truth` **needs the network** and runs only with `--verify-upstream` (which CI
+  passes) — it resolves each version comment against its own upstream repository.
+
+These are not interchangeable, and the tool never lets the cheap half stand in for the whole:
+a run without `--verify-upstream` prints, in its own output, that comment truthfulness went
+unverified. That is lesson **L-0006**'s rule — *a checkpoint that can observe only part of what
+it governs must state the unobservable part in its own output* — applied at design time rather
+than discovered later.
+
+**Proved it can fail before trusting it,** three ways, each restored afterwards with
+`git checkout --` and the tree confirmed clean:
+
+1. A mutable tag in place of a SHA → `pin-shape` fails, naming the action and the reason.
+2. A SHA with its version comment removed → `pin-shape` fails.
+3. **A comment that lies, applied uniformly** — every `# v7.0.1` rewritten to `# v7.0.0` while
+   the SHAs stayed correct. The offline run **passes** (the shape genuinely is fine) and says
+   it did not check truthfulness; the `--verify-upstream` run catches all nine occurrences and
+   prints the SHA the claimed version actually resolves to upstream. This is exactly lesson
+   **L-0011**'s scenario — *a cross-file consistency check cannot see an error applied
+   consistently* — reproduced on demand, which is what makes the assertion non-vacuous rather
+   than merely green.
+
+ADR-0003's *Consequences* section was updated in the same PR: it had said the policy was
+enforced by review rather than by a gate, and that is no longer true. The paragraph records
+that the gap existed and was closed, rather than being rewritten to hide the interval.
+
 ## How the next session resumes
 
 1. **Milestone 2 (`v0.2.0`) — Support layer**: the exception hierarchy, `Str`, `File`, `Env`,
    `Json`, and the shared reflection-metadata cache. The first items with actual behavior to
    write; T-05 property tests land alongside them.
-2. **Item 1.11** — the mechanical gate for ADR-0003, whenever it is convenient; small, and it
-   turns a review-time rule into a checked one.
-3. **One-time admin** — [`docs/workflow/github-setup.md`](../../workflow/github-setup.md):
+2. **One-time admin** — [`docs/workflow/github-setup.md`](../../workflow/github-setup.md):
    branch protection on `master`, squash-only, label import from `.github/labels.yml`. The
-   label import matters more now: every PR in this milestone has carried `enhancement` as a
-   stand-in because the repo's own type labels (`build`, `test`, `ci`, `docs`) do not exist yet.
+   label import matters more now: every PR in this milestone has carried `enhancement` or
+   `documentation` as a stand-in because the repo's own type labels (`build`, `test`, `ci`,
+   `docs`) do not exist yet.

--- a/tools/action_pin_lint.py
+++ b/tools/action_pin_lint.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Daniel Polo
+"""Action-pin lint for egl-util-php — the mechanical gate for ADR-0003.
+
+ADR-0003 decides that every GitHub Actions `uses:` reference in this repository is pinned to
+an immutable 40-character commit SHA, followed by a comment naming the version that SHA
+corresponds to. Until this tool existed the policy was enforced by review only, which the ADR
+said plainly rather than implying coverage it did not have. This is that coverage.
+
+Two checks, with deliberately different observability:
+
+  1. pin-shape      — OFFLINE, always runs. Every `uses:` reference names a 40-hex SHA and
+                      carries a version comment. Pure text; no network, no dependencies.
+  2. pin-label-truth — NETWORK, runs only with --verify-upstream. Resolves each version
+                      comment against the UPSTREAM repository and compares it to the SHA
+                      actually written. This is the half that matters most and the half that
+                      cannot be done from local files: a cross-file consistency check cannot
+                      see an error applied uniformly, and a comment nobody resolves lies for
+                      exactly as long as nobody resolves it.
+
+**The two are not interchangeable, and this tool never lets one stand in for the other.**
+A run without --verify-upstream reports, in its own output, that the truth of every version
+comment went unverified. Partial verification presented as complete is a dishonest gate.
+
+Usage:
+
+    python tools/action_pin_lint.py                    # shape only (offline)
+    python tools/action_pin_lint.py --verify-upstream  # shape + comment truth (network)
+
+Exits non-zero with an actionable report on any violation.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOW_DIR = os.path.join(ROOT, ".github", "workflows")
+
+# `uses:` values that legitimately carry no SHA, because they are not a pinnable third-party
+# ref: a path-relative composite action lives in this repository (already reviewed as source),
+# and a docker:// image is pinned by its own digest syntax. Recognised EXPLICITLY and reported,
+# never skipped in silence — a silent exemption is how a real hole hides in a green gate.
+_EXEMPT_PREFIXES = ("./", "../", "docker://")
+
+# `- uses: owner/repo@ref  # comment` — the comment is optional at the parse level so that a
+# pin missing its comment is reported as a violation rather than not matching at all.
+_USES = re.compile(r"^\s*-?\s*uses:\s*(?P<ref>\S+)\s*(?:#\s*(?P<comment>.+?))?\s*$")
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+_API = "https://api.github.com"
+
+
+class Finding:
+    def __init__(self, check, path, line, message):
+        self.check = check
+        self.path = path
+        self.line = line
+        self.message = message
+
+    def __str__(self):
+        return f"  [{self.check}] {self.path}:{self.line} — {self.message}"
+
+
+def workflow_files():
+    if not os.path.isdir(WORKFLOW_DIR):
+        return []
+    out = []
+    for name in sorted(os.listdir(WORKFLOW_DIR)):
+        if name.endswith((".yml", ".yaml")):
+            out.append(os.path.join(WORKFLOW_DIR, name))
+    return out
+
+
+def collect_uses(path):
+    """Every `uses:` reference in one workflow, as (line_no, ref, comment)."""
+    rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+    found = []
+    with open(path, encoding="utf-8") as fh:
+        for n, line in enumerate(fh, start=1):
+            m = _USES.match(line.rstrip("\n"))
+            if m:
+                found.append((rel, n, m.group("ref"), m.group("comment")))
+    return found
+
+
+def check_shape(entries):
+    """ADR-0003's pin shape: <action>@<40-hex> plus a version comment. Offline."""
+    findings, pins, exempt = [], [], []
+    for rel, line, ref, comment in entries:
+        if ref.startswith(_EXEMPT_PREFIXES):
+            exempt.append((rel, line, ref))
+            continue
+        if "@" not in ref:
+            findings.append(Finding("pin-shape", rel, line,
+                                    f"`{ref}` names no ref at all — ADR-0003 requires "
+                                    "`owner/repo@<40-hex sha>`"))
+            continue
+        action, _, pinned = ref.rpartition("@")
+        if not _SHA.match(pinned):
+            findings.append(Finding("pin-shape", rel, line,
+                                    f"`{action}` is pinned to `{pinned}`, which is a mutable "
+                                    "git ref — ADR-0003 requires a 40-character commit SHA "
+                                    "(a version tag is force-pushable and is NOT immutable)"))
+            continue
+        if not comment:
+            findings.append(Finding("pin-shape", rel, line,
+                                    f"`{action}` is SHA-pinned but carries no version comment "
+                                    "— ADR-0003 requires `# <version>` so the pin is reviewable"))
+            continue
+        pins.append((rel, line, action, pinned, comment.strip()))
+    return findings, pins, exempt
+
+
+def _api(url, token):
+    req = urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "egl-util-php-action-pin-lint",
+    })
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def resolve_tag(action, tag, token):
+    """The commit SHA a tag names upstream, dereferencing annotated tags.
+
+    Returns (sha, None) or (None, reason). The reason is surfaced as a finding rather than
+    swallowed: an unresolvable comment is exactly as unreviewable as a wrong one.
+    """
+    try:
+        ref = _api(f"{_API}/repos/{action}/git/ref/tags/{tag}", token)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None, f"upstream has no tag `{tag}`"
+        return None, f"upstream lookup failed ({exc.code} {exc.reason})"
+    except urllib.error.URLError as exc:
+        return None, f"upstream unreachable ({exc.reason})"
+
+    obj = ref.get("object", {})
+    sha, kind = obj.get("sha"), obj.get("type")
+    if kind == "tag":  # annotated tag -> dereference to the commit
+        try:
+            sha = _api(f"{_API}/repos/{action}/git/tags/{sha}", token)["object"]["sha"]
+        except (urllib.error.HTTPError, urllib.error.URLError, KeyError) as exc:
+            return None, f"annotated tag `{tag}` could not be dereferenced ({exc})"
+    return sha, None
+
+
+def check_label_truth(pins, token):
+    """Does each version comment actually name the pinned SHA, upstream? Network."""
+    findings = []
+    resolved = {}
+    for rel, line, action, sha, comment in pins:
+        tag = comment.split()[0] if comment else ""
+        key = (action, tag)
+        if key not in resolved:
+            resolved[key] = resolve_tag(action, tag, token)
+        upstream, reason = resolved[key]
+        if reason:
+            findings.append(Finding("pin-label-truth", rel, line,
+                                    f"`{action}` comment `{tag}`: {reason}"))
+        elif upstream != sha:
+            findings.append(Finding("pin-label-truth", rel, line,
+                                    f"`{action}` is pinned to {sha} but its comment claims "
+                                    f"`{tag}`, which upstream resolves to {upstream} — the "
+                                    "comment is untrue; resolve toward upstream, never toward "
+                                    "another local file"))
+    return findings, len(resolved)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Enforce ADR-0003's CI action-pinning policy.")
+    ap.add_argument("--verify-upstream", action="store_true",
+                    help="also resolve each version comment against the upstream repository "
+                         "(requires network; uses GITHUB_TOKEN when set)")
+    args = ap.parse_args(argv)
+
+    files = workflow_files()
+    if not files:
+        print("action-pin lint: no workflow files under .github/workflows/ — nothing to check.")
+        return 0
+
+    entries = [e for f in files for e in collect_uses(f)]
+    findings, pins, exempt = check_shape(entries)
+
+    upstream_checked = 0
+    if args.verify_upstream and pins:
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        truth_findings, upstream_checked = check_label_truth(pins, token)
+        findings += truth_findings
+
+    if findings:
+        print("action-pin lint: FAIL\n")
+        for f in findings:
+            print(f)
+        print(f"\n{len(findings)} ADR-0003 violation(s) found.")
+    else:
+        print(f"action-pin lint: OK — {len(pins)} pinned reference(s) across "
+              f"{len(files)} workflow(s) satisfy ADR-0003's pin shape.")
+
+    # Honesty about reach (upstream truth is the half that cannot be observed offline).
+    # A gate that reports only what it managed to check, without naming what it did not,
+    # reads as complete coverage and is not.
+    if args.verify_upstream:
+        print(f"  verified upstream: {upstream_checked} distinct action/version pair(s) — "
+              "each comment resolved against its own repository.")
+    else:
+        print("  NOT verified: whether each version comment truly names its pinned SHA. That "
+              "check resolves against the upstream repositories and needs network — re-run "
+              "with --verify-upstream (CI does).")
+    if exempt:
+        print(f"  exempt (local or docker refs, not pinnable third-party actions): {len(exempt)}")
+        for rel, line, ref in exempt:
+            print(f"    - {rel}:{line} {ref}")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

Roadmap item **1.11**, filed on PR #10. [ADR-0003](docs/adr/0003-pin-ci-actions-by-commit-sha.md)
stated plainly in its own *Consequences* that its policy was enforced **by review, not by a
gate** — rather than implying coverage that did not exist. This closes that gap.

## Change

**[`tools/action_pin_lint.py`](tools/action_pin_lint.py)** — stdlib-only, wired into the
`consistency / lint` CI job (which already runs Python and does not depend on the bootstrap
guard). Kept as its own tool rather than folded into `consistency_lint.py`: that file is
generated from the EADOS templates and covers cross-artifact congruence, while this is a
supply-chain policy check with a different failure mode.

**The design point is the split in observability:**

| Check | Reach | When |
|---|---|---|
| `pin-shape` | offline, pure text | always |
| `pin-label-truth` | resolves each version comment against **its own upstream repository** | only with `--verify-upstream` — which CI passes |

The two are **not interchangeable, and the tool never lets the cheap half stand in for the
whole**: a run without `--verify-upstream` prints, in its own output, that comment truthfulness
went unverified. That is lesson **L-0006**'s rule — *a checkpoint that can observe only part of
what it governs must state the unobservable part in its own output* — applied at design time
rather than discovered later.

Local composite actions (`./…`) and `docker://` images are recognised as **explicitly exempt
and reported**, never skipped in silence — a silent exemption is how a real hole hides inside a
green gate. (None exist today; the check is written to be correct, not merely convenient.)

`AGENTS.md` updated: repo layout, the quality-bar table, and a pre-PR section saying when each
half is required. ADR-0003's *Consequences* now describes the gate — the paragraph records that
the interval existed and was closed, rather than being rewritten to hide it.

## Verification — proved it can fail before trusting it

The item required this explicitly. Three failure modes, each perturbation reverted with
`git checkout --` and the tree confirmed clean afterwards:

1. **A mutable tag in place of a SHA** → `pin-shape` fails, naming the action and why (*"a
   version tag is force-pushable and is NOT immutable"*).
2. **A SHA with its version comment removed** → `pin-shape` fails.
3. **A comment that lies, applied uniformly** — every `# v7.0.1` rewritten to `# v7.0.0` with
   the SHAs left correct. The offline run **passes** (the shape genuinely *is* fine) **and says
   it did not check truthfulness**; the `--verify-upstream` run catches all nine occurrences
   and prints the SHA the claimed version actually resolves to upstream
   (`9c091bb2…` ≠ the pinned `3d3c42e5…`).

Case 3 is the one that matters: it is lesson **L-0011**'s scenario reproduced on demand — *a
cross-file consistency check cannot see an error applied consistently* — and it is what makes
the assertion non-vacuous rather than merely green.

On the restored tree, both gates pass:
- `python tools/consistency_lint.py` → **OK**
- `python tools/action_pin_lint.py --verify-upstream` → **OK — 20 pinned references across 2
  workflows; 4 distinct action/version pairs verified upstream**
- `ci.yml` re-parsed as YAML (9 jobs) after the wiring edit

## Note on the CI step

The new step passes `GITHUB_TOKEN: ${{ github.token }}` purely to lift the unauthenticated API
rate limit; the workflow's `permissions:` block is `contents: read`, so the token is read-only.

**Cross-links:** RFC-0001 · ADR-0003 · roadmap item 1.11 · milestone `v0.1.0` — Milestone 1
remains fully complete, now with its last policy mechanically enforced. Type label: `ci`
(declared in `.github/labels.yml`, still not imported); `enhancement` set as the closest
available default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
