### PR TITLE
feat(support): add File with atomic writes and content-based MIME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- `D4np\Utils\Support\File` (**ADR-0005**): `write()` replaces the target **atomically** — a
+  temporary file in the same directory, `rename()`d over — so a reader never observes a
+  half-written file; writers are serialised through an exclusive `flock()` on a `<path>.lock`
+  sidecar, which is where the lock has to live because a handle held on the target makes the
+  replacement fail on Windows. `read()` reads under a shared lock. `mime()` detects from
+  **contents** via `ext-fileinfo`, never from the filename. Every failure throws `FileException`
+  instead of returning `false`.
 - `D4np\Utils\Support\Str`: `slug()` (three-tier ASCII transliteration — `ext-intl`, then
   `iconv`, then a printable-ASCII filter, degrading gracefully rather than throwing; idempotent
   per spec T-05), `uuid()` (RFC 4122 v4 from `random_bytes()`), and `random()` (CSPRNG

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-03 — Str::slug() / uuid() / random()](docs/journal/2026/08/2026-08-03-str-slug-uuid-random.md).
+  [2026-08-03 — File: atomic writes, and a test that was lying](docs/journal/2026/08/2026-08-03-file-atomic-io.md).
 
 ## Model & effort routing (advisory)
 
@@ -105,9 +105,9 @@ The foundation every group depends on — the deptrac-legal bottom layer (RFC-00
       route: frontier-reasoning / high · **ADR-0004**
 - [x] 2.2 `Str`: `slug()` with ext-intl transliteration fallback, `uuid()` v4, `random()`
       CSPRNG (RFC-0001) — route: fast / low
-- [ ] 2.3 `File`: flock-guarded `write()`/`read()`, atomic write via temp+rename, Fileinfo
+- [x] 2.3 `File`: flock-guarded `write()`/`read()`, atomic write via temp+rename, Fileinfo
       `mime()` (RFC-0001) (severity:medium — concurrency/atomicity semantics) —
-      route: standard / medium
+      route: standard / medium · **ADR-0005**
 - [ ] 2.4 `Env::get()` with boolean coercion; `Json::encode()/decode()` wrapping native
       `\JsonException` (RFC-0001 R-7) — route: fast / low
 - [ ] 2.5 Shared reflection-metadata cache, consumed by the Dto hydrator and the Container

--- a/docs/adr/0005-atomic-file-writes-with-a-sidecar-lock.md
+++ b/docs/adr/0005-atomic-file-writes-with-a-sidecar-lock.md
@@ -1,0 +1,123 @@
+# ADR-0005: Atomic file writes, with the lock on a sidecar rather than the target
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 2.3 · [RFC-0001](../rfc/0001-egl-utils-library.md) ·
+  [spec §2 items 22–23](../specs/01_spec_utils.md) · [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md)
+
+## Context
+
+RFC-0001 and spec §2 item 22 ask for `File::write()`/`File::read()` to be *"flock-guarded,
+atomic write via temp+rename"*. Implementing that literally turns out to be impossible, and
+discovering **why** is what this ADR exists to record — the failure is silent, platform-specific,
+and would have shipped as a write path that simply does not work on Windows.
+
+Two distinct properties hide inside that one sentence:
+
+- **Atomicity** — a reader never observes a half-written file. Delivered by writing to a
+  temporary file in the *same directory* and `rename()`ing it over the target. Same directory is
+  load-bearing: `rename()` is only atomic within a single filesystem.
+- **Writer serialisation** — two concurrent writers do not lose each other's updates. Delivered
+  by an exclusive `flock()`.
+
+The natural implementation — open the target, `flock(LOCK_EX)`, write the temp file, rename,
+release — fails, and it fails in two different ways depending on where the release goes:
+
+1. **Lock held across the `rename()`: broken on Windows.** Verified directly while writing this
+   ADR, on PHP 8.3.1 / Windows 11:
+
+   | Scenario | Result |
+   |---|---|
+   | `rename()` over an existing target, no handles open | **OK** |
+   | `rename()` over an existing target while a handle holds it open | **FAILS** |
+
+   POSIX unlinks the old directory entry and lets existing handles keep reading the old inode;
+   Windows refuses the replacement outright. So a lock handle held on the target — which is
+   exactly what serialisation requires — makes every atomic write fail on Windows.
+
+2. **Lock released before the `rename()`: serialises nothing that matters.** The `rename()` *is*
+   the mutation. If the critical section ends before it, two writers can each prepare a temp
+   file under the lock, release, and then rename in either order — the identical outcome to
+   having no lock at all.
+
+A third subtlety, unrelated to locking but equally silent: **`tempnam()` falls back to the
+system temp directory** when it cannot use the directory it was given. That would place the
+temporary file on a different filesystem, at which point `rename()` stops being atomic and
+degrades to copy-then-delete — the guarantee evaporates with no error anywhere.
+
+## Decision
+
+**`File::write()` replaces the target atomically via a temporary file in the same directory,
+and takes its exclusive `flock()` on a sidecar lock file — `<path>.lock` — held across the whole
+prepare-and-rename sequence.**
+
+The sidecar is never the object of a `rename()`, so holding it is compatible with replacing the
+target on every platform, and holding it *across* the rename is what makes the serialisation
+real rather than decorative.
+
+Supporting commitments:
+
+- The path `tempnam()` returns is **verified to be in the intended directory**; the silent
+  system-temp fallback is treated as a failure, not accepted. Losing atomicity quietly is worse
+  than refusing to write.
+- The temporary file is `chmod`ed to the target's existing mode — or `0644` for a new file —
+  **before** the rename, so the target never briefly carries `tempnam()`'s `0600`.
+- A short write (bytes written ≠ bytes given) is a failure. So is every other error: `File`
+  throws {@see FileException} rather than returning `false`, per ADR-0004's hierarchy.
+- `File::read()` takes a shared `flock()`. Against this library's own writer that is redundant
+  by construction — an atomic replacement is never observable half-done — and it is kept because
+  it is what makes reads cooperate with a *third-party* writer that modifies files in place.
+
+## Alternatives Considered
+
+- **Lock the target, hold across the rename** — the literal reading of the RFC. Rejected: it
+  does not work on Windows (evidence above). This is the alternative the ADR exists to close.
+- **Lock the target, release before the rename** — rejected: provably equivalent to no lock,
+  because the rename is the mutation. It would have satisfied "flock-guarded" as a word while
+  delivering nothing the word implies.
+- **No write lock at all; rely on atomic replacement alone** — the mainstream choice (Symfony's
+  `Filesystem::dumpFile()` does exactly this, leaving locking to a separate component). Genuinely
+  defensible, and it leaves no `.lock` files behind. Rejected because it silently drops the
+  serialisation half of an approved requirement; if the litter proves worse than the guarantee is
+  worth, that is a decision to revisit **with this evidence in hand**, not one to make by
+  omission.
+- **Keep lock files in the system temp directory**, keyed by a hash of the target path, to avoid
+  litter next to user data. Rejected: two processes running as different users see different
+  temp directories, so serialisation would break *silently* — the failure mode this ADR is
+  written to avoid.
+- **Write in place under an exclusive lock** (`truncate` + write, no temp file) — rejected: it is
+  the one design where a concurrent reader genuinely can observe a truncated file, and `flock()`
+  is advisory, so a reader that does not cooperate observes it.
+
+## Consequences
+
+- **Callers get a real atomicity guarantee**, on every supported platform: a rewrite is a
+  replacement, and a reader sees one complete version or the other.
+- **Writer serialisation is real but advisory** — it holds among processes that go through
+  `File::write()`. `flock()` cannot bind a process that does not ask for the lock, and it is
+  unreliable on NFS. Concurrent full replacements are **last-writer-wins**: each write is
+  complete, and lock-acquisition order decides which survives. This library does **not** ship a
+  read-modify-write primitive; a caller needing one needs a lock manager, not this method.
+- **The cost is visible: a `<path>.lock` file appears beside every written file, and stays.**
+  Unlinking a lock file is itself racy — the classic delete-while-another-process-waits bug — so
+  it is deliberately left in place. Callers that write into a directory they also list should
+  expect it.
+- **Testing atomicity needed a real discriminator.** The obvious test — write, then read back,
+  and check the content is complete — passes against a naive truncating implementation, because
+  a single-process sequential test contains no concurrency to observe. It was written, caught
+  passing against a deliberately planted `file_put_contents()` implementation, and replaced with
+  two tests that do discriminate: the target's **inode must change** across a rewrite (a replaced
+  file is a different file; an in-place write keeps the inode), and — on POSIX — an
+  already-open reader must go on seeing the **complete previous** contents. The first is
+  portable and fails against the naive implementation; the second cannot run on Windows for the
+  reason in Context 1, and is skipped there.
+
+## References
+
+- Spec §2 items 22–23; RFC-0001 *Decision → API contract*
+- POSIX `rename(2)` — atomic replacement within a filesystem; Windows `MoveFileEx` sharing
+  semantics (the behavioural difference measured in Context 1)
+- PHP manual: `flock()` (advisory locking, NFS caveat), `tempnam()` (directory fallback),
+  `rename()`
+- Symfony `Filesystem::dumpFile()` — prior art for the no-write-lock alternative

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0002](0002-adopt-cross-language-source-layout.md) | Adopt the cross-language source layout | Accepted |
 | [0003](0003-pin-ci-actions-by-commit-sha.md) | Pin CI actions by commit SHA | Accepted |
 | [0004](0004-root-the-exception-hierarchy-on-an-interface.md) | Root the exception hierarchy on an interface, and close its leaves | Accepted |
