### PR TITLE
feat(dto): add DataTransferObject with strict-by-default hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- `D4np\Utils\Dto\DataTransferObject` (**ADR-0008**) — typed, immutable DTOs hydrated from
+  arrays: `UserDto::fromArray($data)` is **strict by default** (an undeclared key raises
+  `UnknownKeyException`, so a typo or a mass-assignment attempt cannot pass silently), and
+  `UserDto::lenient()->fromArray($data)` is the per-call opt-out that ignores extra keys while
+  still requiring declared ones and still type-checking. Nested DTOs hydrate recursively, and
+  every failure names its path (`customer.address.postcode`). Absence follows RFC-0001 R-4: a
+  defaulted parameter keeps its default, a nullable one without a default becomes `null`, and
+  anything else raises `MissingKeyException`. `Collection<T>` properties land with `Collection`
+  itself.
 - `tools/coverage_gate.py` enforces the **≥ 90% line-coverage floor** (**ADR-0007**) that
   `AGENTS.md` §10 and spec NFR-07 stated but nothing measured — PHPUnit 10 has no fail-under
   option, so a dedicated CI job produces a Clover report and the gate compares it. A missing or

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Closing the coverage floor, and measuring it for the first time](docs/journal/2026/08/2026-08-04-coverage-floor-gate.md).
+  [2026-08-04 — Milestone 3 opens: DTO hydration, and PHP disagreeing with the requirement](docs/journal/2026/08/2026-08-04-dto-hydration.md).
 
 ## Model & effort routing (advisory)
 
