### PR TITLE
ci(ci): enforce the coverage floor that nothing was measuring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,11 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.toolchain == 'php-8.1' && '8.1' || matrix.toolchain == 'php-8.2' && '8.2' || '8.3' }}
-          coverage: pcov
+          # No coverage driver here on purpose. This job never passed a --coverage flag, so pcov
+          # was loaded and never used — overhead that also made the matrix *look* like it was
+          # measuring a floor nothing compared (roadmap 2.7). Coverage is measured once, in the
+          # `coverage` job below.
+          coverage: none
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
@@ -185,6 +189,40 @@ jobs:
         run: composer install --no-interaction --prefer-dist
       - if: steps.cfg.outputs.present == 'true'
         run: vendor/bin/infection --min-msi=70 --only-covered
+
+  # ---------------------------------------------------------------------------
+  # Coverage floor (roadmap 2.7, ADR-0007). AGENTS.md §10 and spec NFR-07 both require >= 90%
+  # line coverage; PHPUnit 10 ships a dozen --fail-on-* switches and no coverage threshold among
+  # them, so the comparison lives in tools/coverage_gate.py.
+  #
+  # Measured ONCE, on one interpreter, rather than per matrix cell: line coverage of this library
+  # does not vary by PHP version, so three runs would be three identical numbers at three times
+  # the cost. The build matrix proves the tests pass everywhere; this proves how much they reach.
+  #
+  # --coverage-text is deliberate alongside the machine-read report: it puts the number in the
+  # log unconditionally, so a failure shows what the coverage actually was and not merely that a
+  # threshold was missed.
+  # ---------------------------------------------------------------------------
+  coverage:
+    name: quality / coverage floor
+    runs-on: ubuntu-24.04
+    needs: bootstrap
+    if: needs.bootstrap.outputs.ready == 'true'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.3'
+          coverage: pcov
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - run: composer install --no-interaction --prefer-dist
+      - name: Measure coverage
+        run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-text
+      - name: Enforce the coverage floor (ADR-0007)
+        run: python tools/coverage_gate.py build/logs/clover.xml --min 90
 
   # Reproducible performance gate — runs only when the project has a benchmark suite.
   #

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__/
 htmlcov/
 /.phpunit.cache/
 .phpunit.result.cache
+/build/logs/
 /.phpstan.cache/
 .php-cs-fixer.cache
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,8 @@ decisions, stricter review, and a maintained compliance-docs surface. The raised
 │   └── bugs/                       # in-repo bug ledger
 ├── tools/
 │   ├── consistency_lint.py         # agent-runnable cross-artifact congruence checker
-│   └── action_pin_lint.py          # ADR-0003 gate: CI actions pinned by SHA, comments truthful
+│   ├── action_pin_lint.py          # ADR-0003 gate: CI actions pinned by SHA, comments truthful
+│   └── coverage_gate.py            # ADR-0007 gate: total line coverage against the 90% floor
 └── .github/                        # CI + release workflows, PR/issue templates, CODEOWNERS, Dependabot
 ```
 
@@ -210,6 +211,20 @@ only that each `uses:` names a 40-hex SHA with a version comment; whether that c
 *true* can only be settled against the upstream repository, and the tool says so in its own
 output rather than letting the cheap half stand in for the whole.
 
+**Coverage floor** — CI enforces it on every PR; run it locally when you have a coverage driver
+(`pcov` or Xdebug), which is the only thing this needs that CI supplies and a bare checkout may
+not:
+
+```bash
+vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+python tools/coverage_gate.py build/logs/clover.xml --min 90
+```
+
+It enforces [ADR-0007](docs/adr/0007-measure-total-line-coverage-against-a-floor.md). A missing
+or empty report **fails** rather than skipping — a coverage gate that goes green when no driver
+was loaded reports a floor nobody is standing on. What it measures is **total** line coverage,
+not the coverage of the lines a change touched; the tool prints that limit on every run.
+
 ## 7. Documentation Maintenance
 
 Documentation is part of the deliverable. Every PR ships its own doc updates.
@@ -283,12 +298,13 @@ Every PR must clear, at minimum:
 | Format | `PHP-CS-Fixer (PSR-12)` clean |
 | Unit tests | cover the new/changed behavior; pass on every CI cell |
 | Sanitizers / checkers | PHPStan max level (type soundness); PCOV for coverage green where applicable |
-| Coverage | new code ≥ 90% line (finalized in an ADR) |
+| Coverage | ≥ 90% total line coverage, enforced in CI by `tools/coverage_gate.py` (**ADR-0007**, which finalizes what is measured: total, not per-diff) |
 | API docs | `phpDocumentor` builds without warnings |
 | Performance claims | backed by a reproducible benchmark under `src/bench/` |
 | Versioning | SemVer; `CHANGELOG.md` updated for user-visible changes |
 | Congruence | `python tools/consistency_lint.py` passes |
 | CI action pinning | `python tools/action_pin_lint.py` passes; CI runs it with `--verify-upstream` (ADR-0003) |
+| Coverage floor | `python tools/coverage_gate.py <clover.xml> --min 90` passes; CI measures and runs it (ADR-0007) |
 | Review (enterprise) | **two** approving reviews before merge; a security-relevant change also requires the `security-auditor`'s sign-off |
 | Security ADR (enterprise) | every security-relevant decision carries an ADR (§7) — no undocumented judgment calls |
 | Compliance (enterprise) | `docs/compliance/` control register current; a touched control's row updated in the same PR |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,12 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   `AGENTS.md` §10 and spec NFR-07 stated but nothing measured — PHPUnit 10 has no fail-under
   option, so a dedicated CI job produces a Clover report and the gate compares it. A missing or
   empty report fails rather than skipping. The `build` matrix no longer loads `pcov`, which it
-  never used.
+  never used. **The first measurement came back at 82.08%**: the stated bar had never been met.
+- Tests for `File`'s failure paths (unwritable directory, unopenable lock file, failed rename
+  leaving no temporary file behind, unreadable file for `read()` and `mime()`) — the branches
+  ADR-0005's design exists to handle, previously never executed — and for the static-utility
+  contract every helper class follows (final, non-instantiable, private inert constructor, all
+  public methods static).
 - Spec §7's **T-05 property-test suite** (Json round-trips, `Str::slug()` idempotence, `Env`
   boolean coercion) is now a runnable, countable unit: `vendor/bin/phpunit --group T-05`. The
   three cases already existed, landed with their own items; `#[Group('T-05')]` ties them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   `AGENTS.md` §10 and spec NFR-07 stated but nothing measured — PHPUnit 10 has no fail-under
   option, so a dedicated CI job produces a Clover report and the gate compares it. A missing or
   empty report fails rather than skipping. The `build` matrix no longer loads `pcov`, which it
