### PR TITLE
feat(support): add Env::get() boolean coercion and the Json wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- `D4np\Utils\Support\Env::get()`: boolean coercion built on PHP's own
+  `filter_var(…, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)` — fixes the classic bug where
+  `getenv('FLAG')` returns the truthy **string** `"false"`. An explicitly empty variable
+  (`FOO=""`) returns `''`, not `false` — a deliberate exception, since the coercion recognises
+  yes/no-shaped words, not "unset-looking" values.
+- `D4np\Utils\Support\Json::encode()`/`decode()`: always pass `JSON_THROW_ON_ERROR`, wrapping
+  the native `\JsonException` via `JsonException::wrap()` (RFC-0001 R-7) so a caller can never
+  forget the flag and get a silent `null`/`false` back.
 - `D4np\Utils\Support\File` (**ADR-0005**): `write()` replaces the target **atomically** — a
   temporary file in the same directory, `rename()`d over — so a reader never observes a
   half-written file; writers are serialised through an exclusive `flock()` on a `<path>.lock`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-03 — File: atomic writes, and a test that was lying](docs/journal/2026/08/2026-08-03-file-atomic-io.md).
+  [2026-08-03 — Env::get() and Json: two functions, three probed gotchas](docs/journal/2026/08/2026-08-03-env-json.md).
 
 ## Model & effort routing (advisory)
 
