### PR TITLE
feat(support): add the exception hierarchy rooted on an interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- Exception hierarchy under `D4np\Utils\Support\` (**ADR-0004**): the `UtilsThrowable`
+  interface every exception implements — `catch (UtilsThrowable $e)` catches anything this
+  library raises — over `UtilsException extends \RuntimeException`, with
+  `DatabaseException`, `HttpException`, `FileException`, `JsonException` (wrapping PHP's native
+  one via `wrap()`, original preserved as `getPrevious()`), and `HydrationException` carrying
+  the failing property path, with `UnknownKeyException`, `MissingKeyException` and
+  `TypeMismatchException` under it. Concrete leaves are `final`; `UtilsException` and
+  `HydrationException` are the documented extension points.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-03 — EADOS pipeline run and the Composer build system](docs/journal/2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md).
+  [2026-08-03 — Milestone 2 opens: the exception hierarchy](docs/journal/2026/08/2026-08-03-m2-exception-hierarchy.md).
 
 ## Model & effort routing (advisory)
 
@@ -100,9 +100,9 @@ The thinnest slice that compiles, tests, and ships under the full quality bar (R
 
 The foundation every group depends on — the deptrac-legal bottom layer (RFC-0001).
 
-- [ ] 2.1 Exception hierarchy: `UtilsException` root + Database/Hydration/Http/File/Json
+- [x] 2.1 Exception hierarchy: `UtilsException` root + Database/Hydration/Http/File/Json
       children, incl. `MissingKeyException` (RFC-0001) (sets-pattern) —
-      route: frontier-reasoning / high
+      route: frontier-reasoning / high · **ADR-0004**
 - [ ] 2.2 `Str`: `slug()` with ext-intl transliteration fallback, `uuid()` v4, `random()`
       CSPRNG (RFC-0001) — route: fast / low
 - [ ] 2.3 `File`: flock-guarded `write()`/`read()`, atomic write via temp+rename, Fileinfo
@@ -114,6 +114,14 @@ The foundation every group depends on — the deptrac-legal bottom layer (RFC-00
       (RFC-0001 R-2) (sets-pattern) — route: frontier-reasoning / high
 - [ ] 2.6 T-05 property tests: Json round-trips, slug idempotence, Env coercion table
       (RFC-0001) — route: fast / low
+- [ ] 2.7 Measure and enforce the coverage floor. `AGENTS.md` §10 and spec NFR-07 both state
+      **≥ 90% line coverage**, and nothing checks it: the `build` job sets up `pcov` but runs
+      `vendor/bin/phpunit` with no `--coverage` flag and no threshold, so the number is neither
+      produced nor compared. PHPUnit 10 has no fail-under option, so this needs a clover report
+      plus a threshold check. Found while writing item 2.1, which could not verify its own
+      coverage claim locally (no driver) *or* in CI (no gate) — the same
+      stated-but-ungated shape as items 1.10/1.11. Prove the gate can fail —
+      route: standard / medium
 
 ---
 
@@ -212,11 +220,11 @@ Legend: ⏳ not started · 🚧 in progress · ✅ done · ❎ N/A.
 | Spec § | Requirement | Roadmap items | Status |
 |--------|-------------|---------------|--------|
 | §1 | Objective & design philosophy | 1.1, 1.6 | ⏳ |
-| §2 | Functional items 1–25 (+9b) | 2.1–2.5, 3.1–3.3, 4.1–4.3, 5.1–5.3, 6.1–6.2, 6.4–6.5 | ⏳ |
+| §2 | Functional items 1–25 (+9b) | 2.1–2.5, 3.1–3.3, 4.1–4.3, 5.1–5.3, 6.1–6.2, 6.4–6.5 | 🚧 |
 | §3 | Architecture & layering (deptrac) | 1.1, 1.6, 2.1, 2.5 | ⏳ |
 | §4 | NFR budgets & benchmark methodology | 3.5, 4.5, 5.5, 6.4, 7.1 | ⏳ |
 | §5 | Security test criteria | 4.4, 5.4, 5.5, 6.3 | ⏳ |
 | §6 | API example / public interface | 1.6, 3.1 | ⏳ |
 | §7 | Verification & test strategy | 1.2, 2.6, 3.4, 4.4, 6.3 | ⏳ |
 | §8 | CI/CD & release engineering | 1.4, 1.7, 7.1–7.3 | ⏳ |
-| §9 | Decision log (imported + seeded ADRs) | 2.1, 5.3, 7.4 | ⏳ |
+| §9 | Decision log (imported + seeded ADRs) | 2.1, 5.3, 7.4 | 🚧 |

--- a/docs/adr/0004-root-the-exception-hierarchy-on-an-interface.md
+++ b/docs/adr/0004-root-the-exception-hierarchy-on-an-interface.md
@@ -1,0 +1,109 @@
+# ADR-0004: Root the exception hierarchy on an interface, and close its leaves
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 2.1 · [RFC-0001](../rfc/0001-egl-utils-library.md) (*API contract →
+  Error model*) · [spec §2 item 26](../specs/01_spec_utils.md) · `AGENTS.md` §8
+
+## Context
+
+RFC-0001 fixes *which* exceptions exist and *what nests under what*:
+
+```
+UtilsException ← DatabaseException, HttpException, FileException, JsonException,
+                 HydrationException ← UnknownKeyException, MissingKeyException,
+                                      TypeMismatchException
+```
+
+and pins that shape as a **MAJOR-version surface** — changing it breaks every consumer `catch`.
+
+What the RFC deliberately did not settle is the *mechanics*, and roadmap item 2.1 is flagged
+`sets-pattern`: it is the first of its class, so whatever shape it lands becomes the shape the
+five remaining component groups copy. Four questions had to be answered before writing the
+first class, and answering them by reflex would have been the expensive kind of cheap:
+
+1. Is the root a **class** or an **interface**? A class root is simpler and is what the RFC's
+   arrow notation literally implies. It also permanently forecloses one thing: an exception that
+   must extend some *other* base for interoperability — an SPL type a framework already catches,
+   or a PSR interface's required parent — cannot then also be part of this family.
+2. Which **SPL base** does the concrete root extend?
+3. Are the leaves **`final`**? Closing them protects the pinned shape; opening them lets
+   consumers specialise.
+4. Hydration failures must "name the path" (spec §2 item 1). `RuntimeException`'s constructor
+   offers `$message, $code, $previous` — and **no consumer of this library will ever branch on
+   an integer code**, while the path is the one fact that makes a nested-DTO failure
+   diagnosable.
+
+## Decision
+
+**The family is defined by an interface, `UtilsThrowable extends \Throwable`, which every
+exception this package raises implements.** `UtilsException extends \RuntimeException implements
+UtilsThrowable` is the concrete base and the one consumers normally extend; the interface is
+what `catch` clauses and downstream contracts should name.
+
+Alongside it:
+
+- **`\RuntimeException`, not `\Exception` or `\LogicException`.** Everything this package raises
+  is detected at run time from data it did not control — a malformed payload, a rejected
+  identifier, an unreadable file. None of it is a `LogicException`-class programming-contract
+  violation, and `\Exception` is too unspecific to carry meaning.
+- **Concrete leaves are `final`; `UtilsException` and `HydrationException` are not.** The two
+  non-final classes are the *documented* extension points. A subclass of a leaf would widen a
+  contract RFC-0001 committed not to widen without a MAJOR bump, so the leaves are closed and
+  the extension points are explicit rather than incidental.
+- **`HydrationException::__construct(string $message, string $path = '', ?Throwable $previous)`**
+  — `$path` occupies the position SPL gives `$code`, exposed through `path()`. PHP exempts
+  constructors from signature compatibility, so this is legal; it is recorded here because it is
+  a deliberate trade and not an oversight. `getCode()` still exists and returns `0`.
+- **The three hydration leaves carry static named constructors** (`UnknownKeyException::forKey()`,
+  `MissingKeyException::forKey()`, `TypeMismatchException::at()`) so the message and the path are
+  composed in one place instead of at every throw site.
+
+## Alternatives Considered
+
+- **A class root only, no interface** — what the RFC's notation literally suggests, and rejected
+  for the reason in Context 1: it is a one-way door. The cost of the interface is one file with
+  no body; the cost of not having it is discovered only when some exception must extend
+  elsewhere, at which point the "one thing to catch" contract is already broken for consumers.
+- **An interface root only, no concrete base** — maximally flexible, rejected: every leaf would
+  then re-declare the same `extends \RuntimeException implements UtilsThrowable`, and there would
+  be nowhere to put shared behaviour such as `HydrationException`'s path.
+- **`\Exception` as the SPL base** — rejected as unspecific; `RuntimeException` states the
+  category correctly and costs nothing.
+- **Leaves left extensible** — rejected: it silently widens a MAJOR-pinned surface. A consumer
+  who genuinely needs a new member of the family extends `UtilsException`, which is the point of
+  leaving *that* open.
+- **Keeping SPL's `$code` and passing the path some other way** (a setter, a `withPath()` clone,
+  a separate context array) — rejected: a setter makes an exception mutable after construction,
+  a clone-wither is ceremony for one string, and a context array gives up the type. The path is
+  not optional metadata; it is what the failure *is about*.
+
+## Consequences
+
+- **Consumers get one `catch` that means "this library failed"**: `catch (UtilsThrowable $e)`.
+  Nothing about that contract depends on the class hierarchy staying as it is today, which is
+  the durable property the interface buys.
+- **`JsonException` can shadow PHP's native `\JsonException` safely.** It extends
+  `UtilsException` (so it is catchable with everything else) and *wraps* the native one via
+  `JsonException::wrap()`, keeping the original as `getPrevious()`. RFC-0001 R-7's decision,
+  now mechanically expressible.
+- **The hierarchy's shape is asserted, not assumed.**
+  `src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php` discovers the exception classes
+  **from disk** and fails when one does not implement `UtilsThrowable`, when the member set
+  changes, or when a leaf stops being `final`. A member added later without joining the family
+  fails the suite instead of reaching a consumer's `catch` and being missed there.
+- **No patterns-catalogue row.** The static named constructors are the *named-constructor
+  idiom*, not GoF **Factory Method**, which is about deferring instantiation so a subclass
+  chooses the concrete type. `docs/patterns/design-patterns.md` lists only the latter, and
+  filing this under it to have something to file would be exactly the force-fit `AGENTS.md` §8
+  forbids. Recorded here so the omission is a decision rather than a gap.
+- **Cost:** one extra file (`UtilsThrowable.php`) with an empty body, and a small amount of
+  explaining — this ADR — that a bare class root would not have needed.
+
+## References
+
+- RFC-0001, *Decision → API contract → Error model* (the pinned hierarchy, R-4 and R-7)
+- [spec §2 item 26](../specs/01_spec_utils.md) — the hierarchy as a functional requirement
+- `AGENTS.md` §8 (patterns policy: justify or reject, never force-fit), §10 (quality bar)
+- PHP manual, *Predefined Exceptions* — `RuntimeException` vs `LogicException` semantics

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
 | [0002](0002-adopt-cross-language-source-layout.md) | Adopt the cross-language source layout | Accepted |
 | [0003](0003-pin-ci-actions-by-commit-sha.md) | Pin CI actions by commit SHA | Accepted |
+| [0004](0004-root-the-exception-hierarchy-on-an-interface.md) | Root the exception hierarchy on an interface, and close its leaves | Accepted |

--- a/docs/journal/2026/08/2026-08-03-m2-exception-hierarchy.md
+++ b/docs/journal/2026/08/2026-08-03-m2-exception-hierarchy.md
@@ -1,0 +1,90 @@
+# 2026-08-03 — Milestone 2 opens: the exception hierarchy
+
+First item of Milestone 2, and the first code in this repository with behaviour rather than
+configuration. Roadmap item **2.1**, flagged `sets-pattern`: it is the first of its class, so
+the shape it lands is the shape the five remaining component groups copy.
+
+## Route
+
+`os/routing` resolves `sets-pattern` to **frontier-reasoning / high**;
+`route_advice.py --check` reported the session model (`opus-5`, standard tier) below that route.
+Surfaced to the maintainer before starting — they hold model authority (ADR-0017) — and work
+proceeded on their standing decision.
+
+## What landed
+
+Ten files under `src/main/php/d4np/utils/Support/`, and **[ADR-0004](../../adr/0004-root-the-exception-hierarchy-on-an-interface.md)**
+for the four mechanics RFC-0001 deliberately left open:
+
+- **An interface root, `UtilsThrowable extends \Throwable`**, alongside the concrete
+  `UtilsException extends \RuntimeException`. The RFC's arrow notation literally implies a class
+  root; that is a one-way door. An exception that later must extend some other base for
+  interoperability can still join the family by implementing the interface, so the "one thing to
+  catch" contract survives a change no class hierarchy could absorb. The cost is one file with
+  an empty body.
+- **`RuntimeException`, not `Exception` or `LogicException`** — everything here is detected at
+  run time from data the library did not control.
+- **Leaves `final`, `UtilsException` and `HydrationException` open.** The hierarchy's shape is a
+  MAJOR surface (RFC-0001); a subclass of a leaf would widen it silently, so the extension points
+  are explicit instead of incidental.
+- **`HydrationException` takes `$path` where SPL takes `$code`.** No consumer will branch on an
+  integer code, while the path (`address.postcode`) is the one fact that makes a nested-DTO
+  failure diagnosable. PHP exempts constructors from signature compatibility; recorded in the
+  ADR because it is a trade, not an oversight.
+
+## The test that carries the weight
+
+`ExceptionHierarchyTest` discovers the exception classes **from disk**, not from a hand-written
+list, and asserts each implements `UtilsThrowable`. A member added later that forgets the
+contract fails here rather than reaching a consumer's `catch` block and being silently missed.
+Proved non-vacuous: planted a `RogueException extends \RuntimeException`, watched both the
+contract test and the pinned-set test fail with actionable messages naming the ADR, removed it,
+watched them pass. 14 tests, 61 assertions.
+
+The suite also pins the *negative* direction — a `catch (HydrationException)` must not swallow a
+database or HTTP failure — and derives that set from disk too, deliberately: a hard-coded list of
+class literals is something PHPStan can decide statically, which would make the assertion a
+tautology dressed as a test.
+
+## PHPStan max earned its keep
+
+Four findings, all in the test file, all fixed at the cause rather than silenced:
+
+1. `is_a()` over hard-coded literals — statically decidable, so the assertion proved nothing.
+   Rewritten to derive the class set at runtime.
+2. and 3. `forKey()` declares `class-string` and the test passed `'App\Dto\UserDto'`, which
+   resolves to no class. The production type is right (the hydrator passes `$target::class`); the
+   test now passes a real one.
+4. `assertNotInstanceOf(NativeJsonException::class, $wrapped)` — already-narrowed. Dropped, with
+   a comment recording why: PHPStan at max decides that disjointness statically for *every* call
+   site, permanently, which is a strictly stronger guarantee than one runtime assertion.
+
+## No patterns-catalogue row, on purpose
+
+The static named constructors (`UnknownKeyException::forKey()`, `TypeMismatchException::at()`)
+are the **named-constructor idiom**, not GoF **Factory Method** — which is about deferring
+instantiation so a subclass picks the concrete type. `docs/patterns/design-patterns.md` lists
+only the latter, and filing this under it to have something to file is exactly the force-fit
+`AGENTS.md` §8 forbids. Recorded in ADR-0004 so the empty catalogue is a decision, not a gap.
+
+## Filed: the coverage floor is stated but ungated (item 2.7)
+
+`AGENTS.md` §10 and spec NFR-07 both require **≥ 90% line coverage**. Nothing checks it: the
+`build` job sets up `pcov` but runs `vendor/bin/phpunit` with no `--coverage` flag and no
+threshold, so the number is neither produced nor compared. Found because this item could not
+verify its own coverage claim — no driver locally, no gate in CI. PHPUnit 10 has no fail-under
+option, so it needs a clover report plus a threshold check; that is real work, not a flag, and it
+is filed as **2.7** rather than bolted onto this PR.
+
+What *is* verifiable and stated instead: every method with a body in this change is exercised by
+a test — the three named constructors, `HydrationException::path()` including its empty default,
+and `JsonException::wrap()`. The empty leaf classes have no executable lines.
+
+## Next
+
+- **2.2 `Str`** (`slug()` with ext-intl fallback, `uuid()` v4, `random()`) — first real
+  algorithms, and the first place CSPRNG discipline matters.
+- **2.7** whenever convenient; it turns a written quality bar into a checked one, the same shape
+  as items 1.10 → 1.11.
+- One-time admin still open: branch protection and the label import
+  ([`github-setup.md`](../../workflow/github-setup.md)).

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,4 +19,5 @@ _(newest first)_
 
 #### August
 
+- [2026-08-03 — Milestone 2 opens: the exception hierarchy](2026/08/2026-08-03-m2-exception-hierarchy.md)
 - [2026-08-03 — EADOS pipeline run and the Composer build system](2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md)

--- a/src/main/php/d4np/utils/Support/DatabaseException.php
+++ b/src/main/php/d4np/utils/Support/DatabaseException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * A persistence operation failed, or was refused before it could reach the driver.
+ *
+ * Covers both halves of the security model's persistence rules (RFC-0001): a driver-level
+ * failure surfacing through `DatabaseConnection`'s pinned `ERRMODE_EXCEPTION`, and a
+ * `QueryBuilder` **refusal** — an identifier that fails the allowlist, or a `LIMIT`/`OFFSET`
+ * that is not a non-negative integer. The refusal case matters most: prepared statements bind
+ * *values*, never table or column names, so rejecting an identifier is the only defence there
+ * is, and it must be loud (spec §5, test T-02).
+ */
+final class DatabaseException extends UtilsException
+{
+}

--- a/src/main/php/d4np/utils/Support/FileException.php
+++ b/src/main/php/d4np/utils/Support/FileException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * A filesystem operation failed.
+ *
+ * `File::read()` / `File::write()` report failure by throwing rather than by returning `false`
+ * — the native functions' `false`-on-error convention is exactly what makes unchecked
+ * filesystem code silently lose data. Covers the lock that could not be taken, the atomic
+ * temp-then-rename that could not complete, and the MIME probe that could not read the file
+ * (spec §2 items 22–23).
+ */
+final class FileException extends UtilsException
+{
+}

--- a/src/main/php/d4np/utils/Support/HttpException.php
+++ b/src/main/php/d4np/utils/Support/HttpException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * A request could not be read, or a response could not be produced, as asked.
+ *
+ * Raised by the HTTP group — a superglobal that does not hold the shape a typed reader was
+ * asked for, a header set after output has begun, a session operation on a session that was
+ * never started. CSRF rejection lives here too: a token that fails constant-time comparison,
+ * or that belongs to another session, is an HTTP-layer refusal (RFC-0001, spec §2 item 12).
+ */
+final class HttpException extends UtilsException
+{
+}

--- a/src/main/php/d4np/utils/Support/HydrationException.php
+++ b/src/main/php/d4np/utils/Support/HydrationException.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+use Throwable;
+
+/**
+ * Raised when a payload cannot be turned into a typed DTO.
+ *
+ * Coarse catch for the three concrete hydration failures — an undeclared key
+ * ({@see UnknownKeyException}), an absent required key ({@see MissingKeyException}), and a
+ * value of the wrong type ({@see TypeMismatchException}).
+ *
+ * Every hydration failure names the **path** at which it occurred, because a DTO graph nests:
+ * "expected int, got string" is not actionable, while `address.postcode` is. The path is
+ * dot-separated from the root of the payload being hydrated.
+ *
+ * The constructor takes `$path` where `RuntimeException` takes `$code`. PHP exempts
+ * constructors from signature compatibility, and the trade is deliberate: an integer code
+ * carries nothing here — no consumer branches on it — while the path is the one piece of
+ * context that makes the failure diagnosable. `getCode()` still exists and returns 0.
+ */
+class HydrationException extends UtilsException
+{
+    public function __construct(
+        string $message,
+        private readonly string $path = '',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    /**
+     * The dot-separated path at which hydration failed, e.g. `address.postcode`.
+     *
+     * Empty when the failure is not attributable to a single property.
+     */
+    public function path(): string
+    {
+        return $this->path;
+    }
+}

--- a/src/main/php/d4np/utils/Support/JsonException.php
+++ b/src/main/php/d4np/utils/Support/JsonException.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+use JsonException as NativeJsonException;
+
+/**
+ * JSON encoding or decoding failed.
+ *
+ * **The name deliberately shadows PHP's native `\JsonException`** — same failure domain, and
+ * inventing a different word for it would cost more in confusion than the collision does. The
+ * two are related by wrapping, not by inheritance: this class must extend
+ * {@see UtilsException} to be catchable with everything else the package raises, so it cannot
+ * also extend the native one.
+ *
+ * `Json::encode()` / `Json::decode()` pass `JSON_THROW_ON_ERROR`, catch the native exception,
+ * and rethrow it through {@see self::wrap()}. The original is always retrievable via
+ * `getPrevious()` — nothing is lost in translation.
+ *
+ * In a file that touches both, alias at the import:
+ *
+ * ```php
+ * use D4np\Utils\Support\JsonException;
+ * use JsonException as NativeJsonException;
+ * ```
+ */
+final class JsonException extends UtilsException
+{
+    /**
+     * Wrap PHP's native JSON exception, preserving its message, code, and the original as
+     * `getPrevious()`.
+     */
+    public static function wrap(NativeJsonException $previous): self
+    {
+        return new self($previous->getMessage(), (int) $previous->getCode(), $previous);
+    }
+}

--- a/src/main/php/d4np/utils/Support/MissingKeyException.php
+++ b/src/main/php/d4np/utils/Support/MissingKeyException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * The payload omits a property the target DTO declares as required.
+ *
+ * "Required" means neither nullable nor carrying a default: a nullable or defaulted property
+ * absent from the payload hydrates to `null` or its default and raises nothing.
+ *
+ * Raised in **both** strict and lenient modes. Lenient hydration relaxes what may arrive, not
+ * what must (RFC-0001 R-4) — a DTO missing a required field is malformed under either policy,
+ * and the imported specification was silent on this case until review added it.
+ */
+final class MissingKeyException extends HydrationException
+{
+    /**
+     * @param string $path  dot-separated path of the absent property
+     * @param class-string $target  the DTO class being hydrated
+     */
+    public static function forKey(string $path, string $target): self
+    {
+        return new self(
+            sprintf(
+                'Missing required key "%s" for %s. The property is neither nullable nor '
+                . 'defaulted, so it cannot be omitted — in strict or lenient mode.',
+                $path,
+                $target,
+            ),
+            $path,
+        );
+    }
+}

--- a/src/main/php/d4np/utils/Support/TypeMismatchException.php
+++ b/src/main/php/d4np/utils/Support/TypeMismatchException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * A payload value cannot satisfy the declared type of the property it maps to.
+ *
+ * The message names the path, the declared type, and what actually arrived — the three facts
+ * needed to fix the caller. PHP has no runtime generics, so this is also the only place a
+ * `Collection<T>` element type can be enforced at run time when the optional `instanceof`
+ * guard is enabled (RFC-0001, spec §2 item 3).
+ */
+final class TypeMismatchException extends HydrationException
+{
+    /**
+     * @param string $path  dot-separated path of the offending value
+     * @param string $expected  the declared type, e.g. `int` or `App\Dto\AddressDto`
+     * @param string $actual  the type that arrived, as reported by `get_debug_type()`
+     */
+    public static function at(string $path, string $expected, string $actual): self
+    {
+        return new self(
+            sprintf('Expected %s at "%s", got %s.', $expected, $path, $actual),
+            $path,
+        );
+    }
+}

--- a/src/main/php/d4np/utils/Support/UnknownKeyException.php
+++ b/src/main/php/d4np/utils/Support/UnknownKeyException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * The payload carries a key the target DTO does not declare.
+ *
+ * Raised by strict hydration, which is the default: silently dropping an unrecognised key is
+ * how a typo in a payload becomes a field that was never assigned, and how a mass-assignment
+ * attempt becomes invisible. Consumers that genuinely receive wider payloads than they map opt
+ * out per call with `lenient()`, which skips unknown keys instead (RFC-0001, spec §2 item 1).
+ */
+final class UnknownKeyException extends HydrationException
+{
+    /**
+     * @param string $path  dot-separated path of the offending key
+     * @param class-string $target  the DTO class being hydrated
+     */
+    public static function forKey(string $path, string $target): self
+    {
+        return new self(
+            sprintf(
+                'Unknown key "%s" for %s. Strict hydration rejects keys the target does not '
+                . 'declare; use lenient() to ignore them.',
+                $path,
+                $target,
+            ),
+            $path,
+        );
+    }
+}

--- a/src/main/php/d4np/utils/Support/UtilsException.php
+++ b/src/main/php/d4np/utils/Support/UtilsException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+use RuntimeException;
+
+/**
+ * The base class of every exception this library throws.
+ *
+ * Extends `RuntimeException` rather than `Exception`: everything this package raises is a
+ * condition detected at run time (a malformed payload, a rejected identifier, an unreadable
+ * file), never a compile-time-checkable programming contract in the `LogicException` sense.
+ *
+ * Deliberately **not** `final`. It is the documented extension point for a consumer who needs
+ * an exception of their own inside this family; the concrete leaves below it are `final`,
+ * because the hierarchy's shape is a MAJOR-version surface (RFC-0001) and a subclass of a leaf
+ * would widen a contract this project has committed not to widen silently. See ADR-0004.
+ */
+class UtilsException extends RuntimeException implements UtilsThrowable
+{
+}

--- a/src/main/php/d4np/utils/Support/UtilsThrowable.php
+++ b/src/main/php/d4np/utils/Support/UtilsThrowable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+use Throwable;
+
+/**
+ * The marker every exception this library throws implements.
+ *
+ * Catching `UtilsThrowable` catches everything the package can raise, without coupling the
+ * `catch` to a concrete base class. That indirection is the point: an exception that must
+ * extend some other SPL base for interoperability can still join the family by implementing
+ * this interface, so the "one thing to catch" contract survives a change no class hierarchy
+ * could absorb. See ADR-0004.
+ */
+interface UtilsThrowable extends Throwable
+{
+}

--- a/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
+++ b/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\DatabaseException;
+use D4np\Utils\Support\FileException;
+use D4np\Utils\Support\HttpException;
+use D4np\Utils\Support\HydrationException;
+use D4np\Utils\Support\JsonException;
+use D4np\Utils\Support\MissingKeyException;
+use D4np\Utils\Support\TypeMismatchException;
+use D4np\Utils\Support\UnknownKeyException;
+use D4np\Utils\Support\UtilsException;
+use D4np\Utils\Support\UtilsThrowable;
+use JsonException as NativeJsonException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use stdClass;
+
+/**
+ * The exception hierarchy is a MAJOR-version surface (RFC-0001), so these tests assert its
+ * *shape*, not merely that the classes exist.
+ *
+ * The discovery test is the load-bearing one: it enumerates the exception classes from disk
+ * rather than from a hand-written list, so an exception added later that forgets to join the
+ * family fails here instead of reaching a consumer's `catch` block and missing it.
+ */
+final class ExceptionHierarchyTest extends TestCase
+{
+    private const SUPPORT_DIR = __DIR__ . '/../../../../../main/php/d4np/utils/Support';
+    private const NAMESPACE_PREFIX = 'D4np\\Utils\\Support\\';
+
+    /**
+     * Every exception class shipped in Support/, discovered from disk.
+     *
+     * @return list<class-string>
+     */
+    private static function discoverExceptionClasses(): array
+    {
+        $dir = realpath(self::SUPPORT_DIR);
+        self::assertIsString($dir, 'the Support source directory should be resolvable');
+
+        $found = [];
+        foreach (scandir($dir) ?: [] as $entry) {
+            if (!str_ends_with($entry, 'Exception.php')) {
+                continue;
+            }
+            /** @var class-string $class */
+            $class = self::NAMESPACE_PREFIX . basename($entry, '.php');
+            $found[] = $class;
+        }
+        sort($found);
+
+        return $found;
+    }
+
+    public function testEveryExceptionInSupportJoinsTheFamily(): void
+    {
+        $classes = self::discoverExceptionClasses();
+
+        self::assertNotSame([], $classes, 'no exception classes were discovered — the test would be vacuous');
+
+        foreach ($classes as $class) {
+            self::assertTrue(
+                is_a($class, UtilsThrowable::class, true),
+                sprintf(
+                    '%s does not implement %s. Every exception this package throws must be '
+                    . 'catchable through the one marker interface (ADR-0004).',
+                    $class,
+                    UtilsThrowable::class,
+                ),
+            );
+            self::assertTrue(
+                is_a($class, UtilsException::class, true),
+                sprintf('%s does not extend %s.', $class, UtilsException::class),
+            );
+        }
+    }
+
+    public function testTheDiscoveredSetIsExactlyTheDocumentedHierarchy(): void
+    {
+        // Pinned deliberately: RFC-0001 makes the hierarchy's shape a MAJOR surface, so adding
+        // or removing a member is a decision, not an edit that should slip through green.
+        self::assertSame(
+            [
+                DatabaseException::class,
+                FileException::class,
+                HttpException::class,
+                HydrationException::class,
+                JsonException::class,
+                MissingKeyException::class,
+                TypeMismatchException::class,
+                UnknownKeyException::class,
+                UtilsException::class,
+            ],
+            self::discoverExceptionClasses(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{class-string<HydrationException>}>
+     */
+    public static function hydrationLeaves(): iterable
+    {
+        yield 'unknown key' => [UnknownKeyException::class];
+        yield 'missing key' => [MissingKeyException::class];
+        yield 'type mismatch' => [TypeMismatchException::class];
+    }
+
+    /**
+     * @param class-string<HydrationException> $leaf
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('hydrationLeaves')]
+    public function testHydrationLeavesAreCatchableCoarsely(string $leaf): void
+    {
+        self::assertTrue(
+            is_a($leaf, HydrationException::class, true),
+            sprintf('%s must be catchable as %s', $leaf, HydrationException::class),
+        );
+    }
+
+    public function testNonHydrationExceptionsAreNotCaughtByAHydrationCatch(): void
+    {
+        // The other half of the coarse-catch contract: a `catch (HydrationException)` must not
+        // swallow a database or HTTP failure. Asserting only the positive direction would pass
+        // even if every exception shared one parent.
+        //
+        // The set is derived from disk rather than written out, for two reasons: a member added
+        // later is covered without anyone remembering to add it here, and a hard-coded list of
+        // literals is something PHPStan can decide statically — which would make this assertion
+        // a tautology dressed as a test.
+        $hydration = [HydrationException::class, UnknownKeyException::class, MissingKeyException::class, TypeMismatchException::class];
+        $others = array_values(array_filter(
+            self::discoverExceptionClasses(),
+            static fn (string $class): bool => !in_array($class, $hydration, true),
+        ));
+
+        self::assertNotSame([], $others, 'no non-hydration exceptions found — the test would be vacuous');
+
+        foreach ($others as $class) {
+            self::assertFalse(
+                is_a($class, HydrationException::class, true),
+                sprintf('%s must NOT be catchable as %s', $class, HydrationException::class),
+            );
+        }
+    }
+
+    public function testConcreteLeavesAreFinalAndBasesAreExtensible(): void
+    {
+        // ADR-0004's extension-point contract, asserted so a later edit cannot flip it quietly.
+        foreach ([UtilsException::class, HydrationException::class] as $base) {
+            self::assertFalse(
+                (new ReflectionClass($base))->isFinal(),
+                sprintf('%s is a documented extension point and must stay non-final', $base),
+            );
+        }
+        $leaves = [
+            DatabaseException::class,
+            FileException::class,
+            HttpException::class,
+            JsonException::class,
+            MissingKeyException::class,
+            TypeMismatchException::class,
+            UnknownKeyException::class,
+        ];
+        foreach ($leaves as $leaf) {
+            self::assertTrue(
+                (new ReflectionClass($leaf))->isFinal(),
+                sprintf('%s is a concrete leaf of a MAJOR-pinned hierarchy and must be final', $leaf),
+            );
+        }
+    }
+
+    public function testUnknownKeyFactoryCarriesThePathAndNamesIt(): void
+    {
+        // stdClass stands in for a consumer DTO: `forKey()` declares `class-string`, so passing
+        // a name that resolves to nothing would be a type violation the production hydrator
+        // could never make (it passes `$target::class`).
+        $e = UnknownKeyException::forKey('address.postcode', stdClass::class);
+
+        self::assertSame('address.postcode', $e->path());
+        self::assertStringContainsString('address.postcode', $e->getMessage());
+        self::assertStringContainsString('stdClass', $e->getMessage());
+        self::assertStringContainsString('lenient()', $e->getMessage(), 'the message should name the opt-out');
+    }
+
+    public function testMissingKeyFactoryCarriesThePathAndSaysItAppliesToBothModes(): void
+    {
+        $e = MissingKeyException::forKey('email', stdClass::class);
+
+        self::assertSame('email', $e->path());
+        self::assertStringContainsString('email', $e->getMessage());
+        self::assertStringContainsString('lenient', $e->getMessage());
+    }
+
+    public function testTypeMismatchFactoryNamesPathExpectedAndActual(): void
+    {
+        $e = TypeMismatchException::at('items.0.qty', 'int', 'string');
+
+        self::assertSame('items.0.qty', $e->path());
+        self::assertStringContainsString('items.0.qty', $e->getMessage());
+        self::assertStringContainsString('int', $e->getMessage());
+        self::assertStringContainsString('string', $e->getMessage());
+    }
+
+    public function testHydrationPathDefaultsToEmptyWhenNotAttributable(): void
+    {
+        self::assertSame('', (new HydrationException('malformed payload'))->path());
+    }
+
+    public function testJsonExceptionWrapsTheNativeOneWithoutLosingIt(): void
+    {
+        $native = new NativeJsonException('Syntax error', 4);
+
+        $wrapped = JsonException::wrap($native);
+
+        self::assertSame('Syntax error', $wrapped->getMessage());
+        self::assertSame(4, $wrapped->getCode());
+        self::assertSame($native, $wrapped->getPrevious(), 'the original must stay retrievable');
+        self::assertInstanceOf(UtilsThrowable::class, $wrapped);
+        // Not asserted here: that the wrapper is NOT a native \JsonException. PHPStan at max
+        // level decides that statically for every call site in the codebase, permanently —
+        // a strictly stronger guarantee than one runtime assertion, which it would flag as an
+        // already-narrowed comparison anyway.
+    }
+}


### PR DESCRIPTION
## Context

Roadmap item **2.1** — the first Milestone 2 item, and the first code in this repository with
*behaviour* rather than configuration. Flagged **`sets-pattern`**: it is the first of its class,
so the shape it lands is the shape the five remaining component groups copy.

RFC-0001 fixed *which* exceptions exist and what nests under what, and pinned that shape as a
**MAJOR-version surface**. It deliberately left the mechanics open — and those are exactly what
a `sets-pattern` item must not decide by reflex.

## Change

Ten files under `src/main/php/d4np/utils/Support/`, plus
**[ADR-0004](docs/adr/0004-root-the-exception-hierarchy-on-an-interface.md)** for the four
decisions:

- **An interface root** — `UtilsThrowable extends \Throwable`, implemented by every exception,
  alongside the concrete `UtilsException extends \RuntimeException`. The RFC's arrow notation
  literally implies a class root; that is a **one-way door**. An exception that later must extend
  some other base for interoperability can still join the family through the interface, so the
  "one thing to catch" contract survives a change no class hierarchy could absorb. Cost: one file
  with an empty body.
- **`RuntimeException`, not `Exception`/`LogicException`** — everything here is detected at run
  time from data the library did not control.
- **Leaves `final`; `UtilsException` and `HydrationException` open** as the *documented*
  extension points. A subclass of a leaf would widen a MAJOR-pinned surface silently.
- **`HydrationException` takes `$path` where SPL takes `$code`** — no consumer branches on an
  integer code, while the path (`address.postcode`) is the one fact that makes a nested-DTO
  failure diagnosable. PHP exempts constructors from signature compatibility; recorded in the ADR
  because it is a trade, not an oversight.

`JsonException` implements RFC-0001 R-7: it extends `UtilsException` (catchable with everything
else) and **wraps** PHP's native `\JsonException` via `wrap()`, keeping the original as
`getPrevious()`.

## Verification

- **14 tests, 61 assertions green**; PHPStan **max** clean; PHP-CS-Fixer clean on every new file;
  `consistency_lint` and `action_pin_lint --verify-upstream` both pass.
- **The test carrying the weight discovers the exception classes from disk**, not from a
  hand-written list, and asserts each implements `UtilsThrowable`. A member added later that
  forgets the contract fails there instead of reaching a consumer's `catch` and being silently
  missed.
- **Proved non-vacuous**: planted a `RogueException extends \RuntimeException`, watched both the
  contract test and the pinned-member-set test fail with actionable messages naming the ADR,
  removed it, watched them pass.
- The **negative** direction is pinned too — a `catch (HydrationException)` must not swallow a
  database or HTTP failure — and its class set is *also* derived from disk, deliberately: a
  hard-coded list of class literals is something PHPStan can decide statically, which would make
  the assertion a tautology dressed as a test.

### PHPStan max earned its keep

Four findings, all in the test file, all fixed at the cause and none silenced:

1. `is_a()` over hard-coded literals → statically decidable, so it proved nothing. Rewritten to
   derive the class set at runtime.
2. & 3. `forKey()` declares `class-string`; the test passed `'App\Dto\UserDto'`, which resolves to
   no class. The production type is right (the hydrator passes `$target::class`) — the test now
   passes a real one.
4. `assertNotInstanceOf(NativeJsonException::class, …)` → already-narrowed. **Dropped**, with a
   comment recording why: PHPStan at max decides that disjointness statically for *every* call
   site, permanently — strictly stronger than one runtime assertion.

## No patterns-catalogue row, on purpose

The static named constructors (`UnknownKeyException::forKey()`, `TypeMismatchException::at()`) are
the **named-constructor idiom**, not GoF **Factory Method** — which is about deferring
instantiation so a subclass picks the concrete type. `docs/patterns/design-patterns.md` lists only
the latter, and filing this under it to have something to file is exactly the force-fit
`AGENTS.md` §8 forbids. Recorded in ADR-0004 so the empty catalogue is a **decision**, not a gap.

## Filed, not bolted on: item 2.7 — the coverage floor is stated but ungated

`AGENTS.md` §10 and spec NFR-07 both require **≥ 90% line coverage**. Nothing checks it: the
`build` job sets up `pcov` but runs `vendor/bin/phpunit` with no `--coverage` flag and no
threshold, so the number is neither produced nor compared. Found because this item could not
verify its own coverage claim — no driver locally, no gate in CI. PHPUnit 10 has no fail-under
option, so it needs a clover report plus a threshold check: real work, filed as **2.7**.

What *is* verifiable and stated instead: **every method with a body in this change is exercised
by a test** — the three named constructors, `HydrationException::path()` including its empty
default, and `JsonException::wrap()`. The empty leaf classes have no executable lines.

## Route

`sets-pattern` resolves to **frontier-reasoning / high**; `route_advice.py --check` reported the
session model (`opus-5`, standard tier) below it. Surfaced to the maintainer before starting —
they hold model authority (ADR-0017) — and proceeded on their standing decision.

**Cross-links:** RFC-0001 · ADR-0004 · roadmap item 2.1 (done), 2.7 (filed) · milestone
`v0.2.0`. Type label: `feat` (declared in `.github/labels.yml`, still not imported);
`enhancement` set as the closest available default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