-  never used. **The first measurement came back at 82.08%**: the stated bar had never been met.
+  never used. **The first measurement came back at 82.08%** — the stated bar had never been met; raised to **91.51%** in the same PR rather than by lowering the threshold.
 - Tests for `File`'s failure paths (unwritable directory, unopenable lock file, failed rename
   leaving no temporary file behind, unreadable file for `read()` and `mime()`) — the branches
   ADR-0005's design exists to handle, previously never executed — and for the static-utility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- `tools/coverage_gate.py` enforces the **≥ 90% line-coverage floor** (**ADR-0007**) that
+  `AGENTS.md` §10 and spec NFR-07 stated but nothing measured — PHPUnit 10 has no fail-under
+  option, so a dedicated CI job produces a Clover report and the gate compares it. A missing or
+  empty report fails rather than skipping. The `build` matrix no longer loads `pcov`, which it
+  never used.
 - Spec §7's **T-05 property-test suite** (Json round-trips, `Str::slug()` idempotence, `Env`
   boolean coercion) is now a runnable, countable unit: `vendor/bin/phpunit --group T-05`. The
   three cases already existed, landed with their own items; `#[Group('T-05')]` ties them

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Making spec §7's T-05 suite a mechanical fact](docs/journal/2026/08/2026-08-04-t05-property-suite.md).
+  [2026-08-04 — Closing the coverage floor, and measuring it for the first time](docs/journal/2026/08/2026-08-04-coverage-floor-gate.md).
 
 ## Model & effort routing (advisory)
 
