### PR TITLE
feat(support): add the shared reflection-metadata cache

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -23,6 +23,11 @@ return (new Config())
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'single_quote' => true,
         'trailing_comma_in_multiline' => true,
-        'no_superfluous_phpdoc_tags' => true,
+        // allow_mixed is deliberate. The rule's default strips `@param mixed $x`, but on a
+        // parameter with no native type that annotation is the ONLY thing giving PHPStan (at
+        // max level) a type — removing it turns a clean file into a `missingType.parameter`
+        // error. The two tools disagree by default; this is where the disagreement is settled,
+        // rather than by suppressing whichever one complains second.
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
     ])
     ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- `D4np\Utils\Support\ReflectionCache` with `ClassMetadata`/`ParameterMetadata` (**ADR-0006**):
+  the single per-class constructor-metadata cache imported ADR-001 commits to, shared by the DTO
+  hydrator (M3) and the Container (M6) — reflection is paid once per class, every later lookup is
+  an array hit, which is what NFR-01/NFR-02 rest on. Instance-scoped, no interface, no static
+  accessor; union and intersection types are recorded as un-autowirable with their declaration
+  preserved for diagnostics, and a failed reflection is not cached.
 - `D4np\Utils\Support\Env::get()`: boolean coercion built on PHP's own
   `filter_var(…, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)` — fixes the classic bug where
   `getenv('FLAG')` returns the truthy **string** `"false"`. An explicitly empty variable

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-03 — Env::get() and Json: two functions, three probed gotchas](docs/journal/2026/08/2026-08-03-env-json.md).
+  [2026-08-04 — The shared reflection cache: designing for consumers that do not exist yet](docs/journal/2026/08/2026-08-04-reflection-metadata-cache.md).
 
 ## Model & effort routing (advisory)
 
@@ -110,8 +110,8 @@ The foundation every group depends on — the deptrac-legal bottom layer (RFC-00
       route: standard / medium · **ADR-0005**
 - [x] 2.4 `Env::get()` with boolean coercion; `Json::encode()/decode()` wrapping native
       `\JsonException` (RFC-0001 R-7) — route: fast / low
-- [ ] 2.5 Shared reflection-metadata cache, consumed by the Dto hydrator and the Container
-      (RFC-0001 R-2) (sets-pattern) — route: frontier-reasoning / high
+- [x] 2.5 Shared reflection-metadata cache, consumed by the Dto hydrator and the Container
+      (RFC-0001 R-2) (sets-pattern) — route: frontier-reasoning / high · **ADR-0006**
 - [ ] 2.6 T-05 property tests: Json round-trips, slug idempotence, Env coercion table
       (RFC-0001) — route: fast / low
 - [ ] 2.7 Measure and enforce the coverage floor. `AGENTS.md` §10 and spec NFR-07 both state

--- a/docs/adr/0006-shared-reflection-metadata-cache.md
+++ b/docs/adr/0006-shared-reflection-metadata-cache.md
@@ -1,0 +1,121 @@
+# ADR-0006: Shape the shared reflection-metadata cache as plain instances, without an interface
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 2.5 · [RFC-0001](../rfc/0001-egl-utils-library.md) R-2 ·
+  imported [ADR-001](../../.specs/d4np_php_adr_001_di_container.md) · spec FR-01, FR-04,
+  NFR-01, NFR-02 · [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md)
+
+## Context
+
+Imported ADR-001 commits to **one** metadata cache: *"the reflection cache used by the container
+is shared infrastructure with the DTO hydrator (one metadata cache)"*. RFC-0001 R-2 places it in
+`Support`, because that is the only layer both the `Dto` and `Container` groups may depend on
+without breaking the no-cross-group-imports rule. NFR-01 (≤ 5 µs/DTO warm) and NFR-02 (≤ 2 µs
+warm singleton resolve) both rest on it: reflection is paid once per class, everything after is
+an array hit.
+
+What neither document settles is the *shape*, and roadmap item 2.5 is flagged `sets-pattern` —
+whatever lands here is what Milestone 3's hydrator and Milestone 6's Container will both build
+on. Four questions had to be answered before writing the first class, at a point where **neither
+consumer exists yet**. That is the real constraint: every decision risks either under-building
+(a consumer blocked later) or speculating (fields and abstractions nobody ever uses).
+
+## Decision
+
+**A concrete `ReflectionCache` returning immutable `ClassMetadata` / `ParameterMetadata` value
+objects, instance-scoped, with no interface and no static accessor.**
+
+### Every metadata field traces to a stated requirement
+
+Nothing is recorded because it might be useful:
+
+| Field | Required by |
+|---|---|
+| `name` | FR-01 — matching a payload key to a constructor parameter |
+| `type`, `isBuiltin` | FR-01 (type-check a scalar vs recurse into a nested DTO) and FR-04 (resolve a class vs refuse) |
+| `allowsNull`, `hasDefault`, `default` | RFC-0001 R-4 — "neither nullable nor defaulted" is exactly what makes a key required. `hasDefault` cannot be folded into `default`: a declared default of `null` is otherwise indistinguishable from having none |
+| `declaredType` | imported ADR-001 requires the Container to *fail loudly* on what it cannot autowire; a refusal that names the type it saw is what makes that useful |
+| `isVariadic` | not a feature — truthfulness. Without it the metadata silently describes `...$args` as an ordinary parameter, and describing the class accurately is the cache's entire job |
+| `isInstantiable` | FR-04 — an interface, abstract class, or private constructor must be refused clearly rather than failing inside `new` |
+
+### No interface — and the asymmetry with ADR-0004 is the point
+
+ADR-0004 rooted the exception hierarchy on an interface precisely because retrofitting one later
+is impossible: an exception forced to extend a different base could no longer join the family,
+and every consumer `catch` would break. **That reasoning does not transfer here.** Extracting an
+interface from a concrete collaborator is a *non-breaking, additive* refactor — existing
+consumers keep working unchanged. There is no one-way door, so there is nothing to buy insurance
+against, and no consumer exists yet to tell us what the interface should say.
+
+### Instance-scoped, with no static accessor
+
+The cache is an ordinary object. Two instances are independent, which is what makes it testable
+and keeps per-process state out of global scope.
+
+The obvious objection is that the hydrator's entry point is expected to be **static**
+(`DataTransferObject::fromArray()`), which cannot receive an injected instance. A `shared()`
+singleton accessor would solve that — and it is **deliberately not built here**, because the
+constraint that would shape it does not exist yet. Building it now means guessing at reset
+semantics, thread/process assumptions, and testability for a caller that has not been written.
+Milestone 3 will have the real constraint in hand.
+
+### Failures throw `UtilsException`, not a new hierarchy member
+
+Reflecting a name that resolves to nothing throws `UtilsException` — the concrete base — rather
+than a new `ReflectionException` leaf. RFC-0001 pins the exception hierarchy's shape as a
+MAJOR-version surface, so **adding a member is a decision, not an implementation detail**. No
+consumer has yet needed to catch reflection failures specifically; when one does, that is a
+decision to take with the driver in hand. What matters immediately is that nothing escapes the
+family: a bare `\ReflectionException` would break ADR-0004's "one thing to catch" contract.
+
+### Explicitly out of scope: `Collection<T>` element types
+
+Spec FR-01 says `Collection<T>` properties hydrate recursively, which needs the element type —
+and PHP has no runtime generics, so it lives in a `@var`/`@param` docblock and requires parsing.
+That parser belongs with `Collection` itself (roadmap 3.3), not here. Recorded so its absence is
+a boundary, not an oversight.
+
+## Alternatives Considered
+
+- **Define a `ReflectionCacheInterface` up front** — rejected per the asymmetry above: the
+  retrofit is additive, so the insurance is unnecessary, and no consumer exists to specify it.
+- **A static/singleton cache** (`ReflectionCache::for()` as a static call) — simplest for a
+  static hydrator entry point, rejected: it makes per-process state global, forces a test-only
+  `reset()` into the production API, and answers a question Milestone 3 has not yet asked.
+- **Adopt PSR-6 / PSR-16 and let consumers plug in a cache backend** — rejected: this is
+  in-process memoisation, not caching. There is nothing to persist (a constructor cannot change
+  while the process runs), no eviction policy to express, and it would add a dependency to a
+  package whose zero-implementation-dependency stance is a stated design goal.
+- **Reduce union and intersection types to their first arm** — rejected: imported ADR-001 has
+  the Container *refuse* what it cannot autowire rather than guess. `type` is `null` for those,
+  and `declaredType` preserves what was seen.
+- **Add a `ReflectionException` leaf to the hierarchy** — rejected for now, as above: it widens a
+  MAJOR-pinned surface with no consumer requiring the distinction.
+
+## Consequences
+
+- **Both Milestone 3 and Milestone 6 can build on one cache**, satisfying imported ADR-001's
+  single-cache commitment, and NFR-01/NFR-02 have the mechanism they assume.
+- **Memoisation is observable, not merely timed.** `isCached()` and `count()` exist so a test can
+  assert reflection happened once — a cache whose only evidence is a timing difference is one
+  nobody can write a deterministic test against. The suite asserts *object identity* across
+  repeated lookups: a non-memoising implementation returns an equal-but-distinct object, so
+  `===` fails where `==` would not.
+- **A failed reflection is not cached**, so a class that becomes loadable later is not
+  permanently poisoned by an early lookup.
+- **PHP's reflection semantics are recorded where they surprised us**, each verified directly
+  rather than assumed: `mixed` is a *named builtin type*, not the absence of a type; a union's
+  arms come back canonically ordered (`int|string` reflects as `string|int`), so tests assert
+  membership rather than an exact string; and `class_exists()` returns **false** for interfaces
+  and traits, which is why the existence guard checks all three.
+- **Cost:** three classes where one might have done, and value objects that will look
+  over-specified until their consumers land. The mitigation is the traceability table above —
+  every field has a named requirement, and a field that cannot cite one does not belong.
+
+## References
+
+- Imported ADR-001 (the single-cache commitment); RFC-0001 R-2 (placement in `Support`)
+- Spec FR-01, FR-04, NFR-01, NFR-02
+- ADR-0004 — the interface decision this one deliberately does *not* mirror, and why

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,3 +21,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0003](0003-pin-ci-actions-by-commit-sha.md) | Pin CI actions by commit SHA | Accepted |
 | [0004](0004-root-the-exception-hierarchy-on-an-interface.md) | Root the exception hierarchy on an interface, and close its leaves | Accepted |
 | [0005](0005-atomic-file-writes-with-a-sidecar-lock.md) | Atomic file writes, with the lock on a sidecar rather than the target | Accepted |