+| [0005](0005-atomic-file-writes-with-a-sidecar-lock.md) | Atomic file writes, with the lock on a sidecar rather than the target | Accepted |

--- a/docs/journal/2026/08/2026-08-03-file-atomic-io.md
+++ b/docs/journal/2026/08/2026-08-03-file-atomic-io.md
@@ -1,0 +1,90 @@
+# 2026-08-03 — `File`: atomic writes, and a test that was lying
+
+Roadmap item **2.3**, flagged `severity:medium` for "concurrency/atomicity semantics" — which
+turned out to be the right flag for the right reason. Route resolved to `standard / medium` and
+the session model matched (first ROUTE-OK of the milestone).
+
+## The finding that shaped the design
+
+RFC-0001 asks for `write()`/`read()` that are *"flock-guarded, atomic write via temp+rename"*.
+Implementing that literally is impossible, and the reason is silent and platform-specific.
+Measured directly, PHP 8.3.1 on Windows 11:
+
+| Scenario | Result |
+|---|---|
+| `rename()` over an existing target, no handles open | **OK** |
+| `rename()` over an existing target while a handle holds it open | **FAILS** |
+
+POSIX unlinks the old directory entry and lets existing handles keep reading the old inode.
+Windows refuses the replacement outright. So the natural implementation — lock the target, write
+the temp file, rename, release — **breaks every atomic write on Windows**, because the lock
+handle is precisely what makes the rename fail.
+
+And moving the release earlier does not rescue it: the `rename()` *is* the mutation, so a
+critical section that ends before it serialises nothing. Two writers can each prepare under the
+lock, release, and rename in either order — identical to having no lock.
+
+Hence **ADR-0005**: the lock goes on a `<path>.lock` sidecar, which is never the object of a
+rename, so it can be held across the whole prepare-and-replace sequence. Cost, stated rather than
+hidden: a `.lock` file appears beside every written file and stays, because unlinking it is
+itself racy.
+
+A second silent trap, caught while reading the manual rather than after a bug report:
+**`tempnam()` falls back to the system temp directory** when it cannot use the one it was given.
+That puts the temp file on another filesystem, at which point `rename()` degrades to
+copy-then-delete and atomicity evaporates with no error anywhere. The returned path is now
+verified to be in the intended directory, and the fallback is treated as a failure.
+
+## The test that was lying
+
+The first atomicity test was called `testConcurrentReadsNeverObserveAPartialFile`. It wrote,
+then read back, then asserted the content was one complete version or the other — forty times.
+
+**It passed against a deliberately planted naive `file_put_contents($path, …)` implementation.**
+
+Of course it did: a single-process sequential test contains no concurrency. `File::write()`
+returns, *then* the read happens; a truncating write has finished truncating by then too. The
+test asserted that writing works, under a name claiming it asserted atomicity. Had it shipped, it
+would have been a green gate over an unverified guarantee — and the name would have kept anyone
+from noticing.
+
+Replaced with two tests that actually discriminate, after probing the platform for an observation
+that does:
+
+1. **`testWriteReplacesTheFileRatherThanTruncatingItInPlace`** — the target's **inode must change**
+   across a rewrite. A replaced file is a different file; an in-place write keeps the inode.
+   Deterministic, single-process, no concurrency to make it flaky, and — verified — `fileinode()`
+   reports real values on Windows too, so it runs everywhere. **Re-planted the naive
+   implementation and watched this one go red**, with a message that explains why it matters.
+2. **`testAnAlreadyOpenReaderKeepsSeeingTheCompletePreviousContents`** — the guarantee itself,
+   observed directly: a reader that opened before the rewrite goes on reading the complete old
+   contents from its own handle. POSIX only; skipped on Windows for the reason in the table above,
+   which is the same finding, now load-bearing twice.
+
+A discarded third candidate, worth recording: "write to a read-only file in a writable directory
+succeeds" would discriminate on POSIX (a truncating open fails, a rename succeeds) — but on
+Windows the rename fails too, so it would have looked like a bug in the atomic implementation.
+Probed before adopting, rejected on evidence.
+
+## Also verified rather than assumed
+
+`mime()`'s headline claim is that it reads content, not the filename. The first fixture was the
+8-byte PNG signature plus zeros — reported as `application/octet-stream`, because this libmagic
+wants the IHDR chunk before committing to `image/png`. Probed four fixtures to find out
+(signature-only PNG, a real 1×1 PNG, `GIF89a`, `%PDF-1.4`) and switched to a genuinely valid PNG,
+which is also more portable across libmagic versions than relying on one version's leniency.
+Two formats are now covered, under deliberately misleading extensions in both directions
+(`.txt` holding a PNG, `.png` holding prose).
+
+## State
+
+71 tests, 142 assertions, 3 skipped — all three Windows-only: two POSIX permission-bit tests and
+the open-handle atomicity test. They run on CI. PHPStan max clean on the first pass, second item
+running.
+
+## Next
+
+- **2.4 `Env::get()` + `Json`** — `Json` is where `JsonException::wrap()` from item 2.1 finally
+  gets its caller, and the `Env` boolean-coercion table is the third T-05 property test.
+- Still open: **2.7** (the coverage floor is stated in `AGENTS.md` §10 and NFR-07 but ungated) and
+  the one-time admin — branch protection and the label import.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-03 — File: atomic writes, and a test that was lying](2026/08/2026-08-03-file-atomic-io.md)
 - [2026-08-03 — Str::slug() / uuid() / random()](2026/08/2026-08-03-str-slug-uuid-random.md)
 - [2026-08-03 — Milestone 2 opens: the exception hierarchy](2026/08/2026-08-03-m2-exception-hierarchy.md)
 - [2026-08-03 — EADOS pipeline run and the Composer build system](2026/08/2026-08-03-pipeline-bootstrap-and-build-system.md)

