### PR TITLE
feat(dto): add WithersTrait rebuilding through the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- `D4np\Utils\Dto\WithersTrait` (**ADR-0009**) — `$user->with(name: 'Grace')` returns a modified
+  copy of an immutable DTO, leaving the receiver untouched. It **rebuilds through the
+  constructor** rather than cloning, which works identically on PHP 8.1/8.2/8.3 (8.3's readonly
+  amendment only permits reassignment *inside* `__clone()`) and, independently of versions,
+  keeps any validation the constructor performs applying to the result. Changes route through
+  the same checks as hydration: an undeclared name raises `UnknownKeyException`, a bad value
+  raises `TypeMismatchException`.
 - `D4np\Utils\Dto\DataTransferObject` (**ADR-0008**) — typed, immutable DTOs hydrated from
   arrays: `UserDto::fromArray($data)` is **strict by default** (an undeclared key raises
   `UnknownKeyException`, so a typo or a mass-assignment attempt cannot pass silently), and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Milestone 3 opens: DTO hydration, and PHP disagreeing with the requirement](docs/journal/2026/08/2026-08-04-dto-hydration.md).
+  [2026-08-04 — Withers: meeting a "per-version" requirement by not depending on the version](docs/journal/2026/08/2026-08-04-withers-trait.md).
 
 ## Model & effort routing (advisory)
 
@@ -137,8 +137,12 @@ Typed, mass-assignment-safe data transfer (RFC-0001).
       this item: `Collection` itself is 3.3, and ADR-0006 deliberately placed the docblock
       generic parser it needs there. Everything else — strict/lenient, R-4 optionality, nested
       DTOs, path-carrying type mismatches — is done and covered by the T-01 suite.*
-- [ ] 3.2 `WithersTrait` with per-version readonly-clone handling 8.1→8.3 (RFC-0001)
-      (severity:medium) — route: standard / medium
+- [x] 3.2 `WithersTrait` with per-version readonly-clone handling 8.1→8.3 (RFC-0001)
+      (severity:medium) — route: standard / medium · **ADR-0009**. *No per-version branch was
+      needed: measured, PHP 8.3's readonly amendment only allows reassignment **inside**
+      `__clone()`, still an error on 8.1/8.2, while rebuilding through the constructor works
+      identically on all three — and additionally preserves constructor validation, which a
+      clone bypasses.*
 - [ ] 3.3 `Collection<T>` with `@template` discipline enforced by PHPStan max (RFC-0001)
       (severity:medium) — route: standard / medium
 - [ ] 3.4 T-01 hydration matrix suite (RFC-0001) — route: fast / low