+| [0006](0006-shared-reflection-metadata-cache.md) | Shape the shared reflection-metadata cache as plain instances, without an interface | Accepted |

--- a/docs/journal/2026/08/2026-08-04-reflection-metadata-cache.md
+++ b/docs/journal/2026/08/2026-08-04-reflection-metadata-cache.md
@@ -1,0 +1,95 @@
+# 2026-08-04 — The shared reflection cache: designing for consumers that do not exist yet
+
+Roadmap item **2.5**, the last Support-layer item with new design surface, and the second
+`sets-pattern` of the milestone. Route resolved to `frontier-reasoning / high`;
+`route_advice.py --check` reported the session (`opus-5`, standard tier) below it — surfaced to
+the maintainer, who holds model authority (ADR-0017), and work proceeded on their standing
+decision.
+
+## The actual difficulty
+
+Imported ADR-001 commits to **one** metadata cache shared by the DTO hydrator and the Container.
+Neither consumer exists yet — the hydrator is Milestone 3, the Container Milestone 6. So every
+decision risked one of two failures: under-building, and blocking a consumer later; or
+speculating, and shipping fields and abstractions nobody ever uses.
+
+The discipline that resolved it: **every metadata field must cite a stated requirement**.
+[ADR-0006](../../adr/0006-shared-reflection-metadata-cache.md) carries the table — `name` from
+FR-01, `allowsNull`/`hasDefault`/`default` from RFC-0001 R-4's "neither nullable nor defaulted"
+rule, `declaredType` from imported ADR-001's *fail loudly* requirement, `isInstantiable` from
+FR-04. A field that cannot name its requirement does not belong.
+
+`isVariadic` is the one that needed a different justification, and it is worth recording: it is
+not a feature request from anywhere. Without it the metadata would silently describe `...$args`
+as an ordinary parameter — and describing the class *truthfully* is the cache's entire job, so
+the field earns its place on accuracy grounds rather than on demand.
+
+## The interface question, and why ADR-0004 does not transfer
+
+ADR-0004 (item 2.1) rooted the exception hierarchy on an interface, and the argument was
+one-way-door avoidance: an exception later forced to extend a different base could never rejoin
+the family, and every consumer `catch` would break.
+
+The reflex would be to mirror that here. **It does not transfer, and noticing why mattered.**
+Extracting an interface from a concrete collaborator is a *non-breaking, additive* refactor —
+existing consumers keep compiling unchanged. There is no door closing, so there is nothing to
+buy insurance against, and no consumer exists yet to say what the interface should declare. So:
+concrete class, no interface, reasoning recorded rather than left as an inconsistency someone
+would otherwise have to re-derive.
+
+The same reasoning deferred a `shared()` singleton accessor. The hydrator's entry point is
+expected to be static (`DataTransferObject::fromArray()`), which cannot receive an injected
+instance — a real constraint, but one whose reset semantics and testability I would be guessing
+at today. Milestone 3 will have it in hand.
+
+## Three PHP facts I had wrong, all caught by tests
+
+Each assumed, then falsified by a red test, then verified directly against reflection:
+
+1. **`mixed` is a named builtin type, not the absence of one.** The fixture called
+   `UntypedService` declared `mixed $anything` — so it was testing the `mixed` case while
+   claiming to test the untyped one. Split into two fixtures: a genuinely untyped parameter
+   (`__construct($anything)`, `getType()` returns `null`) and a `mixed`-typed one. Both are
+   un-autowirable, for reasons a diagnostic message should not conflate.
+2. **PHP canonicalises a union's arms.** The fixture declares `int|string`; reflection reports
+   `string|int`. The test now asserts membership rather than an exact string — otherwise it
+   would be a test of PHP's ordering rule, not of the metadata.
+3. **`class_exists()` returns false for interfaces and traits.** Verified across enums, abstract
+   classes, interfaces and traits before writing the existence guard, which is why it checks all
+   three functions. Narrowing it to `class_exists()` alone makes the interface tests error —
+   confirmed by probe.
+
+## PHPStan max, and a genuine tool disagreement
+
+PHPStan first rejected `catch (ReflectionException)` as **dead**: `class-string` asserts the
+name resolves, so it proved the catch unreachable. At runtime it is reachable — nothing stops a
+caller passing a name read from configuration. Replaced with an explicit `class_exists() ||
+interface_exists() || trait_exists()` precondition, which keeps both truths intact and produces
+a better message than reflection's own.
+
+Then a real conflict between the two quality tools, worth recording because suppressing either
+would have been the easy wrong answer:
+
+- **PHP-CS-Fixer** wanted to delete `@param mixed $anything` as superfluous.
+- **PHPStan at max** requires it — on a parameter with no native type, that annotation is the
+  only thing supplying a type.
+
+Settled in the formatter config (`no_superfluous_phpdoc_tags` → `allow_mixed: true`) with the
+reasoning inline, rather than by silencing whichever tool complained second.
+
+## Proved non-vacuous
+
+- **Removed the memoisation** (reflect on every call) → the identity assertion and the
+  cache-count assertions both failed. Identity is the discriminator on purpose: a non-memoising
+  implementation returns an equal-but-*distinct* object, so `===` fails where `==` would pass.
+- **Narrowed the existence guard** to `class_exists()` alone → both interface tests errored.
+
+138 tests, 284 assertions, 3 skipped (the Windows-only `File` tests; they run on CI). PHPStan max
+clean, PHP-CS-Fixer clean.
+
+## Next
+
+**Milestone 2 is one item from complete.** Only **2.6** (T-05 property tests) and **2.7** (the
+ungated coverage floor) remain — and as flagged on PR #15, all three property tests 2.6 names
+already exist, landed with the items they belong to. Whether 2.6 is ticked as done or rewritten
+as a pointer is the maintainer's call, not the agent's.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — The shared reflection cache: designing for consumers that do not exist yet](2026/08/2026-08-04-reflection-metadata-cache.md)
 - [2026-08-03 — Env::get() and Json: two functions, three probed gotchas](2026/08/2026-08-03-env-json.md)
 - [2026-08-03 — File: atomic writes, and a test that was lying](2026/08/2026-08-03-file-atomic-io.md)
 - [2026-08-03 — Str::slug() / uuid() / random()](2026/08/2026-08-03-str-slug-uuid-random.md)

