### PR TITLE
test(tests): make spec §7's T-05 property-test suite a mechanical unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- Spec §7's **T-05 property-test suite** (Json round-trips, `Str::slug()` idempotence, `Env`
+  boolean coercion) is now a runnable, countable unit: `vendor/bin/phpunit --group T-05`. The
+  three cases already existed, landed with their own items; `#[Group('T-05')]` ties them
+  together so the spec's named suite is a mechanical fact rather than a docblock claim.
 - `D4np\Utils\Support\ReflectionCache` with `ClassMetadata`/`ParameterMetadata` (**ADR-0006**):
   the single per-class constructor-metadata cache imported ADR-001 commits to, shared by the DTO
   hydrator (M3) and the Container (M6) — reflection is paid once per class, every later lookup is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — The shared reflection cache: designing for consumers that do not exist yet](docs/journal/2026/08/2026-08-04-reflection-metadata-cache.md).
+  [2026-08-04 — Making spec §7's T-05 suite a mechanical fact](docs/journal/2026/08/2026-08-04-t05-property-suite.md).
 
 ## Model & effort routing (advisory)
 
@@ -112,8 +112,10 @@ The foundation every group depends on — the deptrac-legal bottom layer (RFC-00
       `\JsonException` (RFC-0001 R-7) — route: fast / low
 - [x] 2.5 Shared reflection-metadata cache, consumed by the Dto hydrator and the Container
       (RFC-0001 R-2) (sets-pattern) — route: frontier-reasoning / high · **ADR-0006**
-- [ ] 2.6 T-05 property tests: Json round-trips, slug idempotence, Env coercion table
-      (RFC-0001) — route: fast / low
+- [x] 2.6 T-05 property tests: Json round-trips, slug idempotence, Env coercion table
+      (RFC-0001) — route: fast / low. All three landed with their own items (2.2, 2.4);
+      this tags them `#[Group('T-05')]` so `vendor/bin/phpunit --group T-05` runs
+      spec §7's named suite as a runnable, countable unit rather than a docblock claim.
 - [ ] 2.7 Measure and enforce the coverage floor. `AGENTS.md` §10 and spec NFR-07 both state
       **≥ 90% line coverage**, and nothing checks it: the `build` job sets up `pcov` but runs
       `vendor/bin/phpunit` with no `--coverage` flag and no threshold, so the number is neither

--- a/docs/journal/2026/08/2026-08-04-t05-property-suite.md
+++ b/docs/journal/2026/08/2026-08-04-t05-property-suite.md
@@ -1,0 +1,40 @@
+# 2026-08-04 — Making spec §7's T-05 suite a mechanical fact
+
+Roadmap item **2.6**. No signals, floor route (`fast / low`); session model matched.
+
+## What this item actually was
+
+By the time this item came up, all three cases spec §7 names for T-05 already existed:
+`Str::slug()` idempotence (item 2.2), `Json` round-trips and the `Env` boolean-coercion table
+(both item 2.4). Writing new tests would have duplicated coverage that already exists and
+already passes.
+
+The real, non-duplicative work: spec §7 names T-05 as **one suite**, and nothing in the repo let
+anyone run or count it as one — the three cases live in three different test classes, tied
+together only by a comment in each docblock saying so. A docblock is not traceability; it is a
+claim nobody checks.
+
+## The fix
+
+`#[Group('T-05')]` on the three specific test methods
+(`StrSlugTest::testSlugIsIdempotent`, `JsonTest::testRoundTrip`,
+`EnvTest::testBooleanCoercionTable`), so `vendor/bin/phpunit --group T-05` runs exactly spec
+§7's named suite as a runnable, countable unit.
+
+**Verified the mechanism discriminates, not just that it runs**: confirmed the filter selects
+exactly 38 tests (the three tagged methods across their data providers) — then added a fourth
+`#[Group('T-05')]` tag to an unrelated method as a probe, watched the count become 39, removed
+it, watched it return to 38. The tag is doing real, bidirectional selection work, not
+decorating tests that would show up in the filtered run regardless.
+
+## State
+
+138 tests, 284 assertions unchanged (no new tests, only tags). PHPStan max clean, PHP-CS-Fixer
+clean, both mandatory gates green.
+
+## Next
+
+**Milestone 2 has one item left: 2.7**, the coverage floor stated in `AGENTS.md` §10 and spec
+NFR-07 but not gated anywhere — filed at item 2.1 and carried since. Closing it finishes
+Milestone 2 (`v0.2.0`) in full, opening Milestone 3 (DTO & data mapping) — the first component
+group that actually consumes the reflection cache from item 2.5.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Making spec §7's T-05 suite a mechanical fact](2026/08/2026-08-04-t05-property-suite.md)
 - [2026-08-04 — The shared reflection cache: designing for consumers that do not exist yet](2026/08/2026-08-04-reflection-metadata-cache.md)
 - [2026-08-03 — Env::get() and Json: two functions, three probed gotchas](2026/08/2026-08-03-env-json.md)
 - [2026-08-03 — File: atomic writes, and a test that was lying](2026/08/2026-08-03-file-atomic-io.md)

--- a/src/test/php/d4np/utils/Support/EnvTest.php
+++ b/src/test/php/d4np/utils/Support/EnvTest.php
@@ -6,6 +6,7 @@ namespace D4np\Utils\Tests\Support;
 
 use D4np\Utils\Support\Env;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -53,6 +54,8 @@ final class EnvTest extends TestCase
         }
     }
 