--- a/docs/adr/0009-withers-rebuild-rather-than-clone.md
+++ b/docs/adr/0009-withers-rebuild-rather-than-clone.md
@@ -1,0 +1,105 @@
+# ADR-0009: Withers rebuild through the constructor rather than cloning
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 3.2 · spec FR-02 · [RFC-0001](../rfc/0001-egl-utils-library.md) ·
+  [ADR-0008](0008-dto-hydration-strictness-and-shared-hydrator.md)
+
+## Context
+
+Spec FR-02 asks for `with(...)` wither semantics on `readonly` DTOs, *"absorbing the PHP
+8.1→8.3 readonly-clone difference per version"*. The phrasing implies the trait should branch on
+`PHP_VERSION_ID` and do one thing on 8.1/8.2 and another on 8.3.
+
+What that difference actually is, measured rather than recalled:
+
+| Operation | 8.1 / 8.2 | 8.3 |
+|---|---|---|
+| assign a `readonly` property after `clone`, **outside** `__clone()` | `Error` | **`Error`** |
+| assign a `readonly` property **inside** `__clone()` | `Error` | **allowed** |
+| build a new instance through the constructor | allowed | allowed |
+
+The first row is the surprising one and was verified on 8.3 directly: PHP 8.3's readonly
+amendment did **not** make readonly properties writable after cloning in general. It relaxed one
+narrow case — reassignment inside `__clone()`. Everywhere else the property stays sealed.
+
+So a clone-based wither needs a `__clone()` hook *and* is still an error on 8.1 and 8.2, which
+this project supports. Meanwhile the third row works everywhere.
+
+There is a second consideration that has nothing to do with versions. A clone copies an object
+into existence **without running its constructor**. A DTO that validates in its constructor —
+a plausible and useful thing — would have that validation bypassed by a clone-based wither,
+which could then produce an object the class itself would refuse to build.
+
+## Decision
+
+**`with(...)` rebuilds the object through its constructor: read the current value of every
+constructor parameter, apply the named changes, and construct a new instance. The trait carries
+no version branch at all.**
+
+The requirement to "absorb the 8.1→8.3 difference" is met by **not depending on the
+difference**. Writing `if (PHP_VERSION_ID >= 80300)` would add a branch that is dead on two of
+the three supported versions and exercised on one — the shape item 3.1 had just been caught
+producing, where `match` arms existed for types undeclarable below the 8.1 floor.
+
+Supporting decisions:
+
+- **`with()` takes named arguments** (`$user->with(name: 'Grace')`), collected by a variadic into
+  a string-keyed array. The call site names what it changes.
+- **It routes through the same hydrator as `fromArray()`**, so an undeclared name raises
+  `UnknownKeyException` and a bad value raises `TypeMismatchException`, each with a path.
+  `with()` is not a way around the type system, and none of that logic is duplicated.
+- **The trait declares `abstract protected static function hydrator(): Hydrator`.** A trait's
+  abstract method is satisfied by an *inherited* one (verified), so `DataTransferObject`'s
+  already-shared instance fulfils it and using the trait elsewhere is a **compile-time** error
+  rather than a surprise at the first `with()` call. It also keeps imported ADR-001's *one*
+  metadata cache true: a trait building its own would quietly make two.
+- **Current values are read through `ReflectionProperty::getValue()`**, not `$source->{$name}`.
+  A promoted property may be `private`, and the hydrator is not in its scope; since PHP 8.1 that
+  call needs no `setAccessible()`. It costs a reflection lookup per property, which is acceptable
+  because withers are not the path NFR-01 measures.
+- **A constructor parameter with no property of the same name is refused with an explanation.**
+  Rebuilding requires every parameter to be recoverable; promoted properties always are, a
+  non-promoted parameter stored under a different name is not.
+
+## Alternatives Considered
+
+- **`clone` plus a `__clone()` hook, branching on `PHP_VERSION_ID`** — the literal reading of
+  FR-02. Rejected: the branch is dead on 8.1 and 8.2, it bypasses constructor validation, and it
+  buys nothing the rebuild does not already provide.
+- **`clone` plus reflection to write the readonly property** — rejected: `ReflectionProperty::setValue()`
+  does not lift the readonly seal on an initialised property, and defeating a language guarantee
+  from inside a library that exists to make guarantees is the wrong trade even where possible.
+- **Per-property withers** (`withName()`, `withEmail()`) — rejected: spec FR-02 says `with(...)`,
+  and generating or hand-writing one method per property is a maintenance cost with no gain over
+  named arguments.
+- **`with(array $changes)`** instead of named variadic arguments — rejected on readability;
+  `->with(['name' => 'Grace'])` says the same thing with more punctuation and no type checking at
+  the call site.
+- **Skipping validation on the rebuild** (construct without running checks) — rejected: it would
+  reintroduce, deliberately, the exact hole the clone approach has by accident.
+
+## Consequences
+
+- **Withers work identically on 8.1, 8.2 and 8.3**, and will keep working on 8.4 without a new
+  branch, because nothing in the trait knows which version it is on.
+- **Constructor validation applies to wither results.** A DTO that guards its invariants in the
+  constructor keeps them under `with()` — the property a clone-based implementation silently
+  loses, asserted directly by a fixture that validates and a test that expects the refusal.
+- **The receiver is never mutated**, which is the point; `with()` on a DTO with no changes
+  returns an equal but distinct object.
+- **A nested DTO is carried across by reference**, not rebuilt: withering the parent does not
+  recreate children that did not change.
+- **Cost:** a rebuild is more work than a clone — reflection per property, plus the constructor
+  and the type checks. For an immutable DTO that is the right trade; if a hot path ever needs
+  otherwise, that is a measurement to bring, not an assumption to design around now.
+- **Not tested, and stated rather than left implicit:** that assigning to a `readonly` property
+  throws. PHPStan at max rejects such an assignment wherever it appears, for every call site —
+  stronger than one runtime assertion, and testing it needs the linter suppressed or dodged.
+
+## References
+
+- Spec FR-02; RFC-0001 (the `readonly`, promoted-constructor DTO shape)
+- PHP RFC *Readonly amendments* (8.3) — the change measured above, and its narrow scope
+- ADR-0008 — the hydrator this trait routes through, and the shared instance it must not duplicate

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0006](0006-shared-reflection-metadata-cache.md) | Shape the shared reflection-metadata cache as plain instances, without an interface | Accepted |
 | [0007](0007-measure-total-line-coverage-against-a-floor.md) | Enforce the coverage floor as total line coverage, measured once | Accepted |
 | [0008](0008-dto-hydration-strictness-and-shared-hydrator.md) | Strict-by-default hydration, and how a static entry point reaches shared state | Accepted |