@@ -108,7 +108,7 @@ The foundation every group depends on — the deptrac-legal bottom layer (RFC-00
 - [x] 2.3 `File`: flock-guarded `write()`/`read()`, atomic write via temp+rename, Fileinfo
       `mime()` (RFC-0001) (severity:medium — concurrency/atomicity semantics) —
       route: standard / medium · **ADR-0005**
-- [ ] 2.4 `Env::get()` with boolean coercion; `Json::encode()/decode()` wrapping native
+- [x] 2.4 `Env::get()` with boolean coercion; `Json::encode()/decode()` wrapping native
       `\JsonException` (RFC-0001 R-7) — route: fast / low
 - [ ] 2.5 Shared reflection-metadata cache, consumed by the Dto hydrator and the Container
       (RFC-0001 R-2) (sets-pattern) — route: frontier-reasoning / high

--- a/docs/journal/2026/08/2026-08-03-env-json.md
+++ b/docs/journal/2026/08/2026-08-03-env-json.md
@@ -1,0 +1,79 @@
+# 2026-08-03 — `Env::get()` and `Json`: two functions, three probed gotchas
+
+Roadmap item **2.4** — the smallest item of the milestone by line count, and the one where
+`JsonException::wrap()` (built in item 2.1, unused since) finally gets a caller. Route: no
+signals, floor `fast / low`; session model matched.
+
+## `Env::get()` — built on a standard primitive, not a hand-rolled token list
+
+Spec FR-24 names the bug directly: `getenv('FLAG')` can return the **string** `"false"`, and
+`if ($value)` is `true` for that string. Rather than inventing a true/false token list, `Env`
+delegates to `filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)` — verified
+directly before writing a line of the class:
+
+```
+"true"/"TRUE"/" true " -> true    "false"/"0"/"off" -> false    "maybe"/"2"/"null" -> NULL
+```
+
+Case-insensitive, trimmed, and an unrecognised value returns `NULL` rather than guessing —
+exactly the contract `Env::get()` needed, already implemented and already the PHP-idiomatic way
+to ask the question.
+
+**One gotcha the same probe surfaced**: `filter_var('', FILTER_VALIDATE_BOOLEAN, …)` returns
+`false`, not `NULL`. Left unhandled, `Env::get()` would silently turn an intentionally blank
+`FOO=""` into the boolean `false` — conflating "unset-looking" with "negative". `Env::get()`
+special-cases the empty string to return `''` unchanged, documented as a deliberate exception in
+the docblock rather than left implicit.
+
+A second, related distinction: `getenv()` itself returns `false` (the bool) for **unset** and
+`''` (the string) for **set-but-empty** — two different values. `Env::get()`'s unset check uses
+`===`, and a probe with `==` instead (see below) proved why that matters.
+
+## `Json` — the wrapper `JsonException` was built for
+
+`encode()`/`decode()` pass `JSON_THROW_ON_ERROR` unconditionally and catch-and-rewrap through
+`JsonException::wrap()` (RFC-0001 R-7), preserving the native exception as `getPrevious()`.
+Nothing novel here — the design was already settled at item 2.1; this is where it finally runs.
+
+## Proved non-vacuous, three ways
+
+Each a real defect planted, confirmed caught, reverted, full suite re-confirmed green:
+
+1. **Skipped boolean coercion entirely** (the classic bug, reintroduced) → **18 of 23** `EnvTest`
+   failures, including the whole coercion-table property test.
+2. **Stopped wrapping the native exception** (`new JsonException($e->getMessage())` instead of
+   `JsonException::wrap($e)`) → the one test asserting `getPrevious()` stays reachable failed
+   with `null is an instance of JsonException` — exactly the loss the design exists to prevent.
+3. **Loosened the unset check from `===` to `==`** → the unset-vs-empty distinction test failed:
+   `''` compares loose-equal to `false` in PHP, so `getenv()`'s two distinct "nothing here"
+   signals collapse into one, and a variable explicitly set to `""` would wrongly fall through
+   to the caller's default.
+
+## PHPStan max: three findings, all real
+
+- `json_encode()`/`json_decode()`'s native signature narrows `$depth` to `int<1, max>`; a plain
+  `int $depth` parameter admits `0` or negative, which PHPStan correctly refuses to pass through
+  silently. Fixed with a `@param int<1, max> $depth` docblock on both methods — PHP itself has no
+  bounded-integer type, so the annotation is what closes the gap without changing the runtime
+  signature.
+- A test asserted `(bool) $value` was `false` immediately after asserting `$value` itself was
+  `false` — statically decidable from the first assertion, so PHPStan called it
+  already-narrowed. Dropped, same reasoning as item 2.1's `assertNotInstanceOf` finding: a
+  static guarantee that holds at every call site is strictly stronger than one runtime check.
+
+## State
+
+116 tests, 192 assertions, 3 skipped (the Windows-only `File` tests from item 2.3; they run on
+CI). PHPStan max clean. `Env` and `Json` bring the file count in `Support/` to eleven.
+
+## Next
+
+- **2.5 — the shared reflection-metadata cache**, flagged `sets-pattern` again: consumed by the
+  DTO hydrator (Milestone 3) and the Container (Milestone 6), per imported ADR-001. The last
+  Support-layer item with new design surface.
+- **2.6 — the T-05 property tests** are formally still open as a roadmap line, though two of its
+  three named cases already exist: slug idempotence (item 2.2) and Json round-trips (this item).
+  Only the `Env` coercion table remains, and it landed here too. Whether 2.6 is "done" or
+  reduced to a pointer at what already exists is the maintainer's call.
+- **2.7** (the coverage floor, stated in `AGENTS.md` §10 and NFR-07, still ungated) — unchanged
+  since item 2.1 filed it.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-03 — Env::get() and Json: two functions, three probed gotchas](2026/08/2026-08-03-env-json.md)
 - [2026-08-03 — File: atomic writes, and a test that was lying](2026/08/2026-08-03-file-atomic-io.md)
 - [2026-08-03 — Str::slug() / uuid() / random()](2026/08/2026-08-03-str-slug-uuid-random.md)
 - [2026-08-03 — Milestone 2 opens: the exception hierarchy](2026/08/2026-08-03-m2-exception-hierarchy.md)