--- a/src/main/php/d4np/utils/Support/ClassMetadata.php
+++ b/src/main/php/d4np/utils/Support/ClassMetadata.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * What one class's constructor declares, reflected once and reused (ADR-0006).
+ *
+ * The unit {@see ReflectionCache} memoises. Both consumers — the DTO hydrator (spec FR-01) and
+ * the Container's autowiring (spec FR-04) — need exactly this: can it be constructed, and with
+ * what parameters.
+ */
+final class ClassMetadata
+{
+    /**
+     * @param class-string             $className      the class this describes
+     * @param list<ParameterMetadata>  $parameters     constructor parameters, in declaration
+     *                                                 order — empty for a class with no
+     *                                                 constructor, which is a legitimate case
+     *                                                 both consumers handle (construct with no
+     *                                                 arguments), not an error
+     * @param bool                     $isInstantiable whether `new` is possible at all. False for
+     *                                                 an interface, an abstract class, or a class
+     *                                                 whose constructor is not public — the last
+     *                                                 being this library's own static-utility
+     *                                                 idiom, so the Container must refuse it
+     *                                                 clearly rather than fail inside `new`
+     */
+    public function __construct(
+        public readonly string $className,
+        public readonly array $parameters,
+        public readonly bool $isInstantiable,
+    ) {
+    }
+
+    /**
+     * The parameter with this name, or `null` when the class declares none.
+     *
+     * How the hydrator answers "is this payload key a declared property?" — the question behind
+     * `UnknownKeyException` in strict mode (spec FR-01).
+     */
+    public function parameter(string $name): ?ParameterMetadata
+    {
+        foreach ($this->parameters as $parameter) {
+            if ($parameter->name === $name) {
+                return $parameter;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Parameter names, in declaration order.
+     *
+     * @return list<string>
+     */
+    public function parameterNames(): array
+    {
+        return array_map(
+            static fn (ParameterMetadata $parameter): string => $parameter->name,
+            $this->parameters,
+        );
+    }
+}

--- a/src/main/php/d4np/utils/Support/ParameterMetadata.php
+++ b/src/main/php/d4np/utils/Support/ParameterMetadata.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * What one constructor parameter declares, reflected once and reused (ADR-0006).
+ *
+ * Every field here exists because a stated requirement needs it — the DTO hydrator (spec FR-01)
+ * or the Container's autowiring (spec FR-04). Nothing is recorded speculatively: a metadata
+ * object that describes more than its consumers ask for is a maintenance cost with no reader.
+ */
+final class ParameterMetadata
+{
+    /**
+     * @param string      $name         parameter name — how the hydrator matches a payload key
+     * @param string|null $type         the single named type, or `null` when the parameter is
+     *                                  untyped **or** declares a union/intersection type; those
+     *                                  cases are distinguished by {@see self::$declaredType}
+     * @param string|null $declaredType the declared type exactly as written (`int`, `?Foo`,
+     *                                  `int|string`, `A&B`), or `null` when untyped. Kept for
+     *                                  diagnostics: imported ADR-001 requires the Container to
+     *                                  *fail loudly* on what it cannot autowire, and a message
+     *                                  naming the type it actually saw is what makes that useful
+     * @param bool        $isBuiltin    whether `$type` is a PHP builtin (`int`, `string`, …)
+     *                                  rather than a class. The branch both consumers make:
+     *                                  the hydrator type-checks a scalar or recurses into a
+     *                                  nested DTO; the Container resolves a class or refuses
+     * @param bool        $allowsNull   whether `null` satisfies the declaration — one half of
+     *                                  RFC-0001 R-4's "neither nullable nor defaulted" rule
+     * @param bool        $hasDefault   whether the parameter declares a default — the other half
+     *                                  of R-4. Needed separately from {@see self::$default},
+     *                                  since a declared default of `null` is indistinguishable
+     *                                  from "no default" by value alone
+     * @param mixed       $default      the declared default, or `null` when `$hasDefault` is false
+     * @param bool        $isVariadic   whether the parameter is variadic. Recorded so the metadata
+     *                                  does not silently describe `...$args` as an ordinary
+     *                                  parameter — being truthful about what was reflected is the
+     *                                  cache's entire job
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly ?string $type,
+        public readonly ?string $declaredType,
+        public readonly bool $isBuiltin,
+        public readonly bool $allowsNull,
+        public readonly bool $hasDefault,
+        public readonly mixed $default,
+        public readonly bool $isVariadic,
+    ) {
+    }
+
+    /**
+     * Whether the parameter may be omitted from a payload without the result being malformed
+     * (RFC-0001 R-4).
+     *
+     * A nullable or defaulted parameter hydrates to `null` or its default when absent; anything
+     * else absent is a `MissingKeyException` — in strict **and** lenient mode alike.
+     */
+    public function isOptional(): bool
+    {
+        return $this->allowsNull || $this->hasDefault || $this->isVariadic;
+    }
+
+    /**
+     * Whether the Container can autowire this parameter without an explicit definition.
+     *
+     * True only for a single named class type. An untyped parameter offers nothing to resolve;
+     * a builtin has no service to look up; a union or intersection type gives no single class to
+     * construct — the case imported ADR-001 names explicitly as one the Container refuses rather
+     * than guesses at.
+     */
+    public function isAutowirable(): bool
+    {
+        return $this->type !== null && !$this->isBuiltin && !$this->isVariadic;
+    }
+}

--- a/src/main/php/d4np/utils/Support/ReflectionCache.php
+++ b/src/main/php/d4np/utils/Support/ReflectionCache.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+use ReflectionClass;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionParameter;
+use Throwable;
+
+/**
+ * Per-class constructor metadata, reflected once per process (spec FR-01/FR-04, ADR-0006).
+ *
+ * The one cache imported ADR-001 commits to: *"the reflection cache used by the container is
+ * shared infrastructure with the DTO hydrator (one metadata cache)"*. It lives in `Support`
+ * because that is the only layer both the `Dto` and `Container` groups may depend on without
+ * breaking the no-cross-group-imports rule (RFC-0001 R-2).
+ *
+ * It is what makes NFR-01 (≤ 5 µs/DTO warm) and NFR-02 (≤ 2 µs warm singleton resolve)
+ * reachable: reflection is paid once per class, and every later lookup is an array hit.
+ *
+ * **Scope, stated plainly:** this is in-process memoisation, not a cache *backend*. PHP is
+ * request-isolated, so the lifetime is one process — there is no persistence, no eviction, and
+ * no TTL, because a class's constructor cannot change while the process runs.
+ */
+final class ReflectionCache
+{
+    /** @var array<class-string, ClassMetadata> */
+    private array $entries = [];
+
+    /**
+     * The metadata for `$class`, reflecting it on first request and returning the **same**
+     * instance on every later one.
+     *
+     * @param class-string $class
+     *
+     * @throws UtilsException if the class cannot be reflected — typically because it does not
+     *                        exist. The native `ReflectionException` is wrapped rather than
+     *                        allowed to escape, so a consumer catching {@see UtilsThrowable}
+     *                        catches this too (ADR-0004's contract).
+     */
+    public function for(string $class): ClassMetadata
+    {
+        return $this->entries[$class] ??= $this->reflect($class);
+    }
+
+    /**
+     * Whether `$class` has already been reflected.
+     *
+     * Exists so the memoisation is observable from outside — a cache whose only evidence is a
+     * timing difference is a cache nobody can write a deterministic test against.
+     *
+     * @param class-string $class
+     */
+    public function isCached(string $class): bool
+    {
+        return isset($this->entries[$class]);
+    }
+
+    /** How many classes have been reflected so far. */
+    public function count(): int
+    {
+        return \count($this->entries);
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @throws UtilsException
+     */
+    private function reflect(string $class): ClassMetadata
+    {
+        // An explicit precondition rather than a `catch (ReflectionException)`: PHPStan proves
+        // that catch dead, because `class-string` asserts the name resolves — and at runtime it
+        // may not, since nothing stops a caller passing a name that came from configuration or
+        // user input. Checking up front keeps both truths intact and produces a better message
+        // than reflection's own.
+        //
+        // The three checks are not redundant: class_exists() covers classes, abstract classes
+        // and enums, but returns false for interfaces and traits — verified directly. All are
+        // reflectable, and the Container in particular must be able to reflect an interface in
+        // order to refuse it as non-instantiable.
+        if (!class_exists($class) && !interface_exists($class) && !trait_exists($class)) {
+            throw new UtilsException(sprintf(
+                'Cannot reflect "%s": no such class, interface, enum or trait is loadable.',
+                $class,
+            ));
+        }
+
+        $reflection = new ReflectionClass($class);
+
+        $constructor = $reflection->getConstructor();
+        $parameters = [];
+        if ($constructor !== null) {
+            foreach ($constructor->getParameters() as $parameter) {
+                $parameters[] = self::describe($parameter);
+            }
+        }
+
+        return new ClassMetadata($class, $parameters, $reflection->isInstantiable());
+    }
+
+    private static function describe(ReflectionParameter $parameter): ParameterMetadata
+    {
+        $type = $parameter->getType();
+
+        // Only a single named type gives the consumers something to act on. A union or
+        // intersection type is deliberately reduced to `null` here and preserved verbatim in
+        // $declaredType: imported ADR-001 has the Container refuse those rather than pick one
+        // arm, and the refusal message needs to name what it saw.
+        $named = $type instanceof ReflectionNamedType ? $type : null;
+
+        return new ParameterMetadata(
+            name: $parameter->getName(),
+            type: $named?->getName(),
+            declaredType: self::declaredTypeOf($type),
+            isBuiltin: $named?->isBuiltin() ?? false,
+            allowsNull: $type === null || $type->allowsNull(),
+            hasDefault: $parameter->isDefaultValueAvailable(),
+            default: self::defaultOf($parameter),
+            isVariadic: $parameter->isVariadic(),
+        );
+    }
+
+    private static function declaredTypeOf(?\ReflectionType $type): ?string
+    {
+        if ($type === null) {
+            return null;
+        }
+
+        // An intersection type's __toString() is well defined, but building the string from its
+        // parts keeps this independent of that (documented-but-easy-to-change) behaviour.
+        if ($type instanceof ReflectionIntersectionType) {
+            return implode('&', array_map(
+                static fn (\ReflectionType $part): string => (string) $part,
+                $type->getTypes(),
+            ));
+        }
+
+        return (string) $type;
+    }
+
+    /**
+     * The declared default, or `null` when there is none.
+     *
+     * A default can be a constant expression that fails to evaluate — `self::SOME_CONST` on a
+     * class whose constant was removed, for instance. Reading it must not turn metadata
+     * collection into a hard failure, so an unreadable default is recorded as absent rather than
+     * thrown: {@see ParameterMetadata::$hasDefault} still says `true`, and the consumer that
+     * genuinely needs the value fails on its own terms with its own context.
+     */
+    private static function defaultOf(ReflectionParameter $parameter): mixed
+    {
+        if (!$parameter->isDefaultValueAvailable()) {
+            return null;
+        }
+
+        try {
+            return $parameter->getDefaultValue();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/AbstractService.php
+++ b/src/test/php/d4np/utils/Support/Fixture/AbstractService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** Abstract: reflectable, not instantiable. */
+abstract class AbstractService
+{
+    public function __construct(public readonly int $value)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/IntersectionTypeService.php
+++ b/src/test/php/d4np/utils/Support/Fixture/IntersectionTypeService.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/**
+ * An intersection type: reflectable, equally un-autowirable.
+ *
+ * `ArrayAccess` is generic, so PHPStan at max level requires its type arguments — supplied in
+ * the docblock, since PHP's native intersection syntax cannot carry them.
+ */
+final class IntersectionTypeService
+{
+    /** @param \Countable&\ArrayAccess<int, string> $both */
+    public function __construct(
+        public readonly \Countable&\ArrayAccess $both,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/MixedTypeService.php
+++ b/src/test/php/d4np/utils/Support/Fixture/MixedTypeService.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/**
+ * A `mixed`-typed parameter.
+ *
+ * Reflection reports `mixed` as a {@see \ReflectionNamedType} that is builtin and nullable —
+ * so unlike {@see UntypedService} it *has* a type, and the metadata must say so rather than
+ * flattening both cases into "no type".
+ */
+final class MixedTypeService
+{
+    public function __construct(
+        public readonly mixed $anything,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/NestedDto.php
+++ b/src/test/php/d4np/utils/Support/Fixture/NestedDto.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** A class-typed parameter: what the Container autowires and the hydrator recurses into. */
+final class NestedDto
+{
+    public function __construct(
+        public readonly ScalarDto $inner,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/NoConstructorService.php
+++ b/src/test/php/d4np/utils/Support/Fixture/NoConstructorService.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** No constructor at all — legitimate, and both consumers construct it with no arguments. */
+final class NoConstructorService
+{
+}

--- a/src/test/php/d4np/utils/Support/Fixture/OptionalsDto.php
+++ b/src/test/php/d4np/utils/Support/Fixture/OptionalsDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** Nullable and defaulted parameters — the two halves of RFC-0001 R-4's "optional" rule. */
+final class OptionalsDto
+{
+    public function __construct(
+        public readonly string $required,
+        public readonly ?string $nullable,
+        public readonly int $defaulted = 42,
+        public readonly ?string $nullableAndDefaulted = null,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/PrivateConstructorService.php
+++ b/src/test/php/d4np/utils/Support/Fixture/PrivateConstructorService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** A private constructor: this library's static-utility idiom, which the Container must refuse. */
+final class PrivateConstructorService
+{
+    private function __construct()
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/ScalarDto.php
+++ b/src/test/php/d4np/utils/Support/Fixture/ScalarDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** The ordinary case: typed, promoted, readonly — the DTO shape spec FR-01 describes. */
+final class ScalarDto
+{
+    public function __construct(
+        public readonly string $email,
+        public readonly int $age,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/ServiceContract.php
+++ b/src/test/php/d4np/utils/Support/Fixture/ServiceContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** An interface: reflectable, not instantiable, and not covered by `class_exists()`. */
+interface ServiceContract
+{
+}

--- a/src/test/php/d4np/utils/Support/Fixture/UnionTypeService.php
+++ b/src/test/php/d4np/utils/Support/Fixture/UnionTypeService.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** A union type — imported ADR-001 has the Container refuse these rather than pick an arm. */
+final class UnionTypeService
+{
+    public function __construct(
+        public readonly int|string $ambiguous,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/UntypedService.php
+++ b/src/test/php/d4np/utils/Support/Fixture/UntypedService.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/**
+ * A genuinely untyped parameter — `getType()` returns `null`.
+ *
+ * Distinct from {@see MixedTypeService}: `mixed` is a *named builtin type*, verified directly
+ * against reflection, not the absence of one. Both are un-autowirable, for different reasons a
+ * diagnostic message should not conflate.
+ *
+ * Cannot use constructor promotion: a promoted property requires a type.
+ */
+final class UntypedService
+{
+    public readonly mixed $anything;
+
+    /** @param mixed $anything */
+    public function __construct($anything)
+    {
+        $this->anything = $anything;
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/VariadicService.php
+++ b/src/test/php/d4np/utils/Support/Fixture/VariadicService.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support\Fixture;
+
+/** A variadic constructor: must not be described as an ordinary parameter. */
+final class VariadicService
+{
+    /** @var list<string> */
+    public readonly array $rest;
+
+    public function __construct(string ...$rest)
+    {
+        $this->rest = array_values($rest);
+    }
+}

--- a/src/test/php/d4np/utils/Support/ReflectionCacheTest.php
+++ b/src/test/php/d4np/utils/Support/ReflectionCacheTest.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\ClassMetadata;
+use D4np\Utils\Support\ReflectionCache;
+use D4np\Utils\Support\UtilsException;
+use D4np\Utils\Support\UtilsThrowable;
+use D4np\Utils\Tests\Support\Fixture\AbstractService;
+use D4np\Utils\Tests\Support\Fixture\IntersectionTypeService;
+use D4np\Utils\Tests\Support\Fixture\MixedTypeService;
+use D4np\Utils\Tests\Support\Fixture\NestedDto;
+use D4np\Utils\Tests\Support\Fixture\NoConstructorService;
+use D4np\Utils\Tests\Support\Fixture\OptionalsDto;
+use D4np\Utils\Tests\Support\Fixture\PrivateConstructorService;
+use D4np\Utils\Tests\Support\Fixture\ScalarDto;
+use D4np\Utils\Tests\Support\Fixture\ServiceContract;
+use D4np\Utils\Tests\Support\Fixture\UnionTypeService;
+use D4np\Utils\Tests\Support\Fixture\UntypedService;
+use D4np\Utils\Tests\Support\Fixture\VariadicService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `ReflectionCache` — spec FR-01/FR-04, ADR-0006.
+ *
+ * Two things are under test and they are not the same: that the metadata **describes the class
+ * truthfully**, and that the cache **actually memoises**. The second is what NFR-01 and NFR-02
+ * rest on, and it is the one a test can accidentally not check at all.
+ */
+final class ReflectionCacheTest extends TestCase
+{
+    private ReflectionCache $cache;
+
+    protected function setUp(): void
+    {
+        $this->cache = new ReflectionCache();
+    }
+
+    // ------------------------------------------------------------ memoisation
+
+    /**
+     * The memoisation itself, observed by object identity rather than by timing.
+     *
+     * A non-memoising implementation returns an equal-but-distinct object every call, so `===`
+     * fails while `==` would still pass — which is exactly why this asserts identity. Timing
+     * would be the flaky way to ask the same question.
+     */
+    public function testTheSameClassReturnsTheVerySameMetadataInstance(): void
+    {
+        $first = $this->cache->for(ScalarDto::class);
+        $second = $this->cache->for(ScalarDto::class);
+
+        self::assertSame($first, $second, 'a second lookup must return the cached object, not a fresh reflection');
+    }
+
+    public function testTheCacheReportsWhatItHasReflected(): void
+    {
+        self::assertFalse($this->cache->isCached(ScalarDto::class));
+        self::assertSame(0, $this->cache->count());
+
+        $this->cache->for(ScalarDto::class);
+
+        self::assertTrue($this->cache->isCached(ScalarDto::class));
+        self::assertSame(1, $this->cache->count());
+
+        // A repeat lookup must not grow the cache — the observable form of "reflected once".
+        $this->cache->for(ScalarDto::class);
+        self::assertSame(1, $this->cache->count());
+
+        $this->cache->for(NestedDto::class);
+        self::assertSame(2, $this->cache->count());
+    }
+
+    public function testTwoCachesAreIndependent(): void
+    {
+        // Instance-scoped, not global (ADR-0006): one cache's state is invisible to another.
+        $other = new ReflectionCache();
+        $this->cache->for(ScalarDto::class);
+
+        self::assertFalse($other->isCached(ScalarDto::class));
+        self::assertNotSame($this->cache->for(ScalarDto::class), $other->for(ScalarDto::class));
+    }
+
+    // --------------------------------------------------------------- accuracy
+
+    public function testScalarConstructorParametersAreDescribedInDeclarationOrder(): void
+    {
+        $meta = $this->cache->for(ScalarDto::class);
+
+        self::assertSame(ScalarDto::class, $meta->className);
+        self::assertTrue($meta->isInstantiable);
+        self::assertSame(['email', 'age'], $meta->parameterNames());
+
+        $email = $meta->parameter('email');
+        self::assertNotNull($email);
+        self::assertSame('string', $email->type);
+        self::assertSame('string', $email->declaredType);
+        self::assertTrue($email->isBuiltin);
+        self::assertFalse($email->allowsNull);
+        self::assertFalse($email->hasDefault);
+        self::assertFalse($email->isVariadic);
+    }
+
+    public function testAnUnknownParameterNameIsNull(): void
+    {
+        self::assertNull($this->cache->for(ScalarDto::class)->parameter('nope'));
+    }
+
+    /** RFC-0001 R-4: "neither nullable nor defaulted" is what makes a key required. */
+    public function testNullableAndDefaultedParametersAreDistinguished(): void
+    {
+        $meta = $this->cache->for(OptionalsDto::class);
+
+        $required = $meta->parameter('required');
+        self::assertNotNull($required);
+        self::assertFalse($required->allowsNull);
+        self::assertFalse($required->hasDefault);
+        self::assertFalse($required->isOptional(), 'a plain typed parameter is required');
+
+        $nullable = $meta->parameter('nullable');
+        self::assertNotNull($nullable);
+        self::assertTrue($nullable->allowsNull);
+        self::assertFalse($nullable->hasDefault);
+        self::assertTrue($nullable->isOptional());
+        self::assertSame('string', $nullable->type, 'the named type survives the ? prefix');
+        self::assertSame('?string', $nullable->declaredType);
+
+        $defaulted = $meta->parameter('defaulted');
+        self::assertNotNull($defaulted);
+        self::assertFalse($defaulted->allowsNull);
+        self::assertTrue($defaulted->hasDefault);
+        self::assertSame(42, $defaulted->default);
+        self::assertTrue($defaulted->isOptional());
+    }
+
+    /**
+     * A default of `null` is why `hasDefault` cannot be inferred from `default` alone — the two
+     * fields carry different facts and a single one would conflate them.
+     */
+    public function testADefaultOfNullIsStillADeclaredDefault(): void
+    {
+        $parameter = $this->cache->for(OptionalsDto::class)->parameter('nullableAndDefaulted');
+
+        self::assertNotNull($parameter);
+        self::assertTrue($parameter->hasDefault);
+        self::assertNull($parameter->default);
+    }
+
+    public function testAClassTypedParameterIsAutowirable(): void
+    {
+        $inner = $this->cache->for(NestedDto::class)->parameter('inner');
+
+        self::assertNotNull($inner);
+        self::assertSame(ScalarDto::class, $inner->type);
+        self::assertFalse($inner->isBuiltin);
+        self::assertTrue($inner->isAutowirable());
+    }
+
+    public function testABuiltinParameterIsNotAutowirable(): void
+    {
+        $email = $this->cache->for(ScalarDto::class)->parameter('email');
+
+        self::assertNotNull($email);
+        self::assertTrue($email->isBuiltin);
+        self::assertFalse($email->isAutowirable(), 'a scalar has no service to resolve');
+    }
+
+    /**
+     * Imported ADR-001 has the Container refuse a union-typed parameter rather than pick an arm.
+     * The metadata makes that refusable *and* explainable: `type` is null, and `declaredType`
+     * still names what was seen.
+     */
+    public function testAUnionTypeHasNoSingleTypeButKeepsItsDeclaration(): void
+    {
+        $parameter = $this->cache->for(UnionTypeService::class)->parameter('ambiguous');
+
+        self::assertNotNull($parameter);
+        self::assertNull($parameter->type);
+        self::assertFalse($parameter->isAutowirable());
+
+        // PHP canonicalises a union's arms rather than preserving declaration order — the
+        // fixture declares `int|string` and reflection reports `string|int`, verified directly.
+        // Asserting membership instead of an exact string keeps this a test of the metadata
+        // rather than of PHP's ordering rule.
+        self::assertNotNull($parameter->declaredType);
+        self::assertStringContainsString('int', $parameter->declaredType);
+        self::assertStringContainsString('string', $parameter->declaredType);
+        self::assertStringContainsString('|', $parameter->declaredType);
+    }
+
+    public function testAnIntersectionTypeHasNoSingleTypeButKeepsItsDeclaration(): void
+    {
+        $parameter = $this->cache->for(IntersectionTypeService::class)->parameter('both');
+
+        self::assertNotNull($parameter);
+        self::assertNull($parameter->type);
+        self::assertNotNull($parameter->declaredType);
+        self::assertStringContainsString('Countable', $parameter->declaredType);
+        self::assertStringContainsString('ArrayAccess', $parameter->declaredType);
+        self::assertFalse($parameter->isAutowirable());
+    }
+
+    /**
+     * A genuinely untyped parameter and a union-typed one both have `type === null`, and they
+     * are not the same situation — `declaredType` is what tells them apart, which is the reason
+     * that field exists.
+     */
+    public function testAnUntypedParameterIsDistinguishableFromAUnionTypedOne(): void
+    {
+        $untyped = $this->cache->for(UntypedService::class)->parameter('anything');
+        $union = $this->cache->for(UnionTypeService::class)->parameter('ambiguous');
+
+        self::assertNotNull($untyped);
+        self::assertNotNull($union);
+        self::assertNull($untyped->type);
+        self::assertNull($union->type);
+
+        self::assertNull($untyped->declaredType, 'no declaration at all');
+        self::assertNotNull($union->declaredType, 'a union declares something, just not one thing');
+    }
+
+    /**
+     * `mixed` is a **named builtin type**, not the absence of one — verified directly against
+     * reflection. Flattening it into "untyped" would lose a real distinction: an untyped
+     * parameter was never annotated, while `mixed` is a deliberate declaration.
+     */
+    public function testMixedIsANamedBuiltinTypeNotTheAbsenceOfOne(): void
+    {
+        $mixed = $this->cache->for(MixedTypeService::class)->parameter('anything');
+        $untyped = $this->cache->for(UntypedService::class)->parameter('anything');
+
+        self::assertNotNull($mixed);
+        self::assertNotNull($untyped);
+
+        self::assertSame('mixed', $mixed->type);
+        self::assertSame('mixed', $mixed->declaredType);
+        self::assertTrue($mixed->isBuiltin);
+        self::assertTrue($mixed->allowsNull, 'mixed accepts null by definition');
+        self::assertFalse($mixed->isAutowirable(), 'a builtin has no service to resolve');
+
+        self::assertNull($untyped->type, 'the untyped case must not be described the same way');
+    }
+
+    public function testAnUntypedParameterAllowsNull(): void
+    {
+        // No declaration constrains nothing, so null is acceptable — which makes the parameter
+        // optional under RFC-0001 R-4's rule.
+        $untyped = $this->cache->for(UntypedService::class)->parameter('anything');
+
+        self::assertNotNull($untyped);
+        self::assertTrue($untyped->allowsNull);
+        self::assertTrue($untyped->isOptional());
+        self::assertFalse($untyped->isAutowirable());
+    }
+
+    public function testAVariadicParameterIsFlaggedAndNotAutowirable(): void
+    {
+        $parameter = $this->cache->for(VariadicService::class)->parameter('rest');
+
+        self::assertNotNull($parameter);
+        self::assertTrue($parameter->isVariadic);
+        self::assertTrue($parameter->isOptional(), 'a variadic parameter may legitimately receive nothing');
+        self::assertFalse($parameter->isAutowirable());
+    }
+
+    // ---------------------------------------------------------- instantiable
+
+    public function testAClassWithNoConstructorHasNoParametersAndIsInstantiable(): void
+    {
+        $meta = $this->cache->for(NoConstructorService::class);
+
+        self::assertSame([], $meta->parameters);
+        self::assertTrue($meta->isInstantiable, 'no constructor is not an error — it is a no-argument one');
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function nonInstantiableClasses(): iterable
+    {
+        yield 'abstract class' => [AbstractService::class];
+        yield 'interface' => [ServiceContract::class];
+        yield 'private constructor' => [PrivateConstructorService::class];
+    }
+
+    /**
+     * @param class-string $class
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('nonInstantiableClasses')]
+    public function testNonInstantiableClassesAreReflectedAndFlagged(string $class): void
+    {
+        // Reflectable but not constructible — the Container needs both facts to refuse clearly
+        // instead of failing inside `new`.
+        $meta = $this->cache->for($class);
+
+        self::assertSame($class, $meta->className);
+        self::assertFalse($meta->isInstantiable);
+    }
+
+    public function testAnInterfaceIsReflectable(): void
+    {
+        // Interfaces are the reason the existence guard checks interface_exists() as well:
+        // class_exists() is false for one. That PHP fact is not re-asserted here — PHPStan
+        // decides it statically — but narrowing the guard to class_exists() alone does make
+        // this test error, which is what keeps it meaningful.
+        self::assertInstanceOf(ClassMetadata::class, $this->cache->for(ServiceContract::class));
+    }
+
+    // ------------------------------------------------------------- failure
+
+    /**
+     * A class name that resolves to nothing, built from a parameter so it is not a literal
+     * PHPStan can narrow — the type is what a caller reading a class name out of configuration
+     * would have, which is exactly the case the runtime guard exists for.
+     *
+     * @return class-string
+     */
+    private static function missingClassName(string $suffix): string
+    {
+        /** @var class-string */
+        return 'D4np\\Utils\\Tests\\Support\\Fixture\\Missing' . $suffix;
+    }
+
+    public function testReflectingAnUnknownClassThrowsThroughTheLibraryMarker(): void
+    {
+        try {
+            $this->cache->for(self::missingClassName('NoSuchClassAnywhere'));
+            self::fail('expected a UtilsException');
+        } catch (UtilsThrowable $e) {
+            // ADR-0004's contract: a consumer catching everything this library raises catches
+            // reflection failures too, rather than a bare \ReflectionException escaping.
+            self::assertInstanceOf(UtilsException::class, $e);
+            self::assertStringContainsString('NoSuchClassAnywhere', $e->getMessage());
+        }
+    }
+
+    public function testAFailedReflectionIsNotCached(): void
+    {
+        try {
+            $this->cache->for(self::missingClassName('AlsoMissing'));
+        } catch (UtilsException) {
+            // expected
+        }
+
+        self::assertSame(0, $this->cache->count(), 'a failure must not leave a poisoned entry behind');
+    }
+}


### PR DESCRIPTION
## Context

Roadmap item **2.5** — the last Support-layer item with new design surface, and the second
`sets-pattern` of the milestone.

**The real difficulty:** imported ADR-001 commits to **one** metadata cache shared by the DTO
hydrator (Milestone 3) and the Container (Milestone 6) — and *neither consumer exists yet*.
Every decision risked one of two failures: under-building and blocking a consumer later, or
speculating and shipping fields and abstractions nobody ever uses.

## Change

`ReflectionCache` + immutable `ClassMetadata` / `ParameterMetadata`, plus
**[ADR-0006](docs/adr/0006-shared-reflection-metadata-cache.md)**.

**Every metadata field cites a stated requirement** — the ADR carries the table: `name` from
FR-01; `allowsNull`/`hasDefault`/`default` from RFC-0001 R-4's "neither nullable nor defaulted"
rule; `declaredType` from imported ADR-001's *fail loudly* requirement; `isInstantiable` from
FR-04. `isVariadic` is the one justified differently, and deliberately so: nothing demanded it,
but without it the metadata silently describes `...$args` as an ordinary parameter — and
describing the class *truthfully* is the cache's entire job.

### No interface — and the asymmetry with ADR-0004 is the point

ADR-0004 (item 2.1) rooted the exception hierarchy on an interface to avoid a **one-way door**:
an exception later forced to extend a different base could never rejoin the family. The reflex
would be to mirror that here. **It does not transfer** — extracting an interface from a concrete
collaborator is an *additive, non-breaking* refactor, so there is no door closing, and no
consumer exists yet to say what the interface should declare.

The same reasoning **defers a `shared()` singleton accessor**. The hydrator's entry point is
expected to be static (`DataTransferObject::fromArray()`), which cannot receive an injected
instance — a real constraint, but one whose reset semantics and testability I would be guessing
at today. Milestone 3 will have it in hand.

Failures throw `UtilsException`, not a new hierarchy leaf: RFC-0001 pins the hierarchy's shape
as a MAJOR surface, so adding a member is a decision, not an implementation detail. What matters
now is that nothing escapes the family (ADR-0004's contract).

## Three PHP facts I had wrong — each falsified by a red test, then verified

1. **`mixed` is a named builtin type, not the absence of one.** The fixture called
   `UntypedService` declared `mixed $anything` — testing the `mixed` case while claiming to test
   the untyped one. Split into two fixtures; both are un-autowirable, for reasons a diagnostic
   message should not conflate.
2. **PHP canonicalises a union's arms.** The fixture declares `int|string`; reflection reports
   `string|int`. The test now asserts membership, not an exact string — otherwise it tests PHP's
   ordering rule rather than the metadata.
3. **`class_exists()` returns false for interfaces and traits.** Verified across enums, abstract
   classes, interfaces and traits before writing the guard, which is why it checks all three.

## A genuine conflict between the two quality tools

PHPStan first rejected `catch (ReflectionException)` as **dead** — `class-string` asserts the
name resolves — though at runtime it is reachable from a configuration-supplied name. Replaced
with an explicit `class_exists() || interface_exists() || trait_exists()` precondition, keeping
both truths and giving a better message than reflection's own.

Then the conflict, worth recording because suppressing either tool was the easy wrong answer:
**PHP-CS-Fixer** strips `@param mixed $x` as superfluous; **PHPStan at max** requires it, since
on a parameter with no native type that annotation is the only type source. Settled in the
formatter config (`no_superfluous_phpdoc_tags` → `allow_mixed: true`) with the reasoning inline.

## Verification — proved non-vacuous

- **Removed the memoisation** (reflect on every call) → the identity assertion and both
  cache-count assertions failed. **Identity is the discriminator on purpose**: a non-memoising
  implementation returns an equal-but-*distinct* object, so `===` fails where `==` would pass.
  Timing would be the flaky way to ask the same question.
- **Narrowed the existence guard** to `class_exists()` alone → both interface tests errored.

**138 tests, 284 assertions**, 3 skipped (Windows-only `File` tests from item 2.3; they run on
CI). PHPStan max clean; PHP-CS-Fixer clean; `consistency_lint` and
`action_pin_lint --verify-upstream` both OK.

## Route

`sets-pattern` resolves to **frontier-reasoning / high**; `route_advice.py --check` reported the
session (`opus-5`, standard tier) below it. Surfaced before starting — you hold model authority
(ADR-0017) — and proceeded on your standing decision.

**Cross-links:** RFC-0001 R-2 · imported ADR-001 · ADR-0004, ADR-0006 · roadmap item 2.5 ·
milestone `v0.2.0`. Type label: `feat` (declared in `.github/labels.yml`, still not imported);
`enhancement` set as the closest available default.

**Milestone 2 is one item from complete** — only 2.6 (T-05 property tests, whose three named
cases all already exist) and 2.7 (the ungated coverage floor) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