+| [0009](0009-withers-rebuild-rather-than-clone.md) | Withers rebuild through the constructor rather than cloning | Accepted |

--- a/docs/journal/2026/08/2026-08-04-withers-trait.md
+++ b/docs/journal/2026/08/2026-08-04-withers-trait.md
@@ -1,0 +1,82 @@
+# 2026-08-04 — Withers: meeting a "per-version" requirement by not depending on the version
+
+Roadmap item **3.2**. Route `standard / medium`; session model matched.
+
+## The requirement said "per version". Measurement said otherwise.
+
+Spec FR-02 asks for withers *"absorbing the PHP 8.1→8.3 readonly-clone difference per version"* —
+phrasing that invites a `PHP_VERSION_ID` branch. Measured on 8.3 before writing anything:
+
+| Operation | 8.1 / 8.2 | 8.3 |
+|---|---|---|
+| assign a `readonly` property after `clone`, **outside** `__clone()` | `Error` | **`Error`** |
+| assign a `readonly` property **inside** `__clone()` | `Error` | **allowed** |
+| build a new instance through the constructor | allowed | allowed |
+
+The first row is the one worth having checked. PHP 8.3's readonly amendment did **not** make
+readonly properties writable after cloning in general — it relaxed one narrow case, reassignment
+inside `__clone()`. Everywhere else the property stays sealed, on 8.3 as much as on 8.1.
+
+So a clone-based wither needs a `__clone()` hook *and* remains an error on two of the three
+supported versions. Rebuilding through the constructor works on all three. **The requirement is
+met by not depending on the difference**, and the trait carries no version branch at all.
+
+Writing `if (PHP_VERSION_ID >= 80300)` would have added a branch dead on two supported versions
+and live on one — precisely the shape item 3.1 was caught producing a few hours earlier, where
+`match` arms existed for types that cannot be declared below the 8.1 floor. Having just paid for
+that lesson, spending it here was the point.
+
+## A second argument that has nothing to do with versions
+
+A `clone` copies an object into existence **without running its constructor**. A DTO that
+validates in its constructor would have that validation bypassed — a clone-based wither could
+produce an object the class itself refuses to build. Rebuilding keeps the guard.
+
+That is asserted directly: a fixture that throws on a malformed email, and a test that expects
+`with(email: 'not-an-email')` to be refused. Under a clone implementation it would quietly
+succeed.
+
+## Shape
+
+`with(mixed ...$changes)` collects **named arguments** into a string-keyed array (verified), so
+the call site names what it changes. It routes through the same hydrator as `fromArray()`, so an
+undeclared name is an `UnknownKeyException` and a bad value a `TypeMismatchException` — `with()`
+is not a way around the type system, and none of that logic is duplicated.
+
+Two details that needed checking rather than assuming:
+
+- **The trait declares `abstract protected static function hydrator(): Hydrator`.** A trait's
+  abstract method *is* satisfied by an inherited one (verified), so `DataTransferObject`'s
+  already-shared instance fulfils it — making "this trait belongs on a DataTransferObject" a
+  compile-time requirement rather than a comment. It also keeps imported ADR-001's *one* metadata
+  cache true: a trait building its own would quietly make two.
+- **Current values are read via `ReflectionProperty::getValue()`**, not `$source->{$name}`: a
+  promoted property may be `private` and the hydrator is not in its scope. Verified that since
+  PHP 8.1 this needs no `setAccessible()`.
+
+## Proved non-vacuous
+
+Two probes, each reverted and the implementation restored byte-identical:
+
+1. **Dropped the current values** (so unnamed properties reset) → 8 errors.
+2. **Reversed the merge order** (so changes lose to current values) → 8 failures.
+
+211 tests, 412 assertions (7 skipped, Windows-only). PHPStan max clean; PHP-CS-Fixer clean.
+
+## A test I wrote, then removed
+
+I wrote a test asserting that assigning to a `readonly` property throws — the constraint the
+whole design works within. PHPStan rejected it: `property.readOnlyAssignOutOfClass`. I tried
+dodging with a dynamic property name; PHPStan resolved that too, correctly.
+
+Both routes amount to disabling a real check in order to assert something it already proves —
+for every call site, permanently, which is stronger than one runtime assertion. So the test is
+gone and the reasoning is in its place in the file. That is the third time this pattern has come
+up (item 2.1's `assertNotInstanceOf`, item 3.1's `class_exists` fixture); the consistent answer
+is that a static guarantee outranks a runtime echo of it.
+
+## Next
+
+**3.3 `Collection<T>`** — and with it the docblock generic parser ADR-0006 deferred, which is
+what finally lets `Collection<T>` properties hydrate. It closes the one gap item 3.1 named in
+its own roadmap entry.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Withers: meeting a "per-version" requirement by not depending on the version](2026/08/2026-08-04-withers-trait.md)
 - [2026-08-04 — Milestone 3 opens: DTO hydration, and PHP disagreeing with the requirement](2026/08/2026-08-04-dto-hydration.md)
 - [2026-08-04 — Closing the coverage floor, and measuring it for the first time](2026/08/2026-08-04-coverage-floor-gate.md)
 - [2026-08-04 — Making spec §7's T-05 suite a mechanical fact](2026/08/2026-08-04-t05-property-suite.md)

--- a/src/main/php/d4np/utils/Dto/DataTransferObject.php
+++ b/src/main/php/d4np/utils/Dto/DataTransferObject.php
@@ -70,7 +70,13 @@ abstract class DataTransferObject
         return new Hydration(static::class, self::hydrator());
     }
 