@@ -116,14 +116,14 @@ The foundation every group depends on — the deptrac-legal bottom layer (RFC-00
       (RFC-0001) — route: fast / low. All three landed with their own items (2.2, 2.4);
       this tags them `#[Group('T-05')]` so `vendor/bin/phpunit --group T-05` runs
       spec §7's named suite as a runnable, countable unit rather than a docblock claim.
-- [ ] 2.7 Measure and enforce the coverage floor. `AGENTS.md` §10 and spec NFR-07 both state
-      **≥ 90% line coverage**, and nothing checks it: the `build` job sets up `pcov` but runs
-      `vendor/bin/phpunit` with no `--coverage` flag and no threshold, so the number is neither
-      produced nor compared. PHPUnit 10 has no fail-under option, so this needs a clover report
-      plus a threshold check. Found while writing item 2.1, which could not verify its own
-      coverage claim locally (no driver) *or* in CI (no gate) — the same
-      stated-but-ungated shape as items 1.10/1.11. Prove the gate can fail —
-      route: standard / medium
+- [x] 2.7 Measure and enforce the coverage floor. `AGENTS.md` §10 and spec NFR-07 both state
+      **≥ 90% line coverage**, and nothing checked it: the `build` job set up `pcov` but ran
+      `vendor/bin/phpunit` with no `--coverage` flag and no threshold, so the number was neither
+      produced nor compared. PHPUnit 10 has no fail-under option (a dozen `--fail-on-*` switches,
+      no coverage threshold), so this needed a Clover report plus `tools/coverage_gate.py`.
+      Settled by **ADR-0007**, which also finalizes what `AGENTS.md` §10 deferred: the figure is
+      **total** line coverage, not per-diff, and the tool says so on every run. Proved the gate
+      can fail on all five paths — route: standard / medium
 
 ---
 

--- a/docs/adr/0007-measure-total-line-coverage-against-a-floor.md
+++ b/docs/adr/0007-measure-total-line-coverage-against-a-floor.md
@@ -1,0 +1,105 @@
+# ADR-0007: Enforce the coverage floor as total line coverage, measured once
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 2.7 · `AGENTS.md` §10 · spec NFR-07 ·
+  [ADR-0003](0003-pin-ci-actions-by-commit-sha.md) (the same stated-but-ungated shape)
+
+## Context
+
+`AGENTS.md` §10 requires **"new code ≥ 90% line (finalized in an ADR)"** and spec NFR-07 requires
+**"PHPUnit line coverage ≥ 90%"**. Nothing measured either. The CI `build` job set up `pcov` and
+then ran `vendor/bin/phpunit` with no `--coverage` flag and no threshold — so the driver was
+loaded, no report was produced, and no number was ever compared. The matrix *looked* like it was
+enforcing a coverage floor while enforcing nothing, which is worse than an obviously absent
+check.
+
+This was found at item 2.1, when that item could not verify its own coverage claim: no driver
+locally, no gate in CI. It is the same shape ADR-0003 dealt with — a policy stated in prose that
+no mechanism could contradict.
+
+Three things had to be settled before a gate could exist:
+
+1. **What tool compares the number.** PHPUnit 10 ships a dozen `--fail-on-*` switches
+   (`--fail-on-risky`, `--fail-on-skipped`, …) and **no coverage threshold** among them —
+   verified against `--help`. The comparison has to live outside PHPUnit.
+2. **What "new code ≥ 90%" means.** `AGENTS.md` explicitly defers this to an ADR, and the two
+   readings differ enormously in cost: total coverage of the codebase, or coverage of the lines a
+   change touches.
+3. **What happens when the report is missing.** The failure mode that makes a coverage gate
+   worthless is passing when nothing was measured.
+
+## Decision
+
+**A dedicated CI job measures line coverage once and compares it to a 90% floor, using
+`tools/coverage_gate.py` over a Clover report. The figure compared is TOTAL line coverage.
+A missing, unparseable, or empty report fails the gate.**
+
+### Total coverage, not per-diff — and the limit is stated in the tool's own output
+
+Per-diff coverage is the stronger check: it catches an untested addition that a large,
+well-covered codebase would otherwise absorb without the total moving. It also needs the base
+ref, a line-level diff, and a per-line comparison against the report — a different class of tool.
+
+Total coverage is adopted because it is **verifiable today and honest about what it is**, and
+`tools/coverage_gate.py` prints, on every successful run:
+
+> `measured: total line coverage. NOT measured: per-diff coverage of changed lines.`
+
+That sentence is the decision's enforcement. A gate that reports 94% without saying *94% of
+what* invites exactly the misreading `AGENTS.md` §10's "new code" phrasing would produce.
+
+### Absence is failure, never a pass
+
+The gate exits non-zero when the report is missing, unparseable, has no project metrics, or
+reports **zero measurable statements**. The last case is the important one: it is what a run
+with no coverage driver produces, and a gate that treated it as "nothing failed" would go green
+on every machine where pcov was not installed — reporting a floor nobody is standing on.
+
+### Measured once, not per matrix cell
+
+Line coverage of this library does not vary by PHP version; three matrix cells would produce
+three identical numbers at three times the cost. The build matrix proves the tests **pass**
+everywhere; the coverage job proves how much they **reach**. `coverage: none` is now set on the
+build matrix, removing both the unused driver and the appearance that it was measuring something.
+
+## Alternatives Considered
+
+- **A Composer package** (`rregeer/phpunit-coverage-check`, `php-coveralls`) — rejected: it adds
+  a dev dependency, and its failure modes on a missing report are its choice rather than this
+  project's. The repository already has two stdlib-Python gates (`consistency_lint.py`,
+  `action_pin_lint.py`); a third is the established pattern and keeps "absence is failure" a
+  local decision.
+- **Per-diff coverage** — the better check, deferred rather than rejected on principle: it needs
+  base-ref plumbing and per-line comparison that this item cannot deliver honestly today. What is
+  rejected is *claiming* per-diff coverage while measuring the total, which is why the tool says
+  which one it did.
+- **Fail the whole `build` matrix on coverage** — rejected: it conflates "the tests pass on PHP
+  8.1" with "the suite reaches 90% of the code", and would triple the measurement cost for one
+  number.
+- **Warn instead of fail** — rejected: `AGENTS.md` §10 lists coverage among gates every PR *must*
+  clear, and shortcuts ("tests next PR") are explicitly disallowed there. A warning is a shortcut
+  with a nicer name.
+
+## Consequences
+
+- **The stated floor is now a fact rather than a claim.** A PR that drops total line coverage
+  below 90% goes red, and the failure output lists the files below the floor worst-first, so it
+  says where to look rather than only that a number was too small.
+- **The gate's reach is narrower than `AGENTS.md` §10's wording**, and says so in its own output
+  every time it runs. Closing that gap means per-diff coverage; until then the difference is
+  visible rather than assumed.
+- **Verified failing before being trusted.** All five failure paths were exercised against
+  synthetic Clover reports — below-floor, zero statements, unparseable XML, missing file, and the
+  passing case — rather than the gate being trusted because it went green once.
+- **Cost:** one more CI job (~30 s) and one more tool to maintain. Offset in part by dropping
+  `pcov` from the three build-matrix cells, where it was loaded and never used.
+
+## References
+
+- `AGENTS.md` §10 (the quality bar, and the "finalized in an ADR" deferral this ADR answers)
+- Spec NFR-07 — `PHPUnit line coverage >= 90%`
+- PHPUnit 10 `--help` — the absence of a coverage threshold among the `--fail-on-*` family
+- ADR-0003 — the same stated-but-ungated shape, and the precedent for closing it with a
+  stdlib-Python gate

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0004](0004-root-the-exception-hierarchy-on-an-interface.md) | Root the exception hierarchy on an interface, and close its leaves | Accepted |
 | [0005](0005-atomic-file-writes-with-a-sidecar-lock.md) | Atomic file writes, with the lock on a sidecar rather than the target | Accepted |
 | [0006](0006-shared-reflection-metadata-cache.md) | Shape the shared reflection-metadata cache as plain instances, without an interface | Accepted |
+| [0007](0007-measure-total-line-coverage-against-a-floor.md) | Enforce the coverage floor as total line coverage, measured once | Accepted |

--- a/docs/journal/2026/08/2026-08-04-coverage-floor-gate.md
+++ b/docs/journal/2026/08/2026-08-04-coverage-floor-gate.md
@@ -49,17 +49,49 @@ proves the tests *pass* everywhere, the coverage job proves how much they *reach
 sets `coverage: none` — removing both the unused driver and the appearance that it was measuring
 something.
 
-## The number is genuinely unknown as this lands
+## The first measurement: 82.08%, and the policy had never been met
 
 `phpdbg` was available locally and turned out not to help — PHPUnit 10 requires pcov or Xdebug,
 and neither is installed on this machine ("No code coverage driver available"). Downloading a
-PHP extension binary was not something to do casually, so **this PR's own CI run is the first
-time the coverage of this repository has ever been measured**.
+PHP extension binary was not something to do casually, so **this PR's own CI run was the first
+time the coverage of this repository had ever been measured**.
 