@@ -131,9 +131,12 @@ The foundation every group depends on — the deptrac-legal bottom layer (RFC-00
 
 Typed, mass-assignment-safe data transfer (RFC-0001).
 
-- [ ] 3.1 `DataTransferObject`: strict/lenient hydration, `MissingKeyException` semantics,
+- [x] 3.1 `DataTransferObject`: strict/lenient hydration, `MissingKeyException` semantics,
       nested DTOs, `Collection<T>` properties (RFC-0001 R-4) (sets-pattern) —
-      route: frontier-reasoning / high
+      route: frontier-reasoning / high · **ADR-0008**. *`Collection<T>` hydration is NOT in
+      this item: `Collection` itself is 3.3, and ADR-0006 deliberately placed the docblock
+      generic parser it needs there. Everything else — strict/lenient, R-4 optionality, nested
+      DTOs, path-carrying type mismatches — is done and covered by the T-01 suite.*
 - [ ] 3.2 `WithersTrait` with per-version readonly-clone handling 8.1→8.3 (RFC-0001)
       (severity:medium) — route: standard / medium
 - [ ] 3.3 `Collection<T>` with `@template` discipline enforced by PHPStan max (RFC-0001)
@@ -141,6 +144,13 @@ Typed, mass-assignment-safe data transfer (RFC-0001).
 - [ ] 3.4 T-01 hydration matrix suite (RFC-0001) — route: fast / low
 - [ ] 3.5 phpbench: NFR-01 hydration + NFR-04 memory benchmarks (RFC-0001) (step:optimize) —
       route: fast / medium
+- [ ] 3.6 Add `deptrac.yaml` and turn on the layering gate. RFC-0001's dependency rule — *groups
+      depend downward on Support only; no cross-group imports* — has had nothing enforcing it:
+      the CI `layering` job self-skips until the config lands (the step-level guard from item
+      1.9). Until item 3.1 there was only one group, so the rule was vacuous; now that `Dto`
+      depends on `Support` it is a real constraint with a real direction, and the next four
+      milestones each add a group that could violate it. Prove the gate can fail by planting a
+      cross-group import — route: standard / medium
 
 ---
 
@@ -227,6 +237,6 @@ Legend: ⏳ not started · 🚧 in progress · ✅ done · ❎ N/A.
 | §4 | NFR budgets & benchmark methodology | 3.5, 4.5, 5.5, 6.4, 7.1 | ⏳ |
 | §5 | Security test criteria | 4.4, 5.4, 5.5, 6.3 | ⏳ |
 | §6 | API example / public interface | 1.6, 3.1 | ⏳ |
-| §7 | Verification & test strategy | 1.2, 2.6, 3.4, 4.4, 6.3 | 🚧 |
+| §7 | Verification & test strategy | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3 | 🚧 |
 | §8 | CI/CD & release engineering | 1.4, 1.7, 7.1–7.3 | ⏳ |
 | §9 | Decision log (imported + seeded ADRs) | 2.1, 5.3, 7.4 | 🚧 |

--- a/docs/adr/0008-dto-hydration-strictness-and-shared-hydrator.md
+++ b/docs/adr/0008-dto-hydration-strictness-and-shared-hydrator.md
@@ -1,0 +1,128 @@
+# ADR-0008: Strict-by-default hydration, and how a static entry point reaches shared state
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 3.1 · [RFC-0001](../rfc/0001-egl-utils-library.md) R-4 · spec FR-01 ·
+  [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md) ·
+  [ADR-0006](0006-shared-reflection-metadata-cache.md) (whose deferred question this answers)
+
+## Context
+
+Spec FR-01 and RFC-0001 fix the *behaviour*: strict hydration by default with an unknown key
+rejected, `lenient()` as the opt-out, `MissingKeyException` when a key that is neither nullable
+nor defaulted is absent, recursion into nested DTOs, and a `TypeMismatchException` that names the
+path. Roadmap item 3.1 is flagged `sets-pattern` — this is the first component group to consume
+`Support`, so its shape is the one Milestones 4–6 copy.
+
+Three things had to be decided, and one of them is a question a previous ADR deliberately left
+open until this moment.
+
+**1. How does a static entry point reach shared state?** The spec's own example is
+`UserDto::fromArray($data)` — a static call. It needs the one `ReflectionCache` imported ADR-001
+commits to, and a static method has no instance to be injected into. ADR-0006 named this
+explicitly and declined to guess: *"Building it now means guessing at reset semantics,
+thread/process assumptions, and testability for a caller that has not been written. Milestone 3
+will have the real constraint in hand."* This is Milestone 3.
+
+**2. What shape does the opt-out take?** `lenient()` has to return something, and the obvious
+alternative — `fromArray($data, lenient: true)` — reads differently at the call site.
+
+**3. What PHP actually does with absent arguments**, which turned out not to match the intuition
+the requirement is written in. Verified directly before writing a line:
+
+| Construct | Result |
+|---|---|
+| named-argument spread from a string-keyed array, key omitted | PHP applies the declared default |
+| `?string $x` with **no** default, argument omitted | **`ArgumentCountError`** — nullable is *not* optional in PHP |
+| `int` passed where `float` is declared, under `strict_types=1` | **accepted**, widened to float |
+
+The middle row is the one that matters: RFC-0001 R-4 says a nullable property absent from the
+payload "hydrates to `null`", and that only holds if `null` is passed **explicitly**. An
+implementation that treats nullable and defaulted the same way — omitting both — raises
+`ArgumentCountError` instead, which is neither the documented behaviour nor a library exception.
+
+## Decision
+
+**Strict hydration is the default; `lenient()` returns a `Hydration<T>` bound to the class; and
+`DataTransferObject` holds one lazily-created process-wide `Hydrator` in a private static, which
+needs no reset hook because the state it holds is immutable.**
+
+### Absence is resolved in three cases, in this order
+
+1. **Has a declared default** → the argument is *omitted*, and PHP applies the default. Nothing
+   is replicated here.
+2. **Nullable without a default** → `null` is passed **explicitly**, because PHP would otherwise
+   raise `ArgumentCountError` (evidence above). This is what makes R-4 true rather than aspirational.
+3. **Neither** → `MissingKeyException`, naming the path.
+
+The order is load-bearing: a parameter that is both nullable *and* defaulted takes its default,
+not `null`, which is what a reader of the declaration would expect.
+
+### The shared hydrator needs no reset, and that is why it is safe
+
+ADR-0006's hesitation was about reset semantics and testability. Both dissolve on inspection:
+the cache memoises **immutable facts** — a class's constructor cannot change while the process
+runs — so there is no stale state a test could observe, and nothing to invalidate. What would
+have been a mutable global is a pure memo table. The *mode* (strict or lenient), by contrast, is
+per-call and never stored, so a lenient call cannot leak into a later strict one.
+
+### `lenient()` returns a type, not a boolean
+
+`Hydration<T>` is a two-line object bound to one class. The alternative,
+`fromArray($data, lenient: true)`, costs nothing to write and something to read: a bare `true`
+at a call site says nothing about which policy it selects, whereas `UserDto::lenient()->fromArray(…)`
+says it in the method name. It is also generic, so PHPStan keeps the concrete DTO type through
+the call.
+
+### Leniency relaxes what may arrive, not what must be present
+
+A lenient hydration still raises `MissingKeyException` for an absent required key and still
+type-checks every value. Without that, `lenient()` quietly becomes "skip validation", which is
+not what the spec offers it for, and the suite asserts it directly.
+
+## Alternatives Considered
+
+- **A trait instead of a base class** — rejected: the spec's example writes `extends
+  DataTransferObject`, `static::class` is needed for the metadata lookup either way, and a trait
+  cannot express the `Hydration<static>` return type as cleanly.
+- **A boolean flag on `fromArray()`** — rejected on readability, as above.
+- **Injecting the cache/hydrator per call** (`UserDto::fromArray($data, $cache)`) — rejected: it
+  pushes the shared-instance problem onto every call site to solve the same problem once, and the
+  spec's example shows a bare static call.
+- **Treating nullable and defaulted identically** (omit both) — rejected on evidence: it raises
+  `ArgumentCountError` for the nullable-without-default case, contradicting R-4.
+- **Rejecting `int` where `float` is declared** — rejected: PHP performs that widening itself
+  under `strict_types=1`, so refusing it would make this library stricter than the language and
+  reject payloads the constructor would have accepted.
+- **Hydrating arbitrary classes from arrays**, not just DTOs — rejected: there is no general way
+  to know an arbitrary constructor's intent. A non-DTO class parameter accepts an instance and
+  refuses an array, which is honest about what the library can and cannot build.
+
+## Consequences
+
+- **Mass assignment is refused by default.** An undeclared key is an error, not a silent drop,
+  which is the property the strict default exists for.
+- **A failure in a graph says where it happened.** Paths compose through recursion
+  (`customer.address.postcode`), so a nested `TypeMismatchException` is actionable. Asserted for
+  all three failure kinds at depth.
+- **No bare `TypeError` escapes.** Construction is wrapped and converted to a
+  `HydrationException`, so ADR-0004's "one thing to catch" contract holds even for a type the
+  checks did not anticipate — an exotic builtin, or a union arm the metadata deliberately does
+  not reduce (ADR-0006).
+- **A variadic constructor is refused, not guessed at.** A keyed payload cannot express "an
+  arbitrary number of positional arguments", so it raises rather than inventing a mapping.
+- **`Collection<T>` hydration is not here.** Spec FR-01 names it, and it needs the docblock
+  generic parser ADR-0006 deliberately placed with `Collection` itself — roadmap item 3.3. The
+  gap is named rather than left for a reader to discover.
+- **Cost:** three classes (`DataTransferObject`, `Hydrator`, `Hydration`) where a single one with
+  a boolean would do. The split buys a readable call site, a testable engine, and a recursion
+  that carries its own path.
+
+## References
+
+- Spec FR-01; RFC-0001 *Error model* and R-4 (the missing-key addition made at review)
+- ADR-0006 — the deferred static-entry-point question this ADR answers, with the constraint in hand
+- ADR-0004 — the exception contract construction must not break
+- PHP manual: named arguments, `strict_types` widening rules — both verified directly rather than
+  taken from the documentation

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0005](0005-atomic-file-writes-with-a-sidecar-lock.md) | Atomic file writes, with the lock on a sidecar rather than the target | Accepted |
 | [0006](0006-shared-reflection-metadata-cache.md) | Shape the shared reflection-metadata cache as plain instances, without an interface | Accepted |
 | [0007](0007-measure-total-line-coverage-against-a-floor.md) | Enforce the coverage floor as total line coverage, measured once | Accepted |
+| [0008](0008-dto-hydration-strictness-and-shared-hydrator.md) | Strict-by-default hydration, and how a static entry point reaches shared state | Accepted |

--- a/docs/journal/2026/08/2026-08-04-dto-hydration.md
+++ b/docs/journal/2026/08/2026-08-04-dto-hydration.md
@@ -69,8 +69,27 @@ Three probes, each reverted and the implementation restored byte-identical:
    `ArgumentCountError` the probe above predicted.
 3. **Stopped composing paths in recursion** (leaf name only) → 3 failures, all the depth tests.
 
-194 tests, 382 assertions (7 skipped, Windows-only). PHPStan max clean; `--group T-01` runs the
-spec's named hydration matrix as its own unit, 34 tests.
+199 tests, 389 assertions (7 skipped, Windows-only). PHPStan max clean; `--group T-01` runs the
+spec's named hydration matrix as its own unit.
+
+## The coverage gate stopped my own code, and found a design defect
+
+The floor from item 2.7 rejected the first push at **86.87%**, `Hydrator` at 73.75%. Reading
+what was uncovered turned up more than a testing gap: `satisfiesBuiltin()` had `match` arms for
+`null`, `true` and `false` — types that only exist as standalone declarations **from PHP 8.2**,
+below this project's 8.1 floor. They were unreachable on the minimum supported version and would
+merely have *looked* like coverage on 8.3. Removed; the `default` arm handles them correctly,
+because PHP's own check runs at construction and the `TypeError` conversion carries the path.
+`callable` went the same way — it cannot be a property type at all.
+
+One branch stays uncovered **on purpose**, and the code now says so: the `class_exists` guard on
+a parameter type. Reaching it needs a DTO whose parameter type does not exist, and **PHPStan at
+max rejects exactly that** (`class.notFound`) — so the state cannot occur in this codebase. A
+fixture to cover it was written, seen rejected by the linter, and removed rather than suppressed
+with `@phpstan-ignore`. The check stays because it is what narrows `string` to `class-string` for
+the type system, and a consumer not running PHPStan can still reach it.
+
+Final: **270/293 lines = 92.15%**, gate green.
 
 ## Two gaps named rather than left
 

--- a/docs/journal/2026/08/2026-08-04-dto-hydration.md
+++ b/docs/journal/2026/08/2026-08-04-dto-hydration.md
@@ -1,0 +1,90 @@
+# 2026-08-04 — Milestone 3 opens: DTO hydration, and PHP disagreeing with the requirement
+
+Roadmap item **3.1**, the third `sets-pattern` item and the first component group to consume
+`Support`. Route `frontier-reasoning / high`; the session ran on `opus-5` (standard tier) — the
+mismatch was surfaced and the maintainer, who holds model authority (ADR-0017), proceeded.
+
+## The finding: PHP does not agree with how R-4 is written
+
+RFC-0001 R-4 says a property "neither nullable nor defaulted" is required, and that a nullable
+or defaulted property absent from the payload "hydrates to `null`/its default". Read plainly,
+that suggests treating nullable and defaulted the same way — omit the argument and let PHP sort
+it out. Probed before writing a line:
+
+| Construct | Result |
+|---|---|
+| named-argument spread, key omitted | PHP applies the declared default |
+| `?string $x` with **no** default, argument omitted | **`ArgumentCountError`** |
+| `int` where `float` is declared, under `strict_types=1` | **accepted**, widened |
+
+**Nullable is not optional in PHP.** A `?string $x` with no default is a *required* parameter.
+So R-4's "hydrates to null" only holds if `null` is passed **explicitly** — an implementation
+that omits both cases raises `ArgumentCountError`, which is neither the documented behaviour nor
+a library exception. The three absence cases are now resolved in a deliberate order, and a
+parameter that is both nullable *and* defaulted takes its default, which is what a reader of the
+declaration expects.
+
+The third row shaped a different decision: `int` where `float` is declared is **accepted**,
+because PHP performs that widening itself under `strict_types`. Refusing it would make this
+library stricter than the language and reject payloads the constructor would have taken.
+
+## Answering the question ADR-0006 deliberately left open
+
+ADR-0006 declined to build a `shared()` accessor for the reflection cache: *"Milestone 3 will
+have the real constraint in hand."* It does — `fromArray()` is static, and a static method has
+no instance to inject into.
+
+The resolution turned out cleaner than the hesitation implied. ADR-0006 worried about reset
+semantics and testability; both dissolve because the cache memoises **immutable facts** — a
+class's constructor cannot change while the process runs — so there is no stale state to
+invalidate and no reset hook to design. What would have been a mutable global is a pure memo
+table. The *mode* (strict/lenient) is per-call and never stored, and the suite asserts directly
+that a lenient call does not leak into a later strict one.
+
+That is the value of the deferral rather than a cost of it: guessing in Milestone 2 would have
+produced a `reset()` in the production API for a problem that does not exist.
+
+## Shape
+
+Three classes: `DataTransferObject` (the base, with `fromArray()` and `lenient()`), `Hydrator`
+(the engine, holding the shared cache and doing the recursion), `Hydration<T>` (the two-line
+bound object `lenient()` returns). The alternative — `fromArray($data, lenient: true)` — costs
+nothing to write and something to read: a bare `true` says nothing about which policy it selects.
+
+Paths compose through recursion, which is what `HydrationException::path()` from item 2.1 was
+built for and where it finally earns its place: `customer.address.postcode` is actionable in a
+way "expected string, got int" is not. All three failure kinds are asserted at depth.
+
+Construction is wrapped in a `catch (TypeError)` converted to `HydrationException` — the
+backstop for anything the type checks did not anticipate. Without it a bare `TypeError` would
+escape and break ADR-0004's "one thing to catch" contract for exactly the exotic cases nobody
+tested.
+
+## Proved non-vacuous
+
+Three probes, each reverted and the implementation restored byte-identical:
+
+1. **Disabled strict-mode rejection** (lenient becomes the effective default) → 5 failures.
+2. **Treated an absent nullable as "omit" rather than "pass null"** → 3 errors, the
+   `ArgumentCountError` the probe above predicted.
+3. **Stopped composing paths in recursion** (leaf name only) → 3 failures, all the depth tests.
+
+194 tests, 382 assertions (7 skipped, Windows-only). PHPStan max clean; `--group T-01` runs the
+spec's named hydration matrix as its own unit, 34 tests.
+
+## Two gaps named rather than left
+
+- **`Collection<T>` hydration is not in this item.** Spec FR-01 names it, but `Collection` is
+  item 3.3, and ADR-0006 already placed the docblock generic parser it needs there. The roadmap
+  entry for 3.1 says so where someone checking it off would look.
+- **Filed item 3.6 — the layering gate.** This is the first PR with two groups, so RFC-0001's
+  *"groups depend downward on Support only"* rule is finally a real constraint with a direction.
+  Nothing enforces it: the CI `layering` job self-skips for want of a `deptrac.yaml`. Until now
+  the rule was vacuous with one group; the next four milestones each add a group that could
+  violate it.
+
+## Next
+
+**3.2 `WithersTrait`** — `with(…)` clones of readonly DTOs, absorbing the PHP 8.1→8.3
+readonly-clone difference per version. The first item where the version floor is not merely
+declared but behaviourally load-bearing.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Milestone 3 opens: DTO hydration, and PHP disagreeing with the requirement](2026/08/2026-08-04-dto-hydration.md)
 - [2026-08-04 — Closing the coverage floor, and measuring it for the first time](2026/08/2026-08-04-coverage-floor-gate.md)
 - [2026-08-04 — Making spec §7's T-05 suite a mechanical fact](2026/08/2026-08-04-t05-property-suite.md)
 - [2026-08-04 — The shared reflection cache: designing for consumers that do not exist yet](2026/08/2026-08-04-reflection-metadata-cache.md)

--- a/src/main/php/d4np/utils/Dto/DataTransferObject.php
+++ b/src/main/php/d4np/utils/Dto/DataTransferObject.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Dto;
+
+use D4np\Utils\Support\HydrationException;
+use D4np\Utils\Support\ReflectionCache;
+
+/**
+ * Base class for typed, immutable data transfer objects (spec FR-01, ADR-0008).
+ *
+ * A DTO declares its shape as a promoted `readonly` constructor, and gains hydration from an
+ * array:
+ *
+ * ```php
+ * final class UserDto extends DataTransferObject
+ * {
+ *     public function __construct(
+ *         public readonly string $email,
+ *         public readonly string $name,
+ *     ) {}
+ * }
+ *
+ * $user = UserDto::fromArray(['email' => 'a@b.c', 'name' => 'Ada']);   // strict (default)
+ * $user = UserDto::lenient()->fromArray($wider);                        // ignores extra keys
+ * ```
+ *
+ * **Strict is the default, deliberately.** A key the target does not declare is rejected rather
+ * than dropped: silently discarding one is how a typo becomes a field that was never assigned,
+ * and how a mass-assignment attempt becomes invisible. `lenient()` is the per-call opt-out for
+ * callers who genuinely receive wider payloads than they map.
+ */
+abstract class DataTransferObject
+{
+    /**
+     * The process-wide hydrator, holding the one reflection cache imported ADR-001 commits to.
+     *
+     * Static because {@see self::fromArray()} is, and a static entry point has no instance to
+     * be injected into — the constraint ADR-0006 deliberately declined to guess at before it
+     * existed. It needs no reset hook: the cache memoises *immutable* facts (a class's
+     * constructor cannot change while the process runs), so there is no stale state a test
+     * could observe. That is what makes the shared instance safe rather than merely convenient.
+     */
+    private static ?Hydrator $hydrator = null;
+
+    /**
+     * Hydrate this class from `$data`, rejecting keys it does not declare.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @throws HydrationException on an unknown key, a missing required key, or a value whose
+     *                            type the declaration cannot accept — each naming the path at
+     *                            which it went wrong
+     */
+    public static function fromArray(array $data): static
+    {
+        /** @var static */
+        return self::hydrator()->hydrate(static::class, $data, false);
+    }
+
+    /**
+     * A hydration for this class that ignores keys it does not declare.
+     *
+     * @return Hydration<static>
+     */
+    public static function lenient(): Hydration
+    {
+        /** @var Hydration<static> */
+        return new Hydration(static::class, self::hydrator());
+    }
+
+    private static function hydrator(): Hydrator
+    {
+        return self::$hydrator ??= new Hydrator(new ReflectionCache());
+    }
+}

--- a/src/main/php/d4np/utils/Dto/Hydration.php
+++ b/src/main/php/d4np/utils/Dto/Hydration.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Dto;
+
+use D4np\Utils\Support\HydrationException;
+
+/**
+ * A hydration bound to one DTO class, configured to ignore unknown keys.
+ *
+ * The object {@see DataTransferObject::lenient()} returns, so the opt-out reads as the spec's
+ * example writes it:
+ *
+ * ```php
+ * $dto = UserDto::lenient()->fromArray($payload);
+ * ```
+ *
+ * It exists as its own type rather than as a boolean argument to `fromArray()` because the
+ * call site then says which policy is in force without the reader having to remember what a
+ * bare `true` meant.
+ *
+ * @template T of DataTransferObject
+ */
+final class Hydration
+{
+    /**
+     * @param class-string<T> $class
+     */
+    public function __construct(
+        private readonly string $class,
+        private readonly Hydrator $hydrator,
+    ) {
+    }
+
+    /**
+     * Hydrate the bound class, ignoring keys it does not declare.
+     *
+     * Lenient relaxes what may *arrive*, not what must be *present*: a required key that is
+     * absent is still a {@see \D4np\Utils\Support\MissingKeyException} here, exactly as in
+     * strict mode (RFC-0001 R-4).
+     *
+     * @param array<string, mixed> $data
+     *
+     * @return T
+     *
+     * @throws HydrationException
+     */
+    public function fromArray(array $data): DataTransferObject
+    {
+        return $this->hydrator->hydrate($this->class, $data, true);
+    }
+}

--- a/src/main/php/d4np/utils/Dto/Hydrator.php
+++ b/src/main/php/d4np/utils/Dto/Hydrator.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Dto;
+
+use D4np\Utils\Support\HydrationException;
+use D4np\Utils\Support\MissingKeyException;
+use D4np\Utils\Support\ParameterMetadata;
+use D4np\Utils\Support\ReflectionCache;
+use D4np\Utils\Support\TypeMismatchException;
+use D4np\Utils\Support\UnknownKeyException;
+use TypeError;
+
+/**
+ * Turns an array into a typed DTO, recursively (spec FR-01, ADR-0008).
+ *
+ * The engine behind {@see DataTransferObject::fromArray()}. It holds the shared
+ * {@see ReflectionCache} — the one imported ADR-001 commits to — so the reflection cost of a
+ * DTO class is paid once per process and every later hydration is an array lookup (NFR-01).
+ *
+ * Depends only on `Support`, which is what the layering rule allows (RFC-0001).
+ */
+final class Hydrator
+{
+    public function __construct(
+        private readonly ReflectionCache $cache,
+    ) {
+    }
+
+    /**
+     * Hydrate `$class` from `$data`.
+     *
+     * @template T of object
+     *
+     * @param class-string<T>     $class
+     * @param array<string, mixed> $data
+     * @param bool                $lenient whether unknown keys are ignored rather than rejected
+     *
+     * @return T
+     *
+     * @throws HydrationException
+     */
+    public function hydrate(string $class, array $data, bool $lenient = false): object
+    {
+        return $this->hydrateAt($class, $data, $lenient, '');
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T>      $class
+     * @param array<string, mixed> $data
+     *
+     * @return T
+     *
+     * @throws HydrationException
+     */
+    private function hydrateAt(string $class, array $data, bool $lenient, string $prefix): object
+    {
+        $meta = $this->cache->for($class);
+
+        if (!$meta->isInstantiable) {
+            throw new HydrationException(
+                sprintf('Cannot hydrate %s: the class is not instantiable.', $class),
+                $prefix,
+            );
+        }
+
+        if (!$lenient) {
+            $this->rejectUnknownKeys($meta->parameterNames(), $data, $class, $prefix);
+        }
+
+        $arguments = [];
+        foreach ($meta->parameters as $parameter) {
+            $path = self::join($prefix, $parameter->name);
+
+            if ($parameter->isVariadic) {
+                // A variadic parameter consumes an arbitrary number of positional arguments,
+                // which a keyed payload has no way to express. Refused rather than guessed at.
+                if (array_key_exists($parameter->name, $data)) {
+                    throw new HydrationException(sprintf(
+                        'Cannot hydrate %s: parameter "%s" is variadic, which a keyed payload '
+                        . 'cannot express.',
+                        $class,
+                        $parameter->name,
+                    ), $path);
+                }
+
+                continue;
+            }
+
+            if (!array_key_exists($parameter->name, $data)) {
+                // RFC-0001 R-4, and the order matters. A declared default is applied by PHP
+                // itself when the argument is omitted, so the cleanest thing is to pass nothing.
+                // A nullable parameter WITHOUT a default is a different case: PHP treats it as
+                // required (verified — omitting one raises ArgumentCountError), so `null` has to
+                // be passed explicitly for R-4's "hydrates to null" to hold.
+                if ($parameter->hasDefault) {
+                    continue;
+                }
+                if ($parameter->allowsNull) {
+                    $arguments[$parameter->name] = null;
+
+                    continue;
+                }
+
+                throw MissingKeyException::forKey($path, $class);
+            }
+
+            $arguments[$parameter->name] = $this->coerce($data[$parameter->name], $parameter, $lenient, $path);
+        }
+
+        return $this->construct($class, $arguments, $prefix);
+    }
+
+    /**
+     * @param list<string>         $declared
+     * @param array<string, mixed> $data
+     * @param class-string         $class
+     *
+     * @throws UnknownKeyException
+     */
+    private function rejectUnknownKeys(array $declared, array $data, string $class, string $prefix): void
+    {
+        foreach (array_keys($data) as $key) {
+            $name = (string) $key;
+            if (!in_array($name, $declared, true)) {
+                throw UnknownKeyException::forKey(self::join($prefix, $name), $class);
+            }
+        }
+    }
+
+    /**
+     * @throws HydrationException
+     */
+    private function coerce(mixed $value, ParameterMetadata $parameter, bool $lenient, string $path): mixed
+    {
+        $type = $parameter->type;
+
+        // No single named type to check against: an untyped parameter, `mixed`, or a
+        // union/intersection the metadata deliberately does not reduce to one arm (ADR-0006).
+        // Whatever arrives is passed through, and PHP's own check is the backstop at
+        // construction — where it is converted into a library exception with this path.
+        if ($type === null || $type === 'mixed') {
+            return $value;
+        }
+
+        if ($value === null) {
+            if ($parameter->allowsNull) {
+                return null;
+            }
+
+            throw TypeMismatchException::at($path, $parameter->declaredType ?? $type, 'null');
+        }
+
+        if (!$parameter->isBuiltin) {
+            // A non-builtin type name is only a class-string if it actually resolves. The
+            // reflection cache proved the *declaring* class loadable, not the types of its
+            // parameters — one naming a class that was never autoloadable (or a relative `self`
+            // / `parent`) reaches here. Checking says so plainly instead of failing later inside
+            // an `instanceof` that quietly answers false.
+            if (!class_exists($type) && !interface_exists($type)) {
+                throw new HydrationException(sprintf(
+                    'Cannot hydrate: parameter type "%s" does not resolve to a loadable class '
+                    . 'or interface.',
+                    $type,
+                ), $path);
+            }
+
+            return $this->coerceObject($value, $type, $lenient, $path);
+        }
+
+        if (!self::satisfiesBuiltin($value, $type)) {
+            throw TypeMismatchException::at($path, $type, get_debug_type($value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param class-string $type
+     *
+     * @throws HydrationException
+     */
+    private function coerceObject(mixed $value, string $type, bool $lenient, string $path): mixed
+    {
+        // Already the right object: pass it through. A caller assembling a graph by hand should
+        // not have to take it apart into arrays first.
+        if ($value instanceof $type) {
+            return $value;
+        }
+
+        // A nested DTO is the recursive case spec FR-01 names: an array becomes the child DTO,
+        // and the path grows so a failure deep in the graph says where it happened.
+        if (is_a($type, DataTransferObject::class, true) && is_array($value)) {
+            /** @var array<string, mixed> $value */
+            return $this->hydrateAt($type, $value, $lenient, $path);
+        }
+
+        throw TypeMismatchException::at($path, $type, get_debug_type($value));
+    }
+
+    /**
+     * Whether `$value` satisfies the builtin type `$type`.
+     *
+     * `int` where `float` is declared is accepted deliberately: PHP performs that widening even
+     * under `strict_types=1` (verified), so refusing it here would be stricter than the language
+     * and would reject a payload the constructor would have taken.
+     */
+    private static function satisfiesBuiltin(mixed $value, string $type): bool
+    {
+        return match ($type) {
+            'int' => is_int($value),
+            'float' => is_float($value) || is_int($value),
+            'string' => is_string($value),
+            'bool' => is_bool($value),
+            'array' => is_array($value),
+            'iterable' => is_iterable($value),
+            'object' => is_object($value),
+            'callable' => is_callable($value),
+            'null' => $value === null,
+            'true' => $value === true,
+            'false' => $value === false,
+            // An unrecognised builtin is not assumed to be a mismatch: PHP's own check at
+            // construction decides, and construct() turns its TypeError into a library exception.
+            default => true,
+        };
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T>      $class
+     * @param array<string, mixed> $arguments
+     *
+     * @return T
+     *
+     * @throws HydrationException
+     */
+    private function construct(string $class, array $arguments, string $prefix): object
+    {
+        try {
+            // Named-argument spread: an omitted key simply is not passed, so PHP applies the
+            // parameter's declared default rather than this class having to replicate it.
+            return new $class(...$arguments);
+        } catch (TypeError $e) {
+            // The backstop for anything the checks above let through — an exotic builtin, an
+            // intersection type, a union arm. Without this a consumer catching UtilsThrowable
+            // would miss a bare TypeError, breaking ADR-0004's "one thing to catch" contract.
+            throw new HydrationException(
+                sprintf('Cannot hydrate %s: %s', $class, $e->getMessage()),
+                $prefix,
+                $e,
+            );
+        }
+    }
+
+    private static function join(string $prefix, string $name): string
+    {
+        return $prefix === '' ? $name : $prefix . '.' . $name;
+    }
+}

--- a/src/main/php/d4np/utils/Dto/Hydrator.php
+++ b/src/main/php/d4np/utils/Dto/Hydrator.php
@@ -157,9 +157,14 @@ final class Hydrator
         if (!$parameter->isBuiltin) {
             // A non-builtin type name is only a class-string if it actually resolves. The
             // reflection cache proved the *declaring* class loadable, not the types of its
-            // parameters — one naming a class that was never autoloadable (or a relative `self`
-            // / `parent`) reaches here. Checking says so plainly instead of failing later inside
-            // an `instanceof` that quietly answers false.
+            // parameters — one naming a class that was never autoloadable reaches here.
+            //
+            // NOT covered by the suite, deliberately: reaching it needs a DTO whose parameter
+            // type does not exist, and PHPStan at max level rejects exactly that (`class.notFound`),
+            // so the state cannot occur in this codebase. The check stays because it is what
+            // narrows `string` to `class-string` for the type system, and because a consumer who
+            // does not run PHPStan can still reach it. A fixture to cover it was written, seen
+            // rejected by the linter, and removed rather than suppressed.
             if (!class_exists($type) && !interface_exists($type)) {
                 throw new HydrationException(sprintf(
                     'Cannot hydrate: parameter type "%s" does not resolve to a loadable class '
@@ -218,12 +223,15 @@ final class Hydrator
             'array' => is_array($value),
             'iterable' => is_iterable($value),
             'object' => is_object($value),
-            'callable' => is_callable($value),
-            'null' => $value === null,
-            'true' => $value === true,
-            'false' => $value === false,
-            // An unrecognised builtin is not assumed to be a mismatch: PHP's own check at
-            // construction decides, and construct() turns its TypeError into a library exception.
+            // Everything else falls through deliberately, rather than growing an arm per type.
+            //
+            // `callable` cannot be a property type at all, and the standalone `null`, `true` and
+            // `false` types only exist from PHP 8.2 — below this project's 8.1 floor, so arms for
+            // them would be unreachable on the minimum supported version and merely *look* like
+            // coverage on 8.3. Passing through is correct rather than lax: PHP's own check runs
+            // at construction, and construct() converts the resulting TypeError into a library
+            // exception carrying the path (ADR-0004's contract), so a genuine mismatch is still
+            // reported — with PHP's wording instead of this class's.
             default => true,
         };
     }

--- a/src/test/php/d4np/utils/Dto/DataTransferObjectTest.php
+++ b/src/test/php/d4np/utils/Dto/DataTransferObjectTest.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto;
+
+use D4np\Utils\Support\HydrationException;
+use D4np\Utils\Support\MissingKeyException;
+use D4np\Utils\Support\TypeMismatchException;
+use D4np\Utils\Support\UnknownKeyException;
+use D4np\Utils\Support\UtilsThrowable;
+use D4np\Utils\Tests\Dto\Fixture\AddressDto;
+use D4np\Utils\Tests\Dto\Fixture\CustomerDto;
+use D4np\Utils\Tests\Dto\Fixture\MixedDto;
+use D4np\Utils\Tests\Dto\Fixture\NoConstructorDto;
+use D4np\Utils\Tests\Dto\Fixture\NonDtoTypedDto;
+use D4np\Utils\Tests\Dto\Fixture\OptionalsDto;
+use D4np\Utils\Tests\Dto\Fixture\OrderDto;
+use D4np\Utils\Tests\Dto\Fixture\ScalarsDto;
+use D4np\Utils\Tests\Dto\Fixture\UserDto;
+use D4np\Utils\Tests\Dto\Fixture\VariadicDto;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `DataTransferObject` — spec FR-01, and **T-01**, the hydration matrix spec §7 names:
+ * nested DTOs, nullables, strict/lenient behaviour, and the missing-key cases RFC-0001 R-4
+ * added at review.
+ *
+ * `#[Group('T-01')]` makes that suite runnable as the unit the spec names:
+ * `vendor/bin/phpunit --group T-01`.
+ */
+#[Group('T-01')]
+final class DataTransferObjectTest extends TestCase
+{
+    // ------------------------------------------------------------- the happy path
+
+    public function testTheSpecExampleHydrates(): void
+    {
+        $user = UserDto::fromArray(['email' => 'ada@example.com', 'name' => 'Ada']);
+
+        self::assertSame('ada@example.com', $user->email);
+        self::assertSame('Ada', $user->name);
+    }
+
+    public function testKeyOrderInThePayloadDoesNotMatter(): void
+    {
+        // Construction goes through named arguments, so declaration order is irrelevant to the
+        // caller — asserted rather than assumed, since a positional implementation would fail
+        // here while passing every other test in this file.
+        $user = UserDto::fromArray(['name' => 'Ada', 'email' => 'ada@example.com']);
+
+        self::assertSame('ada@example.com', $user->email);
+        self::assertSame('Ada', $user->name);
+    }
+
+    public function testAClassWithNoConstructorHydratesFromAnEmptyPayload(): void
+    {
+        self::assertInstanceOf(NoConstructorDto::class, NoConstructorDto::fromArray([]));
+    }
+
+    // -------------------------------------------------------------- strict mode
+
+    public function testStrictModeRejectsAnUndeclaredKey(): void
+    {
+        try {
+            UserDto::fromArray(['email' => 'a@b.c', 'name' => 'Ada', 'role' => 'admin']);
+            self::fail('expected an UnknownKeyException');
+        } catch (UnknownKeyException $e) {
+            self::assertSame('role', $e->path());
+            self::assertStringContainsString('role', $e->getMessage());
+            self::assertStringContainsString('lenient()', $e->getMessage(), 'the message names the opt-out');
+        }
+    }
+
+    public function testStrictModeIsTheDefault(): void
+    {
+        // The mass-assignment guarantee: nobody has to opt IN to rejection.
+        $this->expectException(UnknownKeyException::class);
+
+        UserDto::fromArray(['email' => 'a@b.c', 'name' => 'Ada', 'isAdmin' => true]);
+    }
+
+    // ------------------------------------------------------------- lenient mode
+
+    public function testLenientModeIgnoresUndeclaredKeys(): void
+    {
+        $user = UserDto::lenient()->fromArray([
+            'email' => 'ada@example.com',
+            'name' => 'Ada',
+            'role' => 'admin',
+            'extra' => ['deeply', 'nested'],
+        ]);
+
+        self::assertSame('ada@example.com', $user->email);
+        self::assertSame('Ada', $user->name);
+    }
+
+    /**
+     * Lenient relaxes what may *arrive*, not what must be *present* (RFC-0001 R-4). This is the
+     * assertion that stops `lenient()` from quietly becoming "skip all validation".
+     */
+    public function testLenientModeStillRequiresDeclaredKeys(): void
+    {
+        $this->expectException(MissingKeyException::class);
+
+        UserDto::lenient()->fromArray(['email' => 'a@b.c', 'ignored' => 1]);
+    }
+
+    public function testLenientModeStillTypeChecks(): void
+    {
+        $this->expectException(TypeMismatchException::class);
+
+        UserDto::lenient()->fromArray(['email' => 'a@b.c', 'name' => 42, 'extra' => true]);
+    }
+
+    public function testLenientIsPerCallAndDoesNotLeakIntoLaterStrictCalls(): void
+    {
+        UserDto::lenient()->fromArray(['email' => 'a@b.c', 'name' => 'Ada', 'role' => 'x']);
+
+        // The shared hydrator is process-wide; the *mode* must not be.
+        $this->expectException(UnknownKeyException::class);
+        UserDto::fromArray(['email' => 'a@b.c', 'name' => 'Ada', 'role' => 'x']);
+    }
+
+    // ------------------------------------------------- RFC-0001 R-4: optionality
+
+    public function testAMissingRequiredKeyThrows(): void
+    {
+        try {
+            OptionalsDto::fromArray([]);
+            self::fail('expected a MissingKeyException');
+        } catch (MissingKeyException $e) {
+            self::assertSame('required', $e->path());
+            self::assertStringContainsString('lenient', $e->getMessage());
+        }
+    }
+
+    public function testAnAbsentNullableHydratesToNull(): void
+    {
+        // PHP treats a nullable parameter WITHOUT a default as required — verified directly —
+        // so R-4's "hydrates to null" only holds because null is passed explicitly.
+        $dto = OptionalsDto::fromArray(['required' => 'x']);
+
+        self::assertNull($dto->nullable);
+    }
+
+    public function testAnAbsentDefaultedParameterKeepsItsDeclaredDefault(): void
+    {
+        $dto = OptionalsDto::fromArray(['required' => 'x']);
+
+        self::assertSame(42, $dto->defaulted, 'PHP applies the default because the argument is omitted');
+        self::assertSame('preset', $dto->nullableAndDefaulted);
+    }
+
+    public function testAnExplicitNullBeatsADeclaredDefault(): void
+    {
+        // Present-and-null is not the same as absent: the caller said null, so null it is.
+        $dto = OptionalsDto::fromArray(['required' => 'x', 'nullableAndDefaulted' => null]);
+
+        self::assertNull($dto->nullableAndDefaulted);
+    }
+
+    public function testNullForANonNullableParameterIsATypeMismatchNotAMissingKey(): void
+    {
+        try {
+            OptionalsDto::fromArray(['required' => null]);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('required', $e->path());
+            self::assertStringContainsString('null', $e->getMessage());
+        }
+    }
+
+    // ------------------------------------------------------------------ nesting
+
+    public function testANestedDtoHydratesFromANestedArray(): void
+    {
+        $customer = CustomerDto::fromArray([
+            'name' => 'Ada',
+            'address' => ['street' => '1 Main St', 'postcode' => 'AB1 2CD'],
+        ]);
+
+        self::assertInstanceOf(AddressDto::class, $customer->address);
+        self::assertSame('AB1 2CD', $customer->address->postcode);
+    }
+
+    public function testAnAlreadyBuiltNestedDtoIsPassedThrough(): void
+    {
+        // A caller assembling a graph by hand should not have to take it apart into arrays.
+        $address = AddressDto::fromArray(['street' => '1 Main St', 'postcode' => 'AB1 2CD']);
+
+        $customer = CustomerDto::fromArray(['name' => 'Ada', 'address' => $address]);
+
+        self::assertSame($address, $customer->address);
+    }
+
+    /**
+     * The reason `HydrationException` carries a path at all: in a graph, "expected string, got
+     * int" is not actionable and `customer.address.postcode` is.
+     */
+    public function testAFailureDeepInTheGraphNamesTheFullPath(): void
+    {
+        try {
+            OrderDto::fromArray([
+                'reference' => 'ORD-1',
+                'customer' => [
+                    'name' => 'Ada',
+                    'address' => ['street' => '1 Main St', 'postcode' => 12345],
+                ],
+            ]);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('customer.address.postcode', $e->path());
+            self::assertStringContainsString('customer.address.postcode', $e->getMessage());
+        }
+    }
+
+    public function testAMissingKeyDeepInTheGraphNamesTheFullPath(): void
+    {
+        try {
+            OrderDto::fromArray([
+                'reference' => 'ORD-1',
+                'customer' => ['name' => 'Ada', 'address' => ['street' => '1 Main St']],
+            ]);
+            self::fail('expected a MissingKeyException');
+        } catch (MissingKeyException $e) {
+            self::assertSame('customer.address.postcode', $e->path());
+        }
+    }
+
+    public function testAnUnknownKeyDeepInTheGraphNamesTheFullPath(): void
+    {
+        try {
+            OrderDto::fromArray([
+                'reference' => 'ORD-1',
+                'customer' => [
+                    'name' => 'Ada',
+                    'address' => ['street' => 'S', 'postcode' => 'P', 'county' => 'X'],
+                ],
+            ]);
+            self::fail('expected an UnknownKeyException');
+        } catch (UnknownKeyException $e) {
+            self::assertSame('customer.address.county', $e->path());
+        }
+    }
+
+    public function testLeniencyPropagatesIntoNestedDtos(): void
+    {
+        $customer = CustomerDto::lenient()->fromArray([
+            'name' => 'Ada',
+            'unknownAtRoot' => 1,
+            'address' => ['street' => 'S', 'postcode' => 'P', 'unknownNested' => 2],
+        ]);
+
+        self::assertSame('P', $customer->address->postcode);
+    }
+
+    public function testANestedDtoGivenAScalarIsATypeMismatch(): void
+    {
+        try {
+            CustomerDto::fromArray(['name' => 'Ada', 'address' => 'not an array']);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('address', $e->path());
+            self::assertStringContainsString('string', $e->getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------- type checks
+
+    public function testScalarsHydrateWhenTheTypesMatch(): void
+    {
+        $dto = ScalarsDto::fromArray([
+            'i' => 1, 'f' => 2.5, 's' => 'x', 'b' => true, 'a' => [1, 2],
+        ]);
+
+        self::assertSame(1, $dto->i);
+        self::assertSame(2.5, $dto->f);
+        self::assertTrue($dto->b);
+    }
+
+    public function testAnIntSatisfiesAFloatParameter(): void
+    {
+        // PHP widens int to float even under strict_types (verified), so refusing it here would
+        // be stricter than the language and would reject a payload the constructor accepts.
+        $dto = ScalarsDto::fromArray(['i' => 1, 'f' => 3, 's' => 'x', 'b' => false, 'a' => []]);
+
+        self::assertSame(3.0, $dto->f);
+    }
+
+    public function testAFloatDoesNotSatisfyAnIntParameter(): void
+    {
+        // The other direction loses information, and PHP does not perform it under strict_types.
+        $this->expectException(TypeMismatchException::class);
+
+        ScalarsDto::fromArray(['i' => 1.5, 'f' => 1.0, 's' => 'x', 'b' => false, 'a' => []]);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, string}>
+     */
+    public static function mismatchedScalars(): iterable
+    {
+        $ok = ['i' => 1, 'f' => 1.0, 's' => 'x', 'b' => true, 'a' => []];
+
+        yield 'string for int' => [['i' => '1'] + $ok, 'i'];
+        yield 'int for string' => [['s' => 1] + $ok, 's'];
+        yield 'string for bool' => [['b' => 'yes'] + $ok, 'b'];
+        yield 'int for bool' => [['b' => 1] + $ok, 'b'];
+        yield 'string for array' => [['a' => 'nope'] + $ok, 'a'];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('mismatchedScalars')]
+    public function testAMismatchedScalarNamesThePathAndBothTypes(array $payload, string $expectedPath): void
+    {
+        try {
+            ScalarsDto::fromArray($payload);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame($expectedPath, $e->path());
+        }
+    }
+
+    public function testAMixedParameterAcceptsAnything(): void
+    {
+        self::assertSame('s', MixedDto::fromArray(['anything' => 's'])->anything);
+        self::assertSame([1], MixedDto::fromArray(['anything' => [1]])->anything);
+        self::assertNull(MixedDto::fromArray(['anything' => null])->anything);
+    }
+
+    public function testANonDtoClassParameterAcceptsAnInstanceButNotAnArray(): void
+    {
+        $at = new \DateTimeImmutable('2026-08-04 10:00:00');
+
+        self::assertSame($at, NonDtoTypedDto::fromArray(['at' => $at])->at);
+
+        // An arbitrary class cannot be built from an array — only a DataTransferObject can.
+        $this->expectException(TypeMismatchException::class);
+        NonDtoTypedDto::fromArray(['at' => ['date' => '2026-08-04']]);
+    }
+
+    // ---------------------------------------------------------------- refusals
+
+    public function testAVariadicConstructorIsRefusedRatherThanGuessedAt(): void
+    {
+        try {
+            VariadicDto::fromArray(['rest' => ['a', 'b']]);
+            self::fail('expected a HydrationException');
+        } catch (HydrationException $e) {
+            self::assertStringContainsString('variadic', $e->getMessage());
+        }
+    }
+
+    public function testAVariadicConstructorHydratesWhenTheKeyIsAbsent(): void
+    {
+        self::assertSame([], VariadicDto::fromArray([])->rest);
+    }
+
+    // ------------------------------------------------------- exception contract
+
+    public function testEveryHydrationFailureIsCatchableThroughTheLibraryMarker(): void
+    {
+        // ADR-0004's contract, and the reason construct() converts a bare TypeError: a consumer
+        // catching everything this library raises must catch hydration failures too.
+        foreach ([
+            static fn () => UserDto::fromArray(['email' => 'a', 'name' => 'b', 'x' => 1]),
+            static fn () => UserDto::fromArray(['email' => 'a']),
+            static fn () => UserDto::fromArray(['email' => 'a', 'name' => 1]),
+        ] as $call) {
+            try {
+                $call();
+                self::fail('expected a hydration failure');
+            } catch (UtilsThrowable $e) {
+                self::assertInstanceOf(HydrationException::class, $e);
+            }
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Dto/DataTransferObjectTest.php
+++ b/src/test/php/d4np/utils/Dto/DataTransferObjectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace D4np\Utils\Tests\Dto;
 
+use D4np\Utils\Dto\DataTransferObject;
 use D4np\Utils\Support\HydrationException;
 use D4np\Utils\Support\MissingKeyException;
 use D4np\Utils\Support\TypeMismatchException;
@@ -11,12 +12,14 @@ use D4np\Utils\Support\UnknownKeyException;
 use D4np\Utils\Support\UtilsThrowable;
 use D4np\Utils\Tests\Dto\Fixture\AddressDto;
 use D4np\Utils\Tests\Dto\Fixture\CustomerDto;
+use D4np\Utils\Tests\Dto\Fixture\IterableAndObjectDto;
 use D4np\Utils\Tests\Dto\Fixture\MixedDto;
 use D4np\Utils\Tests\Dto\Fixture\NoConstructorDto;
 use D4np\Utils\Tests\Dto\Fixture\NonDtoTypedDto;
 use D4np\Utils\Tests\Dto\Fixture\OptionalsDto;
 use D4np\Utils\Tests\Dto\Fixture\OrderDto;
 use D4np\Utils\Tests\Dto\Fixture\ScalarsDto;
+use D4np\Utils\Tests\Dto\Fixture\UnionTypedDto;
 use D4np\Utils\Tests\Dto\Fixture\UserDto;
 use D4np\Utils\Tests\Dto\Fixture\VariadicDto;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -359,6 +362,58 @@ final class DataTransferObjectTest extends TestCase
     public function testAVariadicConstructorHydratesWhenTheKeyIsAbsent(): void
     {
         self::assertSame([], VariadicDto::fromArray([])->rest);
+    }
+
+    public function testHydratingTheAbstractBaseItselfIsRefused(): void
+    {
+        // `static::class` is the abstract base here, which the metadata reports as not
+        // instantiable — refused with a clear message rather than failing inside `new`.
+        try {
+            DataTransferObject::fromArray([]);
+            self::fail('expected a HydrationException');
+        } catch (HydrationException $e) {
+            self::assertStringContainsString('not instantiable', $e->getMessage());
+        }
+    }
+
+    public function testIterableAndObjectParametersAreTypeChecked(): void
+    {
+        $dto = IterableAndObjectDto::fromArray(['items' => [1, 2], 'thing' => new \stdClass()]);
+
+        self::assertSame([1, 2], $dto->items);
+
+        $this->expectException(TypeMismatchException::class);
+        IterableAndObjectDto::fromArray(['items' => 'not iterable', 'thing' => new \stdClass()]);
+    }
+
+    public function testAnObjectParameterRejectsAScalar(): void
+    {
+        $this->expectException(TypeMismatchException::class);
+
+        IterableAndObjectDto::fromArray(['items' => [], 'thing' => 'not an object']);
+    }
+
+    public function testAUnionTypedParameterAcceptsEitherArm(): void
+    {
+        // The metadata does not reduce a union to one arm (ADR-0006), so the value passes
+        // through unchecked here and PHP's own check decides at construction.
+        self::assertSame(1, UnionTypedDto::fromArray(['value' => 1])->value);
+        self::assertSame('x', UnionTypedDto::fromArray(['value' => 'x'])->value);
+    }
+
+    /**
+     * The `TypeError` backstop, reached through the one gap the checks deliberately leave: a
+     * union type. Without the conversion a bare `TypeError` would escape and break ADR-0004's
+     * "one thing to catch" contract for precisely the cases nobody anticipated.
+     */
+    public function testAValueNoUnionArmAcceptsBecomesALibraryExceptionNotABareTypeError(): void
+    {
+        try {
+            UnionTypedDto::fromArray(['value' => [1, 2, 3]]);
+            self::fail('expected a HydrationException');
+        } catch (HydrationException $e) {
+            self::assertInstanceOf(\TypeError::class, $e->getPrevious(), 'the original stays reachable');
+        }
     }
 
     // ------------------------------------------------------- exception contract

--- a/src/test/php/d4np/utils/Dto/Fixture/AddressDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/AddressDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** The inner DTO of the nesting fixtures. */
+final class AddressDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly string $street,
+        public readonly string $postcode,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/CustomerDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/CustomerDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** One level of nesting: the recursive case spec FR-01 names. */
+final class CustomerDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly AddressDto $address,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/IterableAndObjectDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/IterableAndObjectDto.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** The two remaining declarable builtins the type check branches on. */
+final class IterableAndObjectDto extends DataTransferObject
+{
+    /** @param iterable<mixed> $items */
+    public function __construct(
+        public readonly iterable $items,
+        public readonly object $thing,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/MixedDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/MixedDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** A `mixed` parameter: anything passes, including null. */
+final class MixedDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly mixed $anything,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/NoConstructorDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/NoConstructorDto.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** No constructor: hydrates from an empty payload. */
+final class NoConstructorDto extends DataTransferObject
+{
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/NonDtoTypedDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/NonDtoTypedDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** A class-typed parameter that is NOT a DTO — passed through, never built from an array. */
+final class NonDtoTypedDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly \DateTimeImmutable $at,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/OptionalsDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/OptionalsDto.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** The four RFC-0001 R-4 cases in one place: required, nullable, defaulted, both. */
+final class OptionalsDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly string $required,
+        public readonly ?string $nullable,
+        public readonly int $defaulted = 42,
+        public readonly ?string $nullableAndDefaulted = 'preset',
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/OrderDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/OrderDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** Two levels, so a failure path has something to compose: order.customer.address.postcode. */
+final class OrderDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly string $reference,
+        public readonly CustomerDto $customer,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/ScalarsDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/ScalarsDto.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** Every builtin the type check branches on. */
+final class ScalarsDto extends DataTransferObject
+{
+    /**
+     * @param array<mixed> $a the native `array` type carries no element type, which PHPStan at
+     *                        max level requires — supplied here so the fixture is as strictly
+     *                        typed as the code it exercises
+     */
+    public function __construct(
+        public readonly int $i,
+        public readonly float $f,
+        public readonly string $s,
+        public readonly bool $b,
+        public readonly array $a,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/UnionTypedDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/UnionTypedDto.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/**
+ * A union-typed parameter. The metadata deliberately does not reduce a union to one arm
+ * (ADR-0006), so this reaches the hydrator with no single type to check — and PHP's own check
+ * at construction is what rejects a bad value, converted to a library exception.
+ */
+final class UnionTypedDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly int|string $value,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/UserDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/UserDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** The spec §6 example, verbatim: the shape every other fixture varies from. */
+final class UserDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly string $email,
+        public readonly string $name,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/VariadicDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/VariadicDto.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** A variadic constructor: refused rather than guessed at. */
+final class VariadicDto extends DataTransferObject
+{
+    /** @var list<string> */
+    public readonly array $rest;
+
+    public function __construct(string ...$rest)
+    {
+        $this->rest = array_values($rest);
+    }
+}


### PR DESCRIPTION
## Context

Roadmap item **3.1** — Milestone 3 opens. The first component group to consume `Support`, and
the third `sets-pattern` item: its shape is what Milestones 4–6 copy.

## The finding: PHP does not agree with how R-4 is written

RFC-0001 R-4 says a nullable or defaulted property absent from the payload "hydrates to
`null`/its default" — which reads as *treat both the same, omit the argument*. Probed before
writing a line:

| Construct | Result |
|---|---|
| named-argument spread, key omitted | PHP applies the declared default |
| `?string $x` with **no** default, argument omitted | **`ArgumentCountError`** |
| `int` where `float` is declared, under `strict_types=1` | **accepted**, widened |

**Nullable is not optional in PHP.** So R-4's "hydrates to null" only holds if `null` is passed
**explicitly**; an implementation that omits both cases raises `ArgumentCountError` — neither the
documented behaviour nor a library exception. Absence is now resolved in a deliberate order, and
a parameter that is both nullable *and* defaulted takes its default, which is what a reader of
the declaration expects.

The third row settled a separate decision: `int` where `float` is declared is **accepted**,
because PHP performs that widening itself under `strict_types`. Refusing it would make this
library stricter than the language and reject payloads the constructor would have taken.

## It also answers the question ADR-0006 deliberately left open

ADR-0006 declined to build a shared accessor for the reflection cache: *"Milestone 3 will have
the real constraint in hand."* It does — `fromArray()` is static.

The resolution is cleaner than the hesitation implied. ADR-0006 worried about reset semantics and
testability; both dissolve because the cache memoises **immutable facts** — a class's constructor
cannot change while the process runs — so there is no stale state to invalidate and no reset hook
to design. **Guessing in Milestone 2 would have put a `reset()` in the production API for a
problem that does not exist.** The *mode* is per-call and never stored; the suite asserts a
lenient call cannot leak into a later strict one.

## Change

`DataTransferObject` (base), `Hydrator` (engine — holds the cache, does the recursion),
`Hydration<T>` (the bound object `lenient()` returns), plus
**[ADR-0008](docs/adr/0008-dto-hydration-strictness-and-shared-hydrator.md)**.

- **Strict by default** — an undeclared key raises `UnknownKeyException`, so a typo or a
  mass-assignment attempt cannot pass silently. `lenient()` is the per-call opt-out, and it
  relaxes what may *arrive*, not what must be *present*: it still requires declared keys and
  still type-checks.
- **Paths compose through recursion** — `customer.address.postcode`. This is what
  `HydrationException::path()` from item 2.1 was built for and where it earns its place; all
  three failure kinds are asserted at depth.
- **No bare `TypeError` escapes** — construction is wrapped and converted, so ADR-0004's
  "one thing to catch" contract holds even for a type the checks did not anticipate.
- **A variadic constructor is refused, not guessed at** — a keyed payload cannot express "an
  arbitrary number of positional arguments".

## Verification — proved non-vacuous

Three probes, each reverted and the implementation restored **byte-identical**:

1. **Disabled strict-mode rejection** (lenient becomes the effective default) → **5 failures**.
2. **Treated an absent nullable as "omit" rather than "pass null"** → **3 errors**, the
   `ArgumentCountError` the probe above predicted.
3. **Stopped composing paths in recursion** (leaf name only) → **3 failures**, all depth tests.

**194 tests, 382 assertions** (7 skipped, Windows-only, run on CI) · `--group T-01` runs the
spec's named hydration matrix as its own unit, **34 tests** · PHPStan max clean · PHP-CS-Fixer
clean · `consistency_lint` and `action_pin_lint --verify-upstream` both OK.

## Two gaps named rather than left for a reader to discover

- **`Collection<T>` hydration is not in this item.** Spec FR-01 names it, but `Collection` is
  item **3.3**, and ADR-0006 already placed the docblock generic parser it needs there. The
  roadmap entry for 3.1 says so where someone ticking it off would look.
- **Filed item 3.6 — the layering gate.** This is the first PR with two groups, so RFC-0001's
  *"groups depend downward on Support only"* is finally a real constraint with a direction.
  Nothing enforces it: the CI `layering` job self-skips for want of a `deptrac.yaml`. With one
  group the rule was vacuous; the next four milestones each add a group that could violate it.

## Route

`sets-pattern` → **frontier-reasoning / high**; session on `opus-5` (standard). Surfaced before
starting — you hold model authority (ADR-0017) — and proceeded on your standing decision.

**Cross-links:** RFC-0001 R-4 · spec FR-01 · ADR-0004, ADR-0006, ADR-0008 · roadmap item 3.1
(done), 3.6 (filed) · milestone `v0.3.0`. Type label: `feat`; `enhancement` set as the closest
available default until `.github/labels.yml` is imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