--- a/src/main/php/d4np/utils/Support/Env.php
+++ b/src/main/php/d4np/utils/Support/Env.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * Environment variable reads with correct boolean coercion (spec §2 item 24).
+ *
+ * The bug this exists to fix: `getenv('FEATURE_X')` can return the **string** `"false"`, and
+ * `if ($value)` is `true` for that string — a feature flag set to disable something silently
+ * enables it instead. `Env::get()` recognises boolean-shaped values and returns a real `bool`.
+ */
+final class Env
+{
+    private function __construct()
+    {
+        // Static-only: no instances.
+    }
+
+    /**
+     * The value of environment variable `$key`, with boolean-shaped values coerced to `bool`.
+     *
+     * Built on `filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)` — PHP's own
+     * boolean-recognition primitive, not a hand-rolled token list — which accepts (case-
+     * insensitively, trimmed): `"true"`/`"1"`/`"yes"`/`"on"` as `true` and
+     * `"false"`/`"0"`/`"no"`/`"off"` as `false`. A value it does not recognise is returned as the
+     * raw string unchanged; `Env::get()` never invents a coercion `filter_var` does not already
+     * define.
+     *
+     * **One deliberate exception**: an environment variable explicitly set to the empty string
+     * is returned as `''`, not coerced. `filter_var('', FILTER_VALIDATE_BOOLEAN, …)` returns
+     * `false` for empty input — verified directly — which would silently turn `FOO=""`
+     * (a real pattern: an intentionally blank placeholder) into the boolean `false`. Boolean
+     * coercion is for recognising yes/no-shaped words, not for treating "unset-looking" as
+     * "negative".
+     *
+     * `$default` is returned only when the variable is **unset**. `getenv()` itself is how that
+     * is distinguished from "set to the empty string": it returns `false` (the bool) when unset
+     * and `''` (the string) when set-but-empty — two different values this method must not
+     * conflate, which is why the unset check comes first and compares with `===`.
+     */
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        $raw = getenv($key);
+        if ($raw === false) {
+            return $default;
+        }
+
+        if ($raw === '') {
+            return '';
+        }
+
+        $coerced = filter_var($raw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        return $coerced ?? $raw;
+    }
+}