-If it comes back below 90, that is the finding — the stated policy was never met — and not a
-defect in the gate. The threshold stays at the number `AGENTS.md` §10 and NFR-07 both state;
-lowering it to make a first run green would defeat the item. `--coverage-text` runs alongside
-the machine-read report precisely so the log shows the actual figure either way.
+It came back **82.08% (174/212 lines)** — below the floor `AGENTS.md` §10 and NFR-07 have both
+stated since day one. That is the finding, not a defect in the gate: the bar was never met, and
+nothing could have told anyone.
+
+| File | Coverage | Uncovered | Why |
+|---|---|---|---|
+| `File.php` | 62.96% | **30** | the failure branches — lock, `chmod`, `rename`, `tempnam` fallback: exactly what ADR-0005 is about, never executed |
+| `Version.php` | 0.00% | 1 | contains *only* a private constructor, unreachable by design |
+| `Json.php`, `Env.php` | ~86% | 1 each | same private-constructor line |
+
+**The threshold was not lowered.** ADR-0007 argues in writing that lowering it to make a first
+run green would defeat the item, so the two honest routes were to raise coverage or to define
+exclusions; the maintainer chose to raise it, in this PR.
+
+### What was added, and why it is not coverage theatre
+
+- **`FileFailureModesTest`** — the paths ADR-0005's design exists to handle: an unwritable
+  directory, a lock file that cannot be opened, a failed `rename` (a non-empty directory
+  standing where the target should be — no permission games needed, works on every platform)
+  which must also leave **no temporary file behind**, an unreadable file for both `read()` and
+  `mime()`, and a parent path that is a file rather than a directory. Each asserts the contract
+  that makes `File` worth using over the native functions: *it fails loudly*. POSIX-mode tests
+  skip on Windows, and skip again when modes are not enforced for the process (running as root)
+  — detected empirically rather than by assuming the CI user.
+- **`StaticUtilityContractTest`** — the private constructors. It asserts the guard **is** there
+  (`final`, not instantiable, constructor private and parameterless) *and* drives that
+  constructor through reflection to confirm it is **inert**. The pairing is the point: a
+  constructor nobody has ever run is a constructor nobody has checked, and a `sleep(10)` or a
+  throw hiding in one would stay invisible until the day someone reflected on the class.
+
+One wrinkle worth recording: the "every public method is static" test asserted *inside* a loop,
+so `Version` — which has no public methods at all — ran it zero times and PHPUnit flagged the
+test risky. With `failOnRisky` on, that would have failed CI. Restructured to collect offenders
+and assert once, which always asserts.
+
+159 tests, 328 assertions locally (7 skipped, all Windows-only); PHPStan max clean.
 
 ## Next
 

--- a/docs/journal/2026/08/2026-08-04-coverage-floor-gate.md
+++ b/docs/journal/2026/08/2026-08-04-coverage-floor-gate.md
@@ -1,0 +1,72 @@
+# 2026-08-04 — Closing the coverage floor, and measuring it for the first time
+
+Roadmap item **2.7**, the last of Milestone 2. Route `standard / medium`; session model matched.
+
+## The gap this closes
+
+`AGENTS.md` §10 required "new code ≥ 90% line (finalized in an ADR)" and spec NFR-07 required
+"PHPUnit line coverage ≥ 90%". **Nothing measured either.** The CI `build` job set up `pcov` and
+then ran `vendor/bin/phpunit` with no `--coverage` flag and no threshold — driver loaded, no
+report produced, no number compared. The matrix *looked* like it was enforcing a floor while
+enforcing nothing, which is worse than an obviously absent check.
+
+Filed at item 2.1, when that item could not verify its own coverage claim. Same shape as
+ADR-0003: a policy stated in prose that no mechanism could contradict.
+
+## Three things had to be settled first
+
+1. **What compares the number.** PHPUnit 10 ships a dozen `--fail-on-*` switches
+   (`--fail-on-risky`, `--fail-on-skipped`, …) and **no coverage threshold** among them —
+   verified against `--help`, not assumed. So the comparison had to live outside PHPUnit.
+2. **What "new code ≥ 90%" means.** `AGENTS.md` explicitly deferred this to an ADR, and the two
+   readings differ enormously in cost. [ADR-0007](../../adr/0007-measure-total-line-coverage-against-a-floor.md)
+   settles it as **total** line coverage — and, more importantly, has the tool print
+   `NOT measured: per-diff coverage of changed lines` on every successful run. Per-diff is the
+   stronger check; claiming it while measuring the total is the failure this avoids.
+3. **What happens with no report.** The failure mode that makes a coverage gate worthless is
+   passing when nothing was measured. `tools/coverage_gate.py` fails on a missing file, an
+   unparseable one, a report with no project metrics, and — the important one — a report with
+   **zero measurable statements**, which is exactly what a run with no driver produces.
+
+## Proved it can fail before trusting it
+
+All five paths exercised against synthetic Clover reports, since the item demands the gate be
+shown failing rather than believed because it went green once:
+
+| Case | Result |
+|---|---|
+| 95/100 lines, floor 90 | `OK`, exit 0 |
+| 70/100 lines, floor 90 | `FAIL`, exit 1, **and names `/src/Bad.php` at 40%** worst-first |
+| zero measurable statements | `FAIL` — "nothing was measured, so there is no coverage to compare" |
+| unparseable XML | `FAIL` with the parse error |
+| missing file | `FAIL` — "a missing report means coverage was never measured, which is a failure and not a pass" |
+
+## Measured once, and `pcov` dropped from the matrix
+
+Line coverage does not vary by PHP version, so three matrix cells would produce three identical
+numbers at three times the cost. A dedicated `coverage` job measures on 8.3; the build matrix
+proves the tests *pass* everywhere, the coverage job proves how much they *reach*. The matrix now
+sets `coverage: none` — removing both the unused driver and the appearance that it was measuring
+something.
+
+## The number is genuinely unknown as this lands
+
+`phpdbg` was available locally and turned out not to help — PHPUnit 10 requires pcov or Xdebug,
+and neither is installed on this machine ("No code coverage driver available"). Downloading a
+PHP extension binary was not something to do casually, so **this PR's own CI run is the first
+time the coverage of this repository has ever been measured**.
+
+If it comes back below 90, that is the finding — the stated policy was never met — and not a
+defect in the gate. The threshold stays at the number `AGENTS.md` §10 and NFR-07 both state;
+lowering it to make a first run green would defeat the item. `--coverage-text` runs alongside
+the machine-read report precisely so the log shows the actual figure either way.
+
+## Next
+
+**Milestone 2 (`v0.2.0`) is complete** once this lands: exception hierarchy, `Str`, `File`,
+`Env`, `Json`, the shared reflection cache, the T-05 suite, and now the coverage floor.
+
+Milestone 3 (DTO & data mapping) opens — the first component group that actually consumes the
+reflection cache from item 2.5, and where `MissingKeyException` / `UnknownKeyException` /
+`TypeMismatchException` from item 2.1 get their real callers. Item 3.1 is flagged
+`sets-pattern`.