--- a/src/main/php/d4np/utils/Support/File.php
+++ b/src/main/php/d4np/utils/Support/File.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * Filesystem reads and writes that fail loudly and replace atomically (spec §2 items 22–23).
+ *
+ * Every operation throws {@see FileException} instead of returning `false`. PHP's native
+ * filesystem functions report failure by return value, which is exactly how unchecked code
+ * silently loses data — a `file_put_contents()` whose result nobody inspects is a write that
+ * may never have happened.
+ *
+ * The concurrency and atomicity model, and why the lock is a sidecar rather than the target
+ * itself, are recorded in **ADR-0005**.
+ */
+final class File
+{
+    /** Mode applied to a file this class creates, when no existing file's mode can be preserved. */
+    private const DEFAULT_MODE = 0644;
+
+    /** Suffix of the sidecar lock file (ADR-0005). */
+    private const LOCK_SUFFIX = '.lock';
+
+    private function __construct()
+    {
+        // Static-only: no instances.
+    }
+
+    /**
+     * Replace `$path`'s contents atomically.
+     *
+     * A concurrent reader sees either the complete previous contents or the complete new
+     * contents — never a mix, and never a truncated file — because the bytes are written to a
+     * temporary file in the **same directory** and then `rename()`d over the target. Same
+     * directory is not incidental: `rename()` is only atomic within one filesystem.
+     *
+     * Cooperating writers are serialised through an exclusive `flock()` on a **sidecar** lock
+     * file (`<path>.lock`), held across the whole prepare-and-rename sequence. The lock cannot
+     * be taken on the target itself — see ADR-0005 for the evidence; briefly, a handle held on
+     * the target makes the `rename()` fail on Windows, and one released before the `rename()`
+     * serialises nothing that matters.
+     *
+     * The target's existing permissions are preserved; a newly created file gets
+     * {@see self::DEFAULT_MODE}.
+     *
+     * @throws FileException if the directory is missing or unwritable, if the temporary file
+     *                        cannot be created in it, if the write is short, or if the rename
+     *                        fails.
+     */
+    public static function write(string $path, string $contents): void
+    {
+        $dir = \dirname($path);
+        if (!is_dir($dir)) {
+            throw new FileException(sprintf('Cannot write "%s": directory "%s" does not exist.', $path, $dir));
+        }
+        if (!is_writable($dir)) {
+            throw new FileException(sprintf('Cannot write "%s": directory "%s" is not writable.', $path, $dir));
+        }
+
+        $mode = self::currentModeOf($path);
+        $lock = self::acquireExclusiveLock($path);
+
+        try {
+            $tmp = self::createTempFileIn($dir);
+
+            try {
+                self::putAll($tmp, $contents, $path);
+
+                // chmod BEFORE the rename: tempnam() creates 0600, and a reader must never see
+                // the target briefly carrying the temp file's restrictive mode.
+                if (!@chmod($tmp, $mode)) {
+                    throw new FileException(sprintf('Cannot write "%s": failed to set mode on the temporary file.', $path));
+                }
+
+                if (!@rename($tmp, $path)) {
+                    throw new FileException(sprintf('Cannot write "%s": atomic rename from the temporary file failed.', $path));
+                }
+            } catch (FileException $e) {
+                // The temp file is this method's litter, not the caller's problem.
+                if (is_file($tmp)) {
+                    @unlink($tmp);
+                }
+
+                throw $e;
+            }
+        } finally {
+            self::releaseLock($lock);
+        }
+    }
+
+    /**
+     * Read `$path` in full, under a shared `flock()`.
+     *
+     * The shared lock is what makes this cooperate with a *third-party* writer that modifies
+     * files in place rather than atomically; against {@see self::write()} it is redundant by
+     * construction, since an atomic replacement is never observable half-done (ADR-0005).
+     *
+     * @throws FileException if the path is not a readable file, or if reading fails.
+     */
+    public static function read(string $path): string
+    {
+        if (!is_file($path)) {
+            throw new FileException(sprintf('Cannot read "%s": not a file.', $path));
+        }
+
+        $handle = @fopen($path, 'rb');
+        if ($handle === false) {
+            throw new FileException(sprintf('Cannot read "%s": failed to open for reading.', $path));
+        }
+
+        try {
+            if (!flock($handle, LOCK_SH)) {
+                throw new FileException(sprintf('Cannot read "%s": failed to acquire a shared lock.', $path));
+            }
+
+            $contents = stream_get_contents($handle);
+            if ($contents === false) {
+                throw new FileException(sprintf('Cannot read "%s": read failed after locking.', $path));
+            }
+
+            return $contents;
+        } finally {
+            @flock($handle, LOCK_UN);
+            @fclose($handle);
+        }
+    }
+
+    /**
+     * The MIME type of `$path`, detected from its **contents**.
+     *
+     * Never infers from the filename: an extension is caller-supplied data, and trusting it is
+     * how an uploaded `.jpg` turns out to be a PHP script. Uses `ext-fileinfo`, which
+     * `composer.json` requires, so the detection path is always available.
+     *
+     * @throws FileException if the path is not a readable file, or if detection fails.
+     */
+    public static function mime(string $path): string
+    {
+        if (!is_file($path)) {
+            throw new FileException(sprintf('Cannot detect the MIME type of "%s": not a file.', $path));
+        }
+
+        $finfo = @finfo_open(FILEINFO_MIME_TYPE);
+        if ($finfo === false) {
+            throw new FileException('Cannot detect a MIME type: failed to open the fileinfo database.');
+        }
+
+        try {
+            $mime = @finfo_file($finfo, $path);
+            if ($mime === false) {
+                throw new FileException(sprintf('Cannot detect the MIME type of "%s": detection failed.', $path));
+            }
+
+            return $mime;
+        } finally {
+            finfo_close($finfo);
+        }
+    }
+
+    /**
+     * The mode to give the file after writing: the target's own, when it already exists, so a
+     * rewrite never silently changes its permissions.
+     */
+    private static function currentModeOf(string $path): int
+    {
+        if (!is_file($path)) {
+            return self::DEFAULT_MODE;
+        }
+
+        $perms = @fileperms($path);
+
+        return $perms === false ? self::DEFAULT_MODE : ($perms & 0777);
+    }
+
+    /**
+     * @return resource the held lock handle, for {@see self::releaseLock()}
+     * @throws FileException
+     */
+    private static function acquireExclusiveLock(string $path)
+    {
+        $lockPath = $path . self::LOCK_SUFFIX;
+
+        // 'c' creates the file when absent and does NOT truncate it — the sidecar carries no
+        // content, only the lock, so truncation would be harmless but pointless.
+        $handle = @fopen($lockPath, 'c');
+        if ($handle === false) {
+            throw new FileException(sprintf('Cannot write "%s": failed to open the lock file "%s".', $path, $lockPath));
+        }
+
+        if (!flock($handle, LOCK_EX)) {
+            @fclose($handle);
+
+            throw new FileException(sprintf('Cannot write "%s": failed to acquire an exclusive lock.', $path));
+        }
+
+        return $handle;
+    }
+
+    /**
+     * @param resource $handle
+     */
+    private static function releaseLock($handle): void
+    {
+        @flock($handle, LOCK_UN);
+        @fclose($handle);
+    }
+
+    /**
+     * A temporary file guaranteed to live in `$dir`.
+     *
+     * `tempnam()` silently falls back to the system temp directory when it cannot use the one
+     * it was given — which would put the temp file on a different filesystem and quietly make
+     * the subsequent `rename()` non-atomic. The returned path is therefore verified to be in
+     * `$dir`, and the fallback is treated as a failure rather than accepted.
+     *
+     * @throws FileException
+     */
+    private static function createTempFileIn(string $dir): string
+    {
+        $tmp = @tempnam($dir, '.egl-utils-');
+        if ($tmp === false) {
+            throw new FileException(sprintf('Failed to create a temporary file in "%s".', $dir));
+        }
+
+        $tmpDir = realpath(\dirname($tmp));
+        $wanted = realpath($dir);
+        if ($tmpDir === false || $wanted === false || $tmpDir !== $wanted) {
+            @unlink($tmp);
+
+            throw new FileException(sprintf(
+                'Refusing to write: the temporary file landed in "%s" instead of "%s", so the '
+                . 'replacement would cross filesystems and lose atomicity.',
+                $tmpDir === false ? 'an unresolvable directory' : $tmpDir,
+                $dir,
+            ));
+        }
+
+        return $tmp;
+    }
+
+    /**
+     * Write every byte of `$contents` to `$tmp`, treating a short write as a failure.
+     *
+     * @throws FileException
+     */
+    private static function putAll(string $tmp, string $contents, string $target): void
+    {
+        $written = @file_put_contents($tmp, $contents);
+        if ($written === false) {
+            throw new FileException(sprintf('Cannot write "%s": writing the temporary file failed.', $target));
+        }
+
+        $expected = \strlen($contents);
+        if ($written !== $expected) {
+            throw new FileException(sprintf(
+                'Cannot write "%s": short write to the temporary file (%d of %d bytes).',
+                $target,
+                $written,
+                $expected,
+            ));
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Support/FileTest.php
+++ b/src/test/php/d4np/utils/Support/FileTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\File;
+use D4np\Utils\Support\FileException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `File` — spec §2 items 22–23, and the concurrency/atomicity semantics ADR-0005 records.
+ *
+ * Every test works inside its own temporary directory, created in `setUp()` and removed in
+ * `tearDown()`, so nothing here depends on or disturbs the repository tree.
+ */
+final class FileTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $base = sys_get_temp_dir() . '/egl-utils-filetest-' . bin2hex(random_bytes(8));
+        if (!mkdir($base) && !is_dir($base)) {
+            self::fail(sprintf('could not create the test directory "%s"', $base));
+        }
+        $this->dir = $base;
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $entry) {
+            if (is_file($entry)) {
+                unlink($entry);
+            }
+        }
+        if (is_dir($this->dir)) {
+            rmdir($this->dir);
+        }
+    }
+
+    private function path(string $name): string
+    {
+        return $this->dir . '/' . $name;
+    }
+
+    // ---------------------------------------------------------------- write
+
+    public function testWriteCreatesTheFileWithExactContents(): void
+    {
+        $path = $this->path('created.txt');
+
+        File::write($path, "line one\nline two\n");
+
+        self::assertFileExists($path);
+        self::assertSame("line one\nline two\n", file_get_contents($path));
+    }
+
+    public function testWriteReplacesExistingContentsEntirely(): void
+    {
+        $path = $this->path('replaced.txt');
+        file_put_contents($path, 'a much longer previous content that must not survive');
+
+        File::write($path, 'short');
+
+        self::assertSame('short', file_get_contents($path));
+    }
+
+    public function testWriteHandlesEmptyContents(): void
+    {
+        $path = $this->path('empty.txt');
+
+        File::write($path, '');
+
+        self::assertFileExists($path);
+        self::assertSame('', file_get_contents($path));
+        self::assertSame(0, filesize($path));
+    }
+
+    public function testWriteHandlesBinaryContentsWithNullBytes(): void
+    {
+        $path = $this->path('binary.bin');
+        $binary = random_bytes(4096) . "\x00\x00" . random_bytes(64);
+
+        File::write($path, $binary);
+
+        self::assertSame($binary, file_get_contents($path));
+    }
+
+    public function testWriteLeavesNoTemporaryFileBehind(): void
+    {
+        $path = $this->path('clean.txt');
+
+        File::write($path, 'content');
+
+        $leftovers = array_values(array_filter(
+            glob($this->dir . '/*') ?: [],
+            static fn (string $entry): bool => str_contains(basename($entry), '.egl-utils-'),
+        ));
+
+        self::assertSame([], $leftovers, 'the temporary file must be renamed away, not left behind');
+    }
+
+    public function testWritePreservesAnExistingFilesPermissions(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX permission bits are not meaningfully enforced on Windows');
+        }
+
+        $path = $this->path('perms.txt');
+        file_put_contents($path, 'before');
+        chmod($path, 0640);
+        clearstatcache(true, $path);
+
+        File::write($path, 'after');
+        clearstatcache(true, $path);
+
+        self::assertSame(0640, fileperms($path) & 0777, 'a rewrite must not silently change the mode');
+    }
+
+    public function testWriteGivesANewFileTheDefaultModeNotTheTempFilesRestrictiveOne(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX permission bits are not meaningfully enforced on Windows');
+        }
+
+        $path = $this->path('newfile.txt');
+
+        File::write($path, 'content');
+        clearstatcache(true, $path);
+
+        // tempnam() creates 0600; the target must not inherit it.
+        self::assertSame(0644, fileperms($path) & 0777);
+    }
+
+    public function testWriteThrowsWhenTheDirectoryDoesNotExist(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        File::write($this->path('no/such/dir/file.txt'), 'content');
+    }
+
+    /**
+     * The mechanism behind the atomicity guarantee: a write must **replace** the file, not
+     * truncate and refill it in place. A replaced file is a different file — a new inode — so
+     * the inode changing across a rewrite is a deterministic, single-process observation of the
+     * property, with no concurrency to make it flaky.
+     *
+     * This is the assertion a naive `file_put_contents($path, …)` fails: truncating in place
+     * keeps the inode. Verified by planting exactly that implementation and watching this test
+     * go red — which is what makes it a test of atomicity rather than a test that the write
+     * happened at all.
+     */
+    public function testWriteReplacesTheFileRatherThanTruncatingItInPlace(): void
+    {
+        $path = $this->path('atomic.txt');
+        File::write($path, str_repeat('A', 4096));
+
+        clearstatcache(true, $path);
+        $before = fileinode($path);
+        self::assertNotFalse($before, 'this platform must report inodes for the test to mean anything');
+
+        File::write($path, str_repeat('B', 2048));
+
+        clearstatcache(true, $path);
+        $after = fileinode($path);
+
+        self::assertNotSame(
+            $before,
+            $after,
+            'the inode did not change, so the file was modified in place rather than replaced — '
+            . 'an in-place write is observable half-done by a concurrent reader',
+        );
+        self::assertSame(str_repeat('B', 2048), file_get_contents($path));
+    }
+
+    /**
+     * The atomicity guarantee itself, observed directly: a reader that opened the file *before*
+     * a rewrite goes on reading the complete previous contents from its own handle. It never
+     * sees a truncated or half-written file, because the replacement gave the target a new inode
+     * and left the old one intact until the last handle closed.
+     *
+     * POSIX only. Windows refuses to `rename()` over a target another handle holds open — the
+     * finding that shaped this design and is recorded in ADR-0005 — so the scenario cannot exist
+     * there.
+     */
+    public function testAnAlreadyOpenReaderKeepsSeeingTheCompletePreviousContents(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('Windows refuses to rename over a target that is held open (ADR-0005)');
+        }
+
+        $path = $this->path('atomic-open-handle.txt');
+        $old = str_repeat('A', 100_000);
+        $new = str_repeat('B', 40_000);
+
+        File::write($path, $old);
+
+        $reader = fopen($path, 'rb');
+        self::assertNotFalse($reader);
+
+        try {
+            File::write($path, $new);
+
+            $observed = stream_get_contents($reader);
+
+            self::assertSame($old, $observed, 'an open reader must not observe the replacement at all');
+            self::assertSame($new, file_get_contents($path), 'a fresh read must see the new contents');
+        } finally {
+            fclose($reader);
+        }
+    }
+
+    // ----------------------------------------------------------------- read
+
+    public function testReadReturnsTheFullContents(): void
+    {
+        $path = $this->path('read.txt');
+        $contents = str_repeat("payload line\n", 5000);
+        file_put_contents($path, $contents);
+
+        self::assertSame($contents, File::read($path));
+    }
+
+    public function testReadRoundTripsWhatWriteStored(): void
+    {
+        $path = $this->path('roundtrip.bin');
+        $payload = random_bytes(8192);
+
+        File::write($path, $payload);
+
+        self::assertSame($payload, File::read($path));
+    }
+
+    public function testReadReturnsEmptyStringForAnEmptyFile(): void
+    {
+        $path = $this->path('emptyread.txt');
+        touch($path);
+
+        self::assertSame('', File::read($path));
+    }
+
+    public function testReadThrowsWhenTheFileIsMissing(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('not a file');
+
+        File::read($this->path('absent.txt'));
+    }
+
+    public function testReadThrowsWhenGivenADirectory(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('not a file');
+
+        File::read($this->dir);
+    }
+
+    // ----------------------------------------------------------------- mime
+
+    /**
+     * The distinguishing behaviour of item 23: detection reads the *contents*. A PNG named
+     * `.txt` is a PNG. This is the test that separates a real detector from one that maps
+     * extensions, and it is why an extension is never trusted — a caller-supplied `.jpg` that
+     * is really a PHP script is the classic upload vulnerability.
+     */
+    public function testMimeIgnoresTheExtensionAndReadsTheContents(): void
+    {
+        // A genuinely valid 1x1 PNG, not just the 8-byte signature: this libmagic requires the
+        // IHDR chunk before it will commit to image/png, and a signature-only fixture is
+        // reported as application/octet-stream. Verified rather than assumed — and a real file
+        // is portable across libmagic versions in a way that relying on one version's leniency
+        // would not be.
+        $png = base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==',
+            true,
+        );
+        self::assertIsString($png);
+
+        $misnamed = $this->path('actually-a-png.txt');
+        File::write($misnamed, $png);
+
+        self::assertSame('image/png', File::mime($misnamed));
+    }
+
+    public function testMimeDetectsGifFromContentUnderAMisleadingExtension(): void
+    {
+        // A second format, so the claim "detection reads content" rests on more than one
+        // fixture: GIF's magic is self-sufficient where PNG's signature alone is not.
+        $path = $this->path('actually-a-gif.pdf');
+        File::write($path, 'GIF89a' . str_repeat("\x00", 32));
+
+        self::assertSame('image/gif', File::mime($path));
+    }
+
+    public function testMimeDetectsPlainTextRegardlessOfAMisleadingExtension(): void
+    {
+        $path = $this->path('actually-text.png');
+        File::write($path, "just some ordinary prose, nothing binary about it\n");
+
+        self::assertSame('text/plain', File::mime($path));
+    }
+
+    public function testMimeThrowsWhenTheFileIsMissing(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('not a file');
+
+        File::mime($this->path('absent.bin'));
+    }
+
+    // -------------------------------------------------------- exception type
+
+    public function testEveryFailureIsCatchableThroughTheLibraryMarker(): void
+    {
+        // FileException joins the ADR-0004 family, so a consumer catching everything this
+        // library raises catches filesystem failures too — asserted here rather than assumed
+        // from the class declaration.
+        try {
+            File::read($this->path('absent.txt'));
+            self::fail('expected a FileException');
+        } catch (\D4np\Utils\Support\UtilsThrowable $e) {
+            self::assertInstanceOf(FileException::class, $e);
+        }
+    }
+}