+    /** `#[Group('T-05')]` makes spec §7's named suite runnable: `vendor/bin/phpunit --group T-05`. */
+    #[Group('T-05')]
     #[DataProvider('booleanTokens')]
     public function testBooleanCoercionTable(string $rawValue, bool $expected): void
     {

--- a/src/test/php/d4np/utils/Support/JsonTest.php
+++ b/src/test/php/d4np/utils/Support/JsonTest.php
@@ -9,6 +9,7 @@ use D4np\Utils\Support\JsonException;
 use D4np\Utils\Support\UtilsThrowable;
 use JsonException as NativeJsonException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /** `Json` — spec §2 item 25, and the T-05 round-trip property test spec §7 names. */
@@ -38,6 +39,8 @@ final class JsonTest extends TestCase
         yield 'array with null and bool members' => [['x' => null, 'y' => true, 'z' => false]];
     }
 
+    /** `#[Group('T-05')]` makes spec §7's named suite runnable: `vendor/bin/phpunit --group T-05`. */
+    #[Group('T-05')]
     #[DataProvider('roundTripValues')]
     public function testRoundTrip(mixed $value): void
     {

--- a/src/test/php/d4np/utils/Support/StrSlugTest.php
+++ b/src/test/php/d4np/utils/Support/StrSlugTest.php
@@ -6,6 +6,7 @@ namespace D4np\Utils\Tests\Support;
 
 use D4np\Utils\Support\Str;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -95,7 +96,13 @@ final class StrSlugTest extends TestCase
         yield 'only punctuation' => ['!!!???'];
     }
 
-    /** T-05 property test (spec §7): slugifying a slug must be a no-op. */
+    /**
+     * T-05 property test (spec §7): slugifying a slug must be a no-op.
+     *
+     * `#[Group('T-05')]` makes the spec's named suite runnable and countable —
+     * `vendor/bin/phpunit --group T-05` — rather than a claim only this docblock makes.
+     */
+    #[Group('T-05')]
     #[DataProvider('idempotenceCorpus')]
     public function testSlugIsIdempotent(string $input): void
     {


### PR DESCRIPTION
## Context

Roadmap item **2.6**. By the time it came up, all three cases spec §7 names for T-05 already
existed: `Str::slug()` idempotence (item 2.2), `Json` round-trips and the `Env` boolean-coercion
table (both item 2.4). Writing new tests would have duplicated coverage that already passes.

## What this item actually is

Spec §7 names T-05 as **one suite**. Nothing let anyone run or count it as one — the three cases
lived in three different test classes, tied together only by a comment in each docblock saying
so. A docblock is a claim; it is not traceability.

## Change

`#[Group('T-05')]` on the three specific test methods —
`StrSlugTest::testSlugIsIdempotent`, `JsonTest::testRoundTrip`,
`EnvTest::testBooleanCoercionTable` — so `vendor/bin/phpunit --group T-05` runs exactly spec
§7's named suite as a runnable, countable unit. No new tests.

## Verification

- `vendor/bin/phpunit --group T-05` → **38 tests, 38 assertions**, spanning exactly the three
  intended classes (`Env`, `Json`, `StrSlug`) — no unrelated test leaks into the group.
- **Proved the mechanism discriminates, not just runs**: added a fourth `#[Group('T-05')]` tag
  to an unrelated method as a probe, watched the filtered count become 39, removed it, watched
  it return to 38. The tag does real bidirectional selection work rather than decorating tests
  that would already appear in the filtered run.
- `vendor/bin/phpunit` (full suite) → 138 tests, 284 assertions, unchanged.
- PHPStan max clean; PHP-CS-Fixer clean; `consistency_lint` and
  `action_pin_lint --verify-upstream` both OK.

No ADR: no architectural decision, only test-grouping traceability.

**Cross-links:** RFC-0001 · roadmap item 2.6 · milestone `v0.2.0`. Type label: `test`
(declared in `.github/labels.yml`, still not imported); `enhancement` set as the closest
available default.

**Milestone 2 has one item left: 2.7**, the coverage floor stated in `AGENTS.md` §10 and spec
NFR-07 but not gated anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