-    private static function hydrator(): Hydrator
+    /**
+     * Protected rather than private so {@see WithersTrait} can reach it — the trait declares it
+     * abstract, which is what makes "this trait belongs on a DataTransferObject" a compile-time
+     * requirement instead of a comment. Sharing this one instance is also what keeps imported
+     * ADR-001's *one* metadata cache true: a trait building its own would quietly make two.
+     */
+    protected static function hydrator(): Hydrator
     {
         return self::$hydrator ??= new Hydrator(new ReflectionCache());
     }

--- a/src/main/php/d4np/utils/Dto/Hydrator.php
+++ b/src/main/php/d4np/utils/Dto/Hydrator.php
@@ -10,6 +10,7 @@ use D4np\Utils\Support\ParameterMetadata;
 use D4np\Utils\Support\ReflectionCache;
 use D4np\Utils\Support\TypeMismatchException;
 use D4np\Utils\Support\UnknownKeyException;
+use ReflectionProperty;
 use TypeError;
 
 /**
@@ -44,6 +45,69 @@ final class Hydrator
     public function hydrate(string $class, array $data, bool $lenient = false): object
     {
         return $this->hydrateAt($class, $data, $lenient, '');
+    }
+
+    /**
+     * A copy of `$source` with `$changes` applied — the engine behind {@see WithersTrait::with()}.
+     *
+     * Rebuilds through the constructor rather than cloning, which is what makes withers work on
+     * the declared PHP 8.1 floor at all: a `readonly` property cannot be reassigned after
+     * `clone`, and PHP 8.3's readonly amendment only relaxes that *inside* `__clone()` — still
+     * an error on 8.1 and 8.2. Rebuilding needs no version branch and behaves identically on all
+     * three (ADR-0009).
+     *
+     * Rebuilding is also the stronger semantics, independently of compatibility: the constructor
+     * runs, so any validation a DTO performs there applies to the result. A clone-based wither
+     * bypasses the constructor entirely and can produce an object the class would have refused
+     * to construct.
+     *
+     * @template T of object
+     *
+     * @param T                    $source
+     * @param array<string, mixed> $changes
+     *
+     * @return T
+     *
+     * @throws HydrationException
+     */
+    public function withChanges(object $source, array $changes): object
+    {
+        $class = $source::class;
+        $meta = $this->cache->for($class);
+
+        $current = [];
+        foreach ($meta->parameters as $parameter) {
+            if ($parameter->isVariadic) {
+                // hydrateAt() refuses these anyway; stopping here keeps the message about the
+                // wither rather than about a payload the caller never wrote.
+                throw new HydrationException(sprintf(
+                    'Cannot apply withers to %s: parameter "%s" is variadic, so the current '
+                    . 'value cannot be read back as a single argument.',
+                    $class,
+                    $parameter->name,
+                ), $parameter->name);
+            }
+
+            if (!property_exists($source, $parameter->name)) {
+                throw new HydrationException(sprintf(
+                    'Cannot apply withers to %s: constructor parameter "%s" has no property of '
+                    . 'the same name to read the current value from. Withers rebuild through the '
+                    . 'constructor, so every parameter must be recoverable — which promoted '
+                    . 'properties always are.',
+                    $class,
+                    $parameter->name,
+                ), $parameter->name);
+            }
+
+            // Reflection rather than `$source->{$name}`: a promoted property may be private, and
+            // this class is not in its scope. Since PHP 8.1 `getValue()` needs no
+            // `setAccessible()`. It costs a reflection lookup per property, which is acceptable
+            // here — withers are not the path NFR-01 measures.
+            $current[$parameter->name] = (new ReflectionProperty($class, $parameter->name))->getValue($source);
+        }
+
+        /** @var T */
+        return $this->hydrateAt($class, array_merge($current, $changes), false, '');
     }
 
     /**

--- a/src/main/php/d4np/utils/Dto/WithersTrait.php
+++ b/src/main/php/d4np/utils/Dto/WithersTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Dto;
+
+use D4np\Utils\Support\HydrationException;
+
+/**
+ * `with(...)` semantics for immutable DTOs (spec FR-02, ADR-0009).
+ *
+ * ```php
+ * final class UserDto extends DataTransferObject
+ * {
+ *     use WithersTrait;
+ *
+ *     public function __construct(
+ *         public readonly string $email,
+ *         public readonly string $name,
+ *     ) {}
+ * }
+ *
+ * $renamed = $user->with(name: 'Grace');   // a new UserDto; $user is untouched
+ * ```
+ *
+ * **Why a rebuild rather than a clone.** A `readonly` property cannot be reassigned after
+ * `clone`, and PHP 8.3's readonly amendment only relaxes that *inside* `__clone()` — still an
+ * error on 8.1 and 8.2, which this project supports. Rebuilding through the constructor works
+ * identically on all three, so the trait carries no version branch at all: the "absorb the
+ * 8.1→8.3 difference" requirement is met by not depending on the difference (ADR-0009).
+ *
+ * It is also the stronger semantics on its own merits — the constructor runs, so a DTO that
+ * validates there validates the wither's result too. A clone-based wither would bypass it and
+ * could produce an object the class itself would have refused to build.
+ *
+ * The abstract declaration below is the requirement, enforced by PHP rather than by a comment:
+ * a class using this trait must supply a {@see Hydrator}, which {@see DataTransferObject}
+ * already does. Using the trait anywhere else is a fatal error at compile time rather than a
+ * surprise at the first `with()` call.
+ */
+trait WithersTrait
+{
+    abstract protected static function hydrator(): Hydrator;
+
+    /**
+     * A copy of this object with the named properties replaced.
+     *
+     * Takes named arguments — `->with(name: 'Grace', email: 'g@example.com')` — so the call site
+     * names what it is changing. Everything not named keeps its current value.
+     *
+     * The result goes through the same checks as hydration: a name the class does not declare
+     * raises `UnknownKeyException`, and a value the declaration cannot accept raises
+     * `TypeMismatchException`. `with()` is not a way around the type system.
+     *
+     * @param mixed ...$changes named arguments only; a positional one has no property to bind to
+     *
+     * @throws HydrationException
+     */
+    public function with(mixed ...$changes): static
+    {
+        /** @var array<string, mixed> $changes */
+        return static::hydrator()->withChanges($this, $changes);
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/WitherNestedDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/WitherNestedDto.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+use D4np\Utils\Dto\WithersTrait;
+
+/** Withers over a nested DTO: the child object is carried across unchanged. */
+final class WitherNestedDto extends DataTransferObject
+{
+    use WithersTrait;
+
+    public function __construct(
+        public readonly string $name,
+        public readonly AddressDto $address,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/WitherPrivateDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/WitherPrivateDto.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+use D4np\Utils\Dto\WithersTrait;
+
+/**
+ * A promoted PRIVATE readonly property. The wither must still read it back, which is why the
+ * current value is read through reflection rather than a property access from another scope.
+ */
+final class WitherPrivateDto extends DataTransferObject
+{
+    use WithersTrait;
+
+    public function __construct(
+        private readonly string $secret,
+        public readonly string $label,
+    ) {
+    }
+
+    public function secret(): string
+    {
+        return $this->secret;
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/WitherUnreadableDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/WitherUnreadableDto.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+use D4np\Utils\Dto\WithersTrait;
+
+/**
+ * A constructor parameter that is NOT promoted and has no property of the same name, so its
+ * current value cannot be read back. The wither must say so plainly.
+ */
+final class WitherUnreadableDto extends DataTransferObject
+{
+    use WithersTrait;
+
+    public readonly string $stored;
+
+    public function __construct(string $incoming)
+    {
+        $this->stored = strtoupper($incoming);
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/WitherUserDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/WitherUserDto.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+use D4np\Utils\Dto\WithersTrait;
+
+/** The documented shape: promoted public readonly properties. */
+final class WitherUserDto extends DataTransferObject
+{
+    use WithersTrait;
+
+    public function __construct(
+        public readonly string $email,
+        public readonly string $name,
+        public readonly int $age = 30,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/WitherValidatingDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/WitherValidatingDto.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+use D4np\Utils\Dto\WithersTrait;
+
+/**
+ * A DTO that validates in its constructor. The whole point of rebuilding rather than cloning:
+ * a clone-based wither would bypass this and could produce an object the class refuses to build.
+ */
+final class WitherValidatingDto extends DataTransferObject
+{
+    use WithersTrait;
+
+    public function __construct(
+        public readonly string $email,
+    ) {
+        if (!str_contains($email, '@')) {
+            throw new \InvalidArgumentException('email must contain @');
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Dto/WithersTraitTest.php
+++ b/src/test/php/d4np/utils/Dto/WithersTraitTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto;
+
+use D4np\Utils\Support\HydrationException;
+use D4np\Utils\Support\TypeMismatchException;
+use D4np\Utils\Support\UnknownKeyException;
+use D4np\Utils\Tests\Dto\Fixture\AddressDto;
+use D4np\Utils\Tests\Dto\Fixture\WitherNestedDto;
+use D4np\Utils\Tests\Dto\Fixture\WitherPrivateDto;
+use D4np\Utils\Tests\Dto\Fixture\WitherUnreadableDto;
+use D4np\Utils\Tests\Dto\Fixture\WitherUserDto;
+use D4np\Utils\Tests\Dto\Fixture\WitherValidatingDto;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `WithersTrait` — spec FR-02, ADR-0009. Part of **T-01**, the hydration matrix spec §7 names
+ * (its "wither clones" column).
+ *
+ * The load-bearing property is immutability: `with()` must produce a *new* object and leave the
+ * receiver untouched. Everything else follows from rebuilding through the constructor.
+ */
+#[Group('T-01')]
+final class WithersTraitTest extends TestCase
+{
+    public function testWithReturnsANewObjectAndLeavesTheOriginalUntouched(): void
+    {
+        $user = WitherUserDto::fromArray(['email' => 'ada@example.com', 'name' => 'Ada']);
+
+        $renamed = $user->with(name: 'Grace');
+
+        self::assertNotSame($user, $renamed, 'with() must not mutate in place');
+        self::assertSame('Ada', $user->name, 'the receiver is unchanged');
+        self::assertSame('Grace', $renamed->name);
+    }
+
+    public function testUnnamedPropertiesKeepTheirCurrentValues(): void
+    {
+        $user = WitherUserDto::fromArray(['email' => 'ada@example.com', 'name' => 'Ada', 'age' => 36]);
+
+        $renamed = $user->with(name: 'Grace');
+
+        self::assertSame('ada@example.com', $renamed->email);
+        self::assertSame(36, $renamed->age, 'a non-default current value survives, rather than resetting to the default');
+    }
+
+    public function testSeveralPropertiesCanChangeAtOnce(): void
+    {
+        $user = WitherUserDto::fromArray(['email' => 'ada@example.com', 'name' => 'Ada']);
+
+        $changed = $user->with(name: 'Grace', email: 'grace@example.com');
+
+        self::assertSame('Grace', $changed->name);
+        self::assertSame('grace@example.com', $changed->email);
+    }
+
+    public function testWithNoChangesProducesAnEqualButDistinctObject(): void
+    {
+        $user = WitherUserDto::fromArray(['email' => 'ada@example.com', 'name' => 'Ada']);
+
+        $copy = $user->with();
+
+        self::assertNotSame($user, $copy);
+        self::assertEquals($user, $copy);
+    }
+
+    public function testTheResultIsItselfWitherableSoCallsChain(): void
+    {
+        $user = WitherUserDto::fromArray(['email' => 'ada@example.com', 'name' => 'Ada']);
+
+        $final = $user->with(name: 'Grace')->with(age: 45);
+
+        self::assertSame('Grace', $final->name);
+        self::assertSame(45, $final->age);
+        self::assertSame('ada@example.com', $final->email);
+    }
+
+    public function testAPrivatePromotedPropertyIsReadBackCorrectly(): void
+    {
+        // The reason the current value is read through reflection rather than a property access:
+        // the hydrator is not in the DTO's scope, and a promoted property may be private.
+        $dto = WitherPrivateDto::fromArray(['secret' => 's3cret', 'label' => 'first']);
+
+        $relabelled = $dto->with(label: 'second');
+
+        self::assertSame('s3cret', $relabelled->secret(), 'the private value survived the rebuild');
+        self::assertSame('second', $relabelled->label);
+    }
+
+    public function testANestedDtoIsCarriedAcrossUnchanged(): void
+    {
+        $dto = WitherNestedDto::fromArray([
+            'name' => 'Ada',
+            'address' => ['street' => '1 Main St', 'postcode' => 'AB1 2CD'],
+        ]);
+
+        $renamed = $dto->with(name: 'Grace');
+
+        self::assertSame($dto->address, $renamed->address, 'the child object is carried, not rebuilt');
+        self::assertSame('Grace', $renamed->name);
+    }
+
+    public function testANestedDtoCanItselfBeReplaced(): void
+    {
+        $dto = WitherNestedDto::fromArray([
+            'name' => 'Ada',
+            'address' => ['street' => '1 Main St', 'postcode' => 'AB1 2CD'],
+        ]);
+        $moved = AddressDto::fromArray(['street' => '2 Other Rd', 'postcode' => 'XY9 8ZW']);
+
+        $result = $dto->with(address: $moved);
+
+        self::assertSame($moved, $result->address);
+        self::assertSame('Ada', $result->name);
+    }
+
+    /**
+     * The argument for rebuilding over cloning that stands independently of PHP versions: the
+     * constructor runs, so a DTO that validates there validates the wither's result too. A
+     * clone-based wither bypasses the constructor and can produce an object the class itself
+     * would have refused to build.
+     */
+    public function testConstructorValidationStillAppliesToTheResult(): void
+    {
+        $valid = WitherValidatingDto::fromArray(['email' => 'ada@example.com']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $valid->with(email: 'not-an-email');
+    }
+
+    public function testAnUndeclaredPropertyNameIsRejected(): void
+    {
+        $user = WitherUserDto::fromArray(['email' => 'ada@example.com', 'name' => 'Ada']);
+
+        try {
+            $user->with(role: 'admin');
+            self::fail('expected an UnknownKeyException');
+        } catch (UnknownKeyException $e) {
+            self::assertSame('role', $e->path());
+        }
+    }
+
+    public function testAWrongTypeIsRejected(): void
+    {
+        // with() is not a way around the type system: the same checks hydration applies, apply.
+        $user = WitherUserDto::fromArray(['email' => 'ada@example.com', 'name' => 'Ada']);
+
+        try {
+            $user->with(age: 'not an int');
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('age', $e->path());
+        }
+    }
+
+    public function testAParameterWithNoMatchingPropertyIsRefusedWithAnExplanation(): void
+    {
+        // Rebuilding requires every constructor parameter to be recoverable from the object.
+        // A non-promoted parameter stored under a different name is not, and saying so beats
+        // failing later with a confusing missing-key error.
+        $dto = WitherUnreadableDto::fromArray(['incoming' => 'abc']);
+
+        try {
+            $dto->with();
+            self::fail('expected a HydrationException');
+        } catch (HydrationException $e) {
+            self::assertStringContainsString('no property of the same name', $e->getMessage());
+            self::assertSame('incoming', $e->path());
+        }
+    }
+
+    // Not asserted here: that assigning to a readonly property throws. It is the constraint the
+    // whole design works within, and it is worth stating why there is no test for it.
+    //
+    // PHPStan at max level rejects such an assignment wherever it appears
+    // (`property.readOnlyAssignOutOfClass`), for every call site, permanently — a strictly
+    // stronger guarantee than one runtime assertion. Writing the test needs the linter either
+    // suppressed or dodged with a dynamic property name, and PHPStan resolves that dodge anyway.
+    // Both were tried; both amount to disabling a real check to assert something it already
+    // proves. The same reasoning retired an `assertNotInstanceOf` in item 2.1.
+}


### PR DESCRIPTION
## Context

Roadmap item **3.2**. Spec FR-02 asks for withers *"absorbing the PHP 8.1→8.3 readonly-clone
difference per version"* — phrasing that invites a `PHP_VERSION_ID` branch.

## The requirement said "per version". Measurement said otherwise.

Measured on 8.3 before writing anything:

| Operation | 8.1 / 8.2 | 8.3 |
|---|---|---|
| assign a `readonly` property after `clone`, **outside** `__clone()` | `Error` | **`Error`** |
| assign a `readonly` property **inside** `__clone()` | `Error` | **allowed** |
| build a new instance through the constructor | allowed | allowed |

The first row is the one worth having checked. **PHP 8.3's readonly amendment did not make
readonly properties writable after cloning in general** — it relaxed one narrow case,
reassignment inside `__clone()`. Everywhere else the property stays sealed, on 8.3 as much as on
8.1.

So a clone-based wither needs a `__clone()` hook *and* remains an error on two of the three
supported versions. Rebuilding through the constructor works on all three. **The requirement is
met by not depending on the difference**, and the trait carries no version branch at all.

Writing `if (PHP_VERSION_ID >= 80300)` would have added a branch dead on two supported versions
— precisely the shape item 3.1 was caught producing, where `match` arms existed for types that
cannot be declared below the 8.1 floor.

## A second argument, independent of versions

A `clone` copies an object into existence **without running its constructor**. A DTO that
validates there would have that validation bypassed — a clone-based wither could produce an
object the class itself refuses to build. Rebuilding keeps the guard, and a fixture that throws
on a malformed email asserts it directly.

## Change

`WithersTrait::with(mixed ...$changes): static` — named arguments collected into a string-keyed
array (verified), so the call site names what it changes. It routes through the **same hydrator**
as `fromArray()`: an undeclared name raises `UnknownKeyException`, a bad value raises
`TypeMismatchException`. `with()` is not a way around the type system, and none of that logic is
duplicated.

Two details checked rather than assumed:

- **The trait declares `abstract protected static function hydrator(): Hydrator`.** A trait's
  abstract method *is* satisfied by an **inherited** one (verified), so `DataTransferObject`'s
  already-shared instance fulfils it — making "this trait belongs on a `DataTransferObject`" a
  **compile-time** requirement rather than a comment. It also keeps imported ADR-001's *one*
  metadata cache true: a trait building its own would quietly make two.
- **Current values are read via `ReflectionProperty::getValue()`**, not `$source->{$name}` — a
  promoted property may be `private` and the hydrator is not in its scope. Since PHP 8.1 this
  needs no `setAccessible()`.

## Verification — proved non-vacuous

Two probes, each reverted and the implementation restored **byte-identical**:

1. **Dropped the current values** (so unnamed properties reset) → **8 errors**.
2. **Reversed the merge order** (so changes lose to current values) → **8 failures**.

**211 tests, 412 assertions** (7 skipped, Windows-only) · PHPStan max clean · PHP-CS-Fixer clean ·
`consistency_lint` and `action_pin_lint --verify-upstream` both OK.

## A test I wrote, then removed

I wrote a test asserting that assigning to a `readonly` property throws — the constraint the
whole design works within. PHPStan rejected it (`property.readOnlyAssignOutOfClass`). I tried
dodging with a dynamic property name; PHPStan resolved that too, correctly.

Both routes amount to **disabling a real check to assert something it already proves** — for
every call site, permanently, which is stronger than one runtime assertion. The test is gone and
the reasoning sits in its place in the file. Third time this pattern has come up (item 2.1's
`assertNotInstanceOf`, item 3.1's `class_exists` fixture); the answer stays consistent.

**Cross-links:** spec FR-02 · ADR-0008, **ADR-0009** · roadmap item 3.2 · milestone `v0.3.0`.
Type label: `feat`; `enhancement` set as the closest available default until
`.github/labels.yml` is imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