### PR DESCRIPTION
## Context

Roadmap item **2.3**, flagged `severity:medium` for "concurrency/atomicity semantics" — which
turned out to be the right flag for the right reason. `FileException`, built in item 2.1, gets
its first real caller.

## The finding that shaped the design

RFC-0001 asks for `write()`/`read()` that are *"flock-guarded, atomic write via temp+rename"*.
**Implementing that literally is impossible**, and the reason is silent and platform-specific.
Measured directly, PHP 8.3.1 / Windows 11:

| Scenario | Result |
|---|---|
| `rename()` over an existing target, no handles open | **OK** |
| `rename()` over an existing target while a handle holds it open | **FAILS** |

POSIX unlinks the old directory entry and lets existing handles keep reading the old inode;
Windows refuses the replacement outright. So the natural implementation — lock the target, write
the temp file, rename, release — **breaks every atomic write on Windows**, because the lock
handle is precisely what makes the rename fail. And moving the release earlier does not rescue
it: the `rename()` *is* the mutation, so a critical section ending before it serialises nothing.

Hence **[ADR-0005](docs/adr/0005-atomic-file-writes-with-a-sidecar-lock.md)**: the lock goes on a
`<path>.lock` **sidecar**, never the object of a rename, so it can be held across the whole
prepare-and-replace sequence. Cost stated rather than hidden — the sidecar stays, because
unlinking a lock file is itself racy.