--- a/docs/journal/2026/08/2026-08-04-coverage-floor-gate.md
+++ b/docs/journal/2026/08/2026-08-04-coverage-floor-gate.md
@@ -91,7 +91,22 @@ so `Version` — which has no public methods at all — ran it zero times and PH
 test risky. With `failOnRisky` on, that would have failed CI. Restructured to collect offenders
 and assert once, which always asserts.
 
-159 tests, 328 assertions locally (7 skipped, all Windows-only); PHPStan max clean.
+Two rounds were needed, and the second is the one worth recording. The first pass took coverage
+to **88.21%** — still short, with `File.php` alone under the floor at 74.07%. The remaining gap
+was closed by testing the *other* silent trap ADR-0005 records: `tempnam()` falling back to the
+system temp directory, which would move the temporary file to another filesystem and quietly
+degrade `rename()` to copy-then-delete. `write()` pre-checks the directory, so that guard is
+unreachable through the public API — which is exactly why it had never run, and why it was worth
+reaching for directly rather than left as the one defence nobody can trigger.
+
+**Final: 194/212 lines = 91.51%**, gate green. 160 tests, 330 assertions locally
+(7 skipped, all Windows-only); PHPStan max clean.
+
+The ~18 lines still uncovered in `File.php` are defensive branches against syscall failures —
+`chmod` refusing on a file we own, a short `file_put_contents`, `flock` failing on a handle we
+just opened — that cannot be triggered portably without mocking the filesystem layer. They are
+above the floor and honestly out of reach; naming them here is better than a comment claiming
+they are covered.
 
 ## Next
 

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Closing the coverage floor, and measuring it for the first time](2026/08/2026-08-04-coverage-floor-gate.md)
 - [2026-08-04 — Making spec §7's T-05 suite a mechanical fact](2026/08/2026-08-04-t05-property-suite.md)
 - [2026-08-04 — The shared reflection cache: designing for consumers that do not exist yet](2026/08/2026-08-04-reflection-metadata-cache.md)
 - [2026-08-03 — Env::get() and Json: two functions, three probed gotchas](2026/08/2026-08-03-env-json.md)

--- a/src/test/php/d4np/utils/Support/FileFailureModesTest.php
+++ b/src/test/php/d4np/utils/Support/FileFailureModesTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\File;
+use D4np\Utils\Support\FileException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `File`'s failure paths — the ones ADR-0005's design is about, and the ones that had never
+ * been executed until the coverage floor (item 2.7) made their absence visible.
+ *
+ * These are not coverage theatre. Each asserts the contract that makes `File` worth using over
+ * the native functions: **it fails loudly**. A filesystem error that returns `false` and is not
+ * checked is how unchecked code silently loses data, so every one of these paths must produce a
+ * `FileException` with a message that says what went wrong — and until now, none of them had
+ * been shown to.
+ *
+ * POSIX permission bits are the lever for most of them, so those tests skip on Windows, and
+ * skip again when the process can write regardless of mode (running as root, where permission
+ * checks do not apply) — detected empirically rather than by assuming the CI user.
+ */
+final class FileFailureModesTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $base = sys_get_temp_dir() . '/egl-utils-failtest-' . bin2hex(random_bytes(8));
+        if (!mkdir($base) && !is_dir($base)) {
+            self::fail(sprintf('could not create the test directory "%s"', $base));
+        }
+        $this->dir = $base;
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore write permission before cleanup: a test that made the directory read-only
+        // would otherwise leave an undeletable tree behind.
+        @chmod($this->dir, 0777);
+        foreach (glob($this->dir . '/*') ?: [] as $entry) {
+            @chmod($entry, 0666);
+            if (is_file($entry)) {
+                @unlink($entry);
+            }
+        }
+        if (is_dir($this->dir)) {
+            @rmdir($this->dir);
+        }
+    }
+
+    private function path(string $name): string
+    {
+        return $this->dir . '/' . $name;
+    }
+
+    /** Skip when POSIX modes cannot actually restrict this process. */
+    private function requireEnforceablePermissions(string $probe): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX permission bits are not enforced on Windows');
+        }
+
+        clearstatcache(true, $probe);
+        if (is_writable($probe)) {
+            self::markTestSkipped('permissions are not enforced for this process (running as root?)');
+        }
+    }
+
+    public function testWritingIntoAnUnwritableDirectoryFailsLoudly(): void
+    {
+        chmod($this->dir, 0555);
+        $this->requireEnforceablePermissions($this->dir);
+
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('is not writable');
+
+        File::write($this->path('nope.txt'), 'content');
+    }
+
+    public function testWritingFailsLoudlyWhenTheLockFileCannotBeOpened(): void
+    {
+        // The sidecar lock is opened before any temp file is created (ADR-0005). An existing
+        // lock file the process cannot open stops the write with a clear message rather than
+        // proceeding unserialised.
+        $target = $this->path('locked.txt');
+        $lock = $target . '.lock';
+        touch($lock);
+        chmod($lock, 0000);
+        $this->requireEnforceablePermissions($lock);
+
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('lock file');
+
+        File::write($target, 'content');
+    }
+
+    /**
+     * The rename is the one step that cannot be retried halfway: if it fails, the temporary file
+     * must not be left behind as litter, and the caller must be told.
+     *
+     * A directory standing where the target should be makes `rename()` fail on any platform —
+     * no permission games needed.
+     */
+    public function testAFailedRenameThrowsAndLeavesNoTemporaryFileBehind(): void
+    {
+        $target = $this->path('target');
+        mkdir($target);
+        // A non-empty directory cannot be replaced by rename() on any supported platform.
+        file_put_contents($target . '/occupant', 'x');
+
+        try {
+            File::write($target, 'content');
+            self::fail('expected a FileException');
+        } catch (FileException $e) {
+            self::assertStringContainsString('rename', $e->getMessage());
+        }
+
+        $leftovers = array_values(array_filter(
+            glob($this->dir . '/*') ?: [],
+            static fn (string $entry): bool => str_contains(basename($entry), '.egl-utils-'),
+        ));
+        self::assertSame([], $leftovers, 'a failed write must clean up its own temporary file');
+
+        unlink($target . '/occupant');
+        rmdir($target);
+    }
+
+    public function testReadingAnUnreadableFileFailsLoudly(): void
+    {
+        $path = $this->path('unreadable.txt');
+        file_put_contents($path, 'secret');
+        chmod($path, 0000);
+
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX permission bits are not enforced on Windows');
+        }
+        clearstatcache(true, $path);
+        if (is_readable($path)) {
+            self::markTestSkipped('permissions are not enforced for this process (running as root?)');
+        }
+
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('failed to open for reading');
+
+        File::read($path);
+    }
+
+    public function testMimeDetectionOnAnUnreadableFileFailsLoudly(): void
+    {
+        $path = $this->path('unreadable.bin');
+        file_put_contents($path, 'GIF89a');
+        chmod($path, 0000);
+
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX permission bits are not enforced on Windows');
+        }
+        clearstatcache(true, $path);
+        if (is_readable($path)) {
+            self::markTestSkipped('permissions are not enforced for this process (running as root?)');
+        }
+
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('detection failed');
+
+        File::mime($path);
+    }
+
+    public function testWritingToAPathWhoseParentIsAFileFailsLoudly(): void
+    {
+        // dirname() of "<file>/child.txt" is a regular file, so is_dir() is false — the first
+        // guard in write(), reached here through a realistic mistake rather than a contrived one.
+        $file = $this->path('a-file.txt');
+        file_put_contents($file, 'x');
+
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        File::write($file . '/child.txt', 'content');
+    }
+}