--- a/src/main/php/d4np/utils/Support/Json.php
+++ b/src/main/php/d4np/utils/Support/Json.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+use JsonException as NativeJsonException;
+
+/**
+ * `json_encode()`/`json_decode()` wrappers that always throw on failure (spec §2 item 25).
+ *
+ * Both native functions accept `JSON_THROW_ON_ERROR`, which turns a silent `false`/`null`
+ * return into a thrown `\JsonException` — but a caller has to remember to pass the flag every
+ * time, and forgetting it is how a truncated payload becomes a `null` nobody checked. These
+ * wrappers pass it unconditionally and rethrow through {@see JsonException::wrap()}
+ * (RFC-0001 R-7), so the original is never lost — it stays reachable via `getPrevious()`.
+ */
+final class Json
+{
+    private function __construct()
+    {
+        // Static-only: no instances.
+    }
+
+    /**
+     * @param int<1, max> $depth
+     *
+     * @throws JsonException if `$value` cannot be encoded — a resource, `NAN`/`INF`, or a
+     *                        depth beyond `$depth`.
+     */
+    public static function encode(mixed $value, int $flags = 0, int $depth = 512): string
+    {
+        try {
+            return json_encode($value, $flags | JSON_THROW_ON_ERROR, $depth);
+        } catch (NativeJsonException $e) {
+            throw JsonException::wrap($e);
+        }
+    }
+
+    /**
+     * @param int<1, max> $depth
+     *
+     * @throws JsonException if `$json` is not valid JSON, or nests beyond `$depth`.
+     */
+    public static function decode(string $json, bool $associative = true, int $depth = 512, int $flags = 0): mixed
+    {
+        try {
+            return json_decode($json, $associative, $depth, $flags | JSON_THROW_ON_ERROR);
+        } catch (NativeJsonException $e) {
+            throw JsonException::wrap($e);
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Support/EnvTest.php
+++ b/src/test/php/d4np/utils/Support/EnvTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Env;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Env::get()` — spec §2 item 24, and the T-05 boolean-coercion property test spec §7 names.
+ *
+ * Every variable used here carries a per-test unique name (a random suffix) so parallel or
+ * repeated runs never collide over process-global environment state, and `tearDown()` always
+ * `putenv()`-unsets whatever the test set — including on failure, since PHPUnit still calls it.
+ */
+final class EnvTest extends TestCase
+{
+    /** @var list<string> */
+    private array $setKeys = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->setKeys as $key) {
+            putenv($key);
+        }
+        $this->setKeys = [];
+    }
+
+    private function withEnv(string $value): string
+    {
+        $key = 'D4NP_UTILS_ENV_TEST_' . bin2hex(random_bytes(8));
+        putenv("{$key}={$value}");
+        $this->setKeys[] = $key;
+
+        return $key;
+    }
+
+    /**
+     * The T-05 property test (spec §7): the coercion table. One row per recognised token, both
+     * cases, so a regression that stops recognising "On" but keeps "on" is caught.
+     *
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function booleanTokens(): iterable
+    {
+        foreach (['true', 'True', 'TRUE', '1', 'yes', 'Yes', 'on', 'On'] as $token) {
+            yield "\"{$token}\" is true" => [$token, true];
+        }
+        foreach (['false', 'False', 'FALSE', '0', 'no', 'No', 'off', 'Off'] as $token) {
+            yield "\"{$token}\" is false" => [$token, false];
+        }
+    }
+
+    #[DataProvider('booleanTokens')]
+    public function testBooleanCoercionTable(string $rawValue, bool $expected): void
+    {
+        $key = $this->withEnv($rawValue);
+
+        self::assertSame($expected, Env::get($key));
+    }
+
+    public function testTheClassicBugIsFixedStringFalseIsNotTruthy(): void
+    {
+        // The bug this method exists to fix, spelled out: getenv() alone returns the STRING
+        // "false", and `if ($value)` is true for it. Env::get() must not repeat that mistake.
+        $key = $this->withEnv('false');
+
+        self::assertFalse(Env::get($key));
+        // Not asserted separately: casting the result to bool. PHPStan already knows the
+        // result is `false` from the assertion above (an already-narrowed, statically
+        // decidable check) — a redundant runtime assertion would prove nothing more.
+    }
+
+    public function testSurroundingWhitespaceIsTrimmedBeforeCoercion(): void
+    {
+        $key = $this->withEnv('  true  ');
+
+        self::assertTrue(Env::get($key));
+    }
+
+    public function testAnUnrecognisedValueIsReturnedAsTheRawString(): void
+    {
+        $key = $this->withEnv('postgres://localhost/db');
+
+        self::assertSame('postgres://localhost/db', Env::get($key));
+    }
+
+    public function testANumericNonBooleanValueIsReturnedUnchanged(): void
+    {
+        // "2" is not a recognised boolean token (only "0"/"1" are), so it must pass through as
+        // the string "2" rather than being coerced or silently mangled.
+        $key = $this->withEnv('2');
+
+        self::assertSame('2', Env::get($key));
+    }
+
+    public function testAnExplicitlyEmptyValueIsReturnedAsEmptyStringNotFalse(): void
+    {
+        // The deliberate exception: filter_var('', FILTER_VALIDATE_BOOLEAN, ...) returns false,
+        // which would silently turn an intentional FOO="" into the boolean false. Verified
+        // directly against filter_var before writing Env::get() this way.
+        $key = $this->withEnv('');
+
+        self::assertSame('', Env::get($key));
+    }
+
+    public function testAnUnsetVariableReturnsTheDefault(): void
+    {
+        $key = 'D4NP_UTILS_ENV_TEST_DEFINITELY_UNSET_' . bin2hex(random_bytes(8));
+
+        self::assertSame('fallback', Env::get($key, 'fallback'));
+        self::assertNull(Env::get($key));
+    }
+
+    public function testAnUnsetVariableIsNotConflatedWithAnEmptyOne(): void
+    {
+        // getenv() itself distinguishes these: false (bool) for unset, '' (string) for
+        // set-but-empty. This is the pair of assertions that would fail if Env::get() used a
+        // loose (==) comparison instead of ===.
+        $unset = 'D4NP_UTILS_ENV_TEST_UNSET_' . bin2hex(random_bytes(8));
+        $empty = $this->withEnv('');
+
+        self::assertNull(Env::get($unset), 'unset must fall through to the default (null here)');
+        self::assertSame('', Env::get($empty), 'set-but-empty must return the empty string, not the default');
+    }
+}

--- a/src/test/php/d4np/utils/Support/JsonTest.php
+++ b/src/test/php/d4np/utils/Support/JsonTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Json;
+use D4np\Utils\Support\JsonException;
+use D4np\Utils\Support\UtilsThrowable;
+use JsonException as NativeJsonException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** `Json` — spec §2 item 25, and the T-05 round-trip property test spec §7 names. */
+final class JsonTest extends TestCase
+{
+    /**
+     * The T-05 property test (spec §7): round-trips. Each value must survive
+     * `decode(encode($value))` unchanged — the property `Json` exists to guarantee.
+     *
+     * @return iterable<string, array{mixed}>
+     */
+    public static function roundTripValues(): iterable
+    {
+        yield 'null' => [null];
+        yield 'true' => [true];
+        yield 'false' => [false];
+        yield 'zero' => [0];
+        yield 'negative int' => [-42];
+        yield 'float' => [3.14159];
+        yield 'empty string' => [''];
+        yield 'ascii string' => ['hello world'];
+        yield 'unicode string' => ['Café — Ångström — Токио — 🎉'];
+        yield 'string with a literal quote and backslash' => ['she said "hi\\"'];
+        yield 'empty list' => [[]];
+        yield 'flat list' => [[1, 2, 3]];
+        yield 'assoc array' => [['a' => 1, 'b' => ['c' => 2, 'd' => [3, 4]]]];
+        yield 'array with null and bool members' => [['x' => null, 'y' => true, 'z' => false]];
+    }
+
+    #[DataProvider('roundTripValues')]
+    public function testRoundTrip(mixed $value): void
+    {
+        self::assertSame($value, Json::decode(Json::encode($value)));
+    }
+
+    public function testEncodeProducesTheExpectedJsonText(): void
+    {
+        self::assertSame('{"a":1,"b":[2,3]}', Json::encode(['a' => 1, 'b' => [2, 3]]));
+    }
+
+    public function testDecodeAssociativeReturnsAnArrayByDefault(): void
+    {
+        $result = Json::decode('{"a":1}');
+
+        self::assertIsArray($result);
+        self::assertSame(['a' => 1], $result);
+    }
+
+    public function testDecodeNonAssociativeReturnsAnObject(): void
+    {
+        $result = Json::decode('{"a":1}', false);
+
+        self::assertInstanceOf(\stdClass::class, $result);
+        self::assertSame(1, $result->a);
+    }
+
+    public function testDecodeThrowsOnMalformedJsonAndWrapsTheNativeException(): void
+    {
+        try {
+            Json::decode('{"a": invalid}');
+            self::fail('expected a JsonException');
+        } catch (JsonException $e) {
+            self::assertInstanceOf(NativeJsonException::class, $e->getPrevious(), 'the native exception must stay reachable');
+        }
+    }
+
+    public function testEncodeThrowsOnAResourceWhichCannotBeEncoded(): void
+    {
+        $resource = fopen('php://memory', 'rb');
+        self::assertIsResource($resource);
+
+        try {
+            $this->expectException(JsonException::class);
+            Json::encode($resource);
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function testEncodeThrowsOnNanWhichHasNoJsonRepresentation(): void
+    {
+        $this->expectException(JsonException::class);
+
+        Json::encode(NAN);
+    }
+
+    public function testDecodeThrowsWhenNestingExceedsTheDepthLimit(): void
+    {
+        $this->expectException(JsonException::class);
+
+        Json::decode('[[[[[1]]]]]', true, 3);
+    }
+
+    public function testEveryFailureIsCatchableThroughTheLibraryMarker(): void
+    {
+        try {
+            Json::decode('not json');
+            self::fail('expected a JsonException');
+        } catch (UtilsThrowable $e) {
+            self::assertInstanceOf(JsonException::class, $e);
+        }
+    }
+}


### PR DESCRIPTION
## Context

Roadmap item **2.4** — the smallest item of the milestone by line count, and the one where
`JsonException::wrap()` (built in item 2.1, unused since) finally gets a caller.

## Change

**`Env::get()`** fixes the bug spec FR-24 names directly: `getenv('FLAG')` can return the
**string** `"false"`, and `if ($value)` is `true` for it. Built on
`filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)` rather than a hand-rolled
token list — PHP's own boolean-recognition primitive, verified directly before writing the
class (case-insensitive, trimmed; `NULL` for anything unrecognized).

The same probe surfaced a real gotcha: `filter_var('', …)` returns `false`, which would silently
turn an intentionally blank `FOO=""` into the boolean `false`. `Env::get()` special-cases the
empty string to return `''` unchanged — documented as deliberate, not left implicit. A second
distinction: `getenv()` itself returns `false` (bool) for **unset** and `''` (string) for
**set-but-empty** — the unset check uses `===` on purpose.

**`Json::encode()`/`decode()`** pass `JSON_THROW_ON_ERROR` unconditionally and rethrow through
`JsonException::wrap()`, preserving the native exception as `getPrevious()` (RFC-0001 R-7) — the
design settled at item 2.1, running for the first time.

## Verification — proved non-vacuous, three ways

Each a real defect planted, confirmed caught, reverted, full suite re-confirmed green:

1. **Skipped boolean coercion entirely** (the classic bug, reintroduced) → **18 of 23**
   `EnvTest` failures, including the whole coercion-table property test.
2. **Reverted `JsonException::wrap()` to a plain rethrow** → lost `getPrevious()`; the test
   asserting it stays reachable failed with `null is an instance of JsonException`.
3. **Loosened the unset check from `===` to `==`** → collapsed `getenv()`'s two distinct
   "nothing here" signals (`false` vs `''`) into one; a variable explicitly set to `""` would
   wrongly fall through to the caller's default.

### PHPStan max: three findings, all real

- `json_encode()`/`json_decode()`'s native signature narrows `$depth` to `int<1, max>`; a plain
  `int $depth` admits `0` or negative. Closed with a `@param int<1, max> $depth` docblock on
  both methods — PHP has no bounded-integer type, so the annotation is what closes the gap
  without changing the runtime signature.
- One already-narrowed test assertion (redundant given the assertion immediately before it),
  dropped rather than kept as noise PHPStan would otherwise flag — same reasoning as item 2.1's
  `assertNotInstanceOf` finding.

### Results

- **116 tests, 192 assertions** (3 skipped — the Windows-only `File` tests from item 2.3; they
  run on CI)
- PHPStan max clean; PHP-CS-Fixer clean on every new file
- `consistency_lint` and `action_pin_lint --verify-upstream` → both OK

## A note for the maintainer

Roadmap item **2.6** ("T-05 property tests: Json round-trips, slug idempotence, Env coercion
table") names three cases; all three now exist — slug idempotence landed with item 2.2, Json
round-trips and the Env coercion table land here. Whether 2.6 should be ticked as done, or kept
as a pointer at tests that already exist elsewhere, is a call for you rather than the agent.

**Cross-links:** RFC-0001 · roadmap item 2.4 · milestone `v0.2.0`. Type label: `feat`
(declared in `.github/labels.yml`, still not imported); `enhancement` set as the closest
available default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