A second silent trap, caught from the manual rather than after a bug report: **`tempnam()` falls
back to the system temp directory** when it cannot use the one it was given, which would put the
temp file on another filesystem and degrade `rename()` to copy-then-delete with atomicity gone
and no error anywhere. The returned path is now verified to be in the intended directory.

## Change

`D4np\Utils\Support\File` — `write()`, `read()`, `mime()`:

- `write()` replaces atomically; `chmod` happens **before** the rename so the target never
  briefly carries `tempnam()`'s `0600`; an existing file's permissions are preserved; a short
  write is a failure.
- `read()` reads under a shared lock — redundant against this library's own writer (an atomic
  replacement is never observable half-done), kept because it cooperates with third-party
  in-place writers.
- `mime()` detects from **contents** via `ext-fileinfo`, never the filename.
- Every failure throws `FileException` instead of returning `false`, per ADR-0004.

## ⚠️ The first atomicity test was vacuous — recorded, not quietly fixed

The original test was named `testConcurrentReadsNeverObserveAPartialFile`. It wrote, then read
back, then asserted the content was one complete version or the other — forty times.

**It passed against a deliberately planted naive `file_put_contents($path, …)` implementation.**

Of course it did: a single-process sequential test contains no concurrency. `write()` returns,
*then* the read happens — a truncating write has finished truncating by then too. It asserted
that writing works, under a name claiming it asserted atomicity. Shipped, it would have been a
green gate over an unverified guarantee, and the name would have stopped anyone noticing.