--- a/src/test/php/d4np/utils/Support/FileFailureModesTest.php
+++ b/src/test/php/d4np/utils/Support/FileFailureModesTest.php
@@ -168,6 +168,35 @@ final class FileFailureModesTest extends TestCase
         File::mime($path);
     }
 
+    /**
+     * The second silent trap ADR-0005 records: **`tempnam()` falls back to the system temp
+     * directory** when it cannot use the one it was given. That would put the temporary file on
+     * another filesystem, at which point `rename()` stops being atomic and degrades to
+     * copy-then-delete — the guarantee evaporating with no error anywhere.
+     *
+     * `write()` pre-checks the directory, so this guard is unreachable through the public API —
+     * which is exactly why it needs testing directly. A defence nobody can trigger is a defence
+     * nobody has verified, and this one protects the property the whole class exists for.
+     *
+     * Verified first: `tempnam()` on a non-existent directory really does return a path in the
+     * system temp directory rather than `false`.
+     */
+    public function testTheTempFileGuardRefusesAFallbackToAnotherDirectory(): void
+    {
+        $method = new \ReflectionMethod(File::class, 'createTempFileIn');
+        $method->setAccessible(true);
+
+        $nonExistent = $this->dir . '/no-such-subdirectory';
+
+        try {
+            $method->invoke(null, $nonExistent);
+            self::fail('expected a FileException — tempnam() falls back silently and must be refused');
+        } catch (FileException $e) {
+            self::assertStringContainsString('cross filesystems', $e->getMessage());
+            self::assertStringContainsString('atomicity', $e->getMessage());
+        }
+    }
+
     public function testWritingToAPathWhoseParentIsAFileFailsLoudly(): void
     {
         // dirname() of "<file>/child.txt" is a regular file, so is_dir() is false — the first

--- a/src/test/php/d4np/utils/Support/StaticUtilityContractTest.php
+++ b/src/test/php/d4np/utils/Support/StaticUtilityContractTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Env;
+use D4np\Utils\Support\File;
+use D4np\Utils\Support\Json;
+use D4np\Utils\Support\Str;
+use D4np\Utils\Version;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The static-utility contract every helper class in this library follows.
+ *
+ * Each of these exposes only static methods and declares a private constructor so it cannot be
+ * instantiated. That constructor is the guard, and it is *unreachable by design* — which is
+ * exactly why it had never been executed, and why these classes were dragging the coverage floor
+ * down (roadmap 2.7): `Version` sat at 0%, its private constructor being the only executable
+ * line it has.
+ *
+ * The test does two things rather than one, and the pairing is the point: it asserts the guard
+ * **is** there (`new` is impossible from outside), and it drives the constructor through
+ * reflection to confirm the guard is **inert** — that it does no work, allocates nothing, and
+ * cannot fail. A constructor nobody has ever run is a constructor nobody has checked; a
+ * `sleep(10)` or a thrown exception hiding in one would be invisible until the day someone
+ * reflected on the class.
+ */
+final class StaticUtilityContractTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function staticUtilityClasses(): iterable
+    {
+        yield 'Version' => [Version::class];
+        yield 'Str' => [Str::class];
+        yield 'File' => [File::class];
+        yield 'Env' => [Env::class];
+        yield 'Json' => [Json::class];
+    }
+
+    /**
+     * @param class-string $class
+     */
+    #[DataProvider('staticUtilityClasses')]
+    public function testTheClassIsFinalAndCannotBeInstantiatedNormally(string $class): void
+    {
+        $reflection = new ReflectionClass($class);
+
+        self::assertTrue($reflection->isFinal(), sprintf('%s must be final', $class));
+        self::assertFalse(
+            $reflection->isInstantiable(),
+            sprintf('%s must not be instantiable — its constructor is the guard', $class),
+        );
+
+        $constructor = $reflection->getConstructor();
+        self::assertNotNull($constructor, sprintf('%s must declare a constructor to make private', $class));
+        self::assertTrue($constructor->isPrivate(), sprintf('%s::__construct() must be private', $class));
+        self::assertSame(
+            0,
+            $constructor->getNumberOfParameters(),
+            sprintf('%s::__construct() takes no parameters — it exists only to be private', $class),
+        );
+    }
+
+    /**
+     * @param class-string $class
+     */
+    #[DataProvider('staticUtilityClasses')]
+    public function testThePrivateConstructorIsInert(string $class): void
+    {
+        // Reflection is the only way to reach it, which is the whole point of the guard. Driving
+        // it here proves the constructor does nothing: it returns an object and throws nothing.
+        // Without this, the one statement in it has never run anywhere.
+        $reflection = new ReflectionClass($class);
+
+        $instance = $reflection->newInstanceWithoutConstructor();
+        $constructor = $reflection->getConstructor();
+        self::assertNotNull($constructor);
+        $constructor->setAccessible(true);
+        $constructor->invoke($instance);
+
+        self::assertInstanceOf($class, $instance);
+    }
+
+    /**
+     * @param class-string $class
+     */
+    #[DataProvider('staticUtilityClasses')]
+    public function testEveryPublicMethodIsStatic(string $class): void
+    {
+        // The other half of the contract: a private constructor is pointless if some public
+        // method needs an instance it can never get.
+        //
+        // Collected into a list and asserted once, rather than asserted inside the loop: a class
+        // with no public methods at all (Version) would otherwise run the loop zero times and
+        // assert nothing, which PHPUnit correctly flags as risky — and `failOnRisky` is on.
+        $nonStatic = [];
+        foreach ((new ReflectionClass($class))->getMethods() as $method) {
+            if ($method->isPublic() && !$method->isStatic()) {
+                $nonStatic[] = $method->getName();
+            }
+        }
+
+        self::assertSame(
+            [],
+            $nonStatic,
+            sprintf('%s has public non-static method(s): %s', $class, implode(', ', $nonStatic)),
+        );
+    }
+}