Replaced with two tests that **do** discriminate, after probing the platform for an observation
that can:

1. **`testWriteReplacesTheFileRatherThanTruncatingItInPlace`** — the target's **inode must
   change** across a rewrite. A replaced file is a different file; an in-place write keeps the
   inode. Deterministic, single-process, no flakiness — and `fileinode()` was verified to report
   real values on Windows too, so it runs everywhere. **Re-planted the naive implementation and
   watched it go red.**
2. **`testAnAlreadyOpenReaderKeepsSeeingTheCompletePreviousContents`** — the guarantee itself,
   observed directly. POSIX only; skipped on Windows for the reason in the table above — the same
   finding, now load-bearing twice.

A third candidate is worth recording as rejected: "writing to a read-only file in a writable
directory succeeds" discriminates on POSIX (truncating open fails, rename succeeds) — but on
Windows the rename fails too, so it would have looked like a bug in the *correct* implementation.
Probed before adopting, rejected on evidence.

## `mime()`'s fixture was also corrected on evidence

The first fixture was the 8-byte PNG signature plus zeros — reported as
`application/octet-stream`, because this libmagic wants the IHDR chunk before committing to
`image/png`. Probed four fixtures (signature-only PNG, a real 1×1 PNG, `GIF89a`, `%PDF-1.4`) and
switched to a genuinely valid PNG, which is also more portable across libmagic versions than
relying on one version's leniency. Two formats now covered, under misleading extensions in both
directions (`.txt` holding a PNG, `.png` holding prose).

## Verification

- **71 tests, 142 assertions**, 3 skipped — all three Windows-only (two POSIX permission-bit
  tests, one open-handle atomicity test). **They run on CI**, so the permission-preservation logic
  is verified there rather than here; flagged honestly rather than claimed.
- `vendor/bin/phpstan analyse` (max) → clean on the first pass, second item running
- PHP-CS-Fixer clean on every new file
- `consistency_lint` and `action_pin_lint --verify-upstream` → both OK

**Cross-links:** RFC-0001 · ADR-0004, ADR-0005 · roadmap item 2.3 · milestone `v0.2.0`.
Type label: `feat` (declared in `.github/labels.yml`, still not imported); `enhancement` set as
the closest available default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