--- a/tools/coverage_gate.py
+++ b/tools/coverage_gate.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Daniel Polo
+"""Coverage-floor gate for egl-util-php — the mechanical check behind ADR-0007.
+
+`AGENTS.md` §10 and spec NFR-07 both require **≥ 90% line coverage**. Until this tool existed
+nothing measured it: the CI `build` job set up `pcov` and then ran `vendor/bin/phpunit` with no
+`--coverage` flag and no threshold, so the number was neither produced nor compared. PHPUnit 10
+offers a dozen `--fail-on-*` switches and no coverage threshold among them (verified against
+`--help`), so the comparison has to live outside it.
+
+Reads a Clover XML report and compares the project's line coverage to a floor.
+
+    php -d pcov.enabled=1 vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+    python tools/coverage_gate.py build/logs/clover.xml --min 90
+
+**Absence is failure, never a pass.** A missing report, an unparseable one, or one that measured
+zero statements all exit non-zero. A coverage gate that goes green when the driver was not
+installed is worse than no gate: it reports a floor nobody is standing on.
+
+Exits 0 when the floor is met, 1 otherwise.
+"""
+
+import argparse
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+DEFAULT_MIN = 90.0
+
+
+class GateError(Exception):
+    """A condition that must fail the gate rather than be reported as coverage."""
+
+
+def load_project_metrics(path):
+    """The aggregate `<metrics>` under `<project>`, as (statements, covered).
+
+    Clover nests per-file metrics inside the project element and repeats the totals on the
+    project's own `<metrics>` child. That aggregate is the one to compare; summing the per-file
+    ones by hand would silently disagree with every other Clover consumer.
+    """
+    if not os.path.isfile(path):
+        raise GateError(
+            f"no coverage report at {path}. The report is produced by "
+            "`phpunit --coverage-clover <path>` and needs pcov or Xdebug loaded; a missing "
+            "report means coverage was never measured, which is a failure and not a pass."
+        )
+
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        raise GateError(f"{path} is not parseable as Clover XML: {exc}") from exc
+
+    project = root.find("project")
+    if project is None:
+        raise GateError(f"{path} has no <project> element — not a Clover report?")
+
+    metrics = project.find("metrics")
+    if metrics is None:
+        raise GateError(f"{path} has no project-level <metrics> element")
+
+    try:
+        statements = int(metrics.get("statements", "0"))
+        covered = int(metrics.get("coveredstatements", "0"))
+    except ValueError as exc:
+        raise GateError(f"{path} has non-numeric metrics: {exc}") from exc
+
+    if statements == 0:
+        raise GateError(
+            f"{path} reports zero measurable statements. Either the source filter matched no "
+            "files or no driver was active — either way nothing was measured, so there is no "
+            "coverage to compare."
+        )
+
+    return statements, covered
+
+
+def files_below(path, minimum):
+    """Per-file coverage below `minimum`, worst first, as (file, pct, covered, statements).
+
+    Reported on failure so the output says where to look, rather than only that a number was
+    too small.
+    """
+    root = ET.parse(path).getroot()
+    project = root.find("project")
+    if project is None:
+        return []
+
+    out = []
+    for f in project.iter("file"):
+        m = f.find("metrics")
+        if m is None:
+            continue
+        statements = int(m.get("statements", "0"))
+        if statements == 0:
+            continue
+        covered = int(m.get("coveredstatements", "0"))
+        pct = covered / statements * 100
+        if pct < minimum:
+            name = f.get("name") or f.get("path") or "<unknown>"
+            out.append((name, pct, covered, statements))
+
+    out.sort(key=lambda row: row[1])
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Fail when line coverage is below the floor.")
+    ap.add_argument("report", nargs="?", default="build/logs/clover.xml",
+                    help="path to the Clover XML report (default: build/logs/clover.xml)")
+    ap.add_argument("--min", type=float, default=DEFAULT_MIN,
+                    help=f"minimum line coverage percent (default: {DEFAULT_MIN:g})")
+    args = ap.parse_args(argv)
+
+    try:
+        statements, covered = load_project_metrics(args.report)
+    except GateError as exc:
+        print(f"coverage gate: FAIL\n\n  {exc}")
+        return 1
+
+    pct = covered / statements * 100
+    print(f"coverage gate: {covered}/{statements} lines = {pct:.2f}% (floor {args.min:g}%)")
+
+    if pct + 1e-9 < args.min:
+        print("\ncoverage gate: FAIL — below the floor required by AGENTS.md §10 and spec NFR-07.\n")
+        below = files_below(args.report, args.min)
+        if below:
+            print(f"  {len(below)} file(s) under {args.min:g}%, worst first:")
+            for name, file_pct, file_covered, file_statements in below[:20]:
+                print(f"    {file_pct:6.2f}%  {file_covered:4d}/{file_statements:<4d}  {name}")
+            if len(below) > 20:
+                print(f"    … and {len(below) - 20} more")
+        return 1
+
+    print("coverage gate: OK")
+
+    # What this gate does NOT measure, stated in its own output rather than left to the reader
+    # (ADR-0007): the figure above is TOTAL line coverage, not the coverage of the lines this
+    # change touched. A large well-covered codebase can absorb an untested addition without the
+    # total moving. Diff-aware coverage needs the base ref and a per-line comparison, which is
+    # deliberately out of scope here.
+    print("  measured: total line coverage. NOT measured: per-diff coverage of changed lines.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

Roadmap item **2.7**, the last of Milestone 2 — filed back at item 2.1, when that item could not
verify its own coverage claim.

`AGENTS.md` §10 required *"new code ≥ 90% line (finalized in an ADR)"* and spec NFR-07 required
*"PHPUnit line coverage ≥ 90%"*. **Nothing measured either.** The CI `build` job set up `pcov`
and then ran `vendor/bin/phpunit` with no `--coverage` flag and no threshold — driver loaded, no
report produced, no number compared. The matrix *looked* like it enforced a floor while enforcing
nothing, which is worse than an obviously absent check, and is the same shape ADR-0003 dealt with.

## Three things settled before a gate could exist

1. **What compares the number.** PHPUnit 10 ships a dozen `--fail-on-*` switches
   (`--fail-on-risky`, `--fail-on-skipped`, …) and **no coverage threshold** among them —
   verified against `--help`. So the comparison lives outside PHPUnit, in
   `tools/coverage_gate.py`: the third stdlib-Python gate, matching `consistency_lint` and
   `action_pin_lint`, which keeps "absence is failure" a local decision rather than a
   dependency's choice.
2. **What "new code ≥ 90%" means** — `AGENTS.md` explicitly deferred this to an ADR.
   **[ADR-0007](docs/adr/0007-measure-total-line-coverage-against-a-floor.md)** settles it as
   **total** line coverage and, more importantly, has the tool print
   `NOT measured: per-diff coverage of changed lines` on **every successful run**. Per-diff is
   the stronger check; claiming it while measuring the total is exactly the failure this avoids.
3. **What happens with no report.** A missing file, an unparseable one, one with no project
   metrics, and — the important case — one reporting **zero measurable statements** all exit
   non-zero. That last is what a run with no driver produces, and a gate treating it as "nothing
   failed" would go green on every machine without pcov, reporting a floor nobody stands on.

## Verification — proved it can fail before trusting it

All five paths, against synthetic Clover reports:

| Case | Result |
|---|---|
| 95/100 lines, floor 90 | `OK`, exit 0 |
| 70/100 lines, floor 90 | `FAIL`, exit 1, **and names `/src/Bad.php` at 40%** worst-first |
| zero measurable statements | `FAIL` — *"nothing was measured, so there is no coverage to compare"* |
| unparseable XML | `FAIL` with the parse error |
| missing file | `FAIL` — *"a missing report means coverage was never measured, which is a failure and not a pass"* |

Also: 138 tests / 284 assertions unchanged · PHPStan max clean · PHP-CS-Fixer clean ·
`consistency_lint` OK · `action_pin_lint --verify-upstream` OK (**23** pinned references now —
the three new ones in the coverage job included, and verified upstream).

## Measured once, and `pcov` dropped from the matrix

Line coverage does not vary by PHP version, so three matrix cells would be three identical
numbers at three times the cost. A dedicated `coverage` job measures on 8.3; the build matrix
proves the tests *pass* everywhere, this proves how much they *reach*. The matrix now sets
`coverage: none`, removing both an unused driver and the appearance that it measured something.

## ⚠️ The number is genuinely unknown as this lands

`phpdbg` is available locally and does not help — PHPUnit 10 requires pcov or Xdebug, neither of
which is installed here ("No code coverage driver available"), and downloading a PHP extension
binary was not something to do casually. **So this PR's own CI run is the first time this
repository's coverage has ever been measured.**

If it comes back **below 90, that is the finding** — the stated policy was never met — and not a
defect in the gate. The threshold stays at the number both `AGENTS.md` §10 and NFR-07 state;
lowering it to make a first run green would defeat the item. `--coverage-text` runs alongside the
machine-read report precisely so the log shows the actual figure either way.

**Cross-links:** `AGENTS.md` §10 · spec NFR-07 · ADR-0003 (the precedent), ADR-0007 · roadmap
item 2.7 · milestone `v0.2.0`. Type label: `ci` (declared in `.github/labels.yml`, still not
imported); `enhancement` set as the closest available default.

**Milestone 2 (`v0.2.0`) is complete once this lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
