### PR TITLE
feat(dto): add Collection<T> and attribute-driven element hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- `D4np\Utils\Dto\Collection` (**ADR-0010**) — an immutable, functional list wrapper with
+  `map()`/`filter()`/`reduce()`, `@template-covariant` (sound because nothing mutates), and an
+  **optional** runtime `instanceof` guard: PHP has no runtime generics, so `Collection<Foo>` is
+  enforced by PHPStan and, when asked, by `Collection::of(Foo::class, …)`. `filter()` carries
+  the guard across; `map()` drops it, since the element type changes.
+- `D4np\Utils\Dto\CollectionOf` — `#[CollectionOf(Foo::class)]` on a `Collection` constructor
+  parameter lets hydration build its elements, closing the `Collection<T>` gap deferred from
+  the DTO item. An attribute rather than the docblock because PHP resolves its argument to a
+  real class-string, whereas `Collection<Addr>` in a docblock is an alias token only a full
+  parser could resolve. Failures name the index: `stops.1.postcode`.
 - `D4np\Utils\Dto\WithersTrait` (**ADR-0009**) — `$user->with(name: 'Grace')` returns a modified
   copy of an immutable DTO, leaving the receiver untouched. It **rebuilds through the
   constructor** rather than cloning, which works identically on PHP 8.1/8.2/8.3 (8.3's readonly

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Withers: meeting a "per-version" requirement by not depending on the version](docs/journal/2026/08/2026-08-04-withers-trait.md).
+  [2026-08-04 — Collection<T>, and changing a decision a previous ADR had already named](docs/journal/2026/08/2026-08-04-collection.md).
 
 ## Model & effort routing (advisory)
 
@@ -143,8 +143,11 @@ Typed, mass-assignment-safe data transfer (RFC-0001).
       `__clone()`, still an error on 8.1/8.2, while rebuilding through the constructor works
       identically on all three — and additionally preserves constructor validation, which a
       clone bypasses.*
-- [ ] 3.3 `Collection<T>` with `@template` discipline enforced by PHPStan max (RFC-0001)
-      (severity:medium) — route: standard / medium
+- [x] 3.3 `Collection<T>` with `@template` discipline enforced by PHPStan max (RFC-0001)
+      (severity:medium) — route: standard / medium · **ADR-0010**. *Also closes the
+      `Collection<T>` hydration gap item 3.1 deferred here — via a `#[CollectionOf]` attribute
+      rather than the docblock parser ADR-0006 anticipated, because a docblock yields an
+      unresolvable alias token while an attribute argument arrives already resolved by PHP.*
 - [ ] 3.4 T-01 hydration matrix suite (RFC-0001) — route: fast / low
 - [ ] 3.5 phpbench: NFR-01 hydration + NFR-04 memory benchmarks (RFC-0001) (step:optimize) —
       route: fast / medium

--- a/docs/adr/0010-collection-generics-by-attribute.md
+++ b/docs/adr/0010-collection-generics-by-attribute.md
@@ -1,0 +1,109 @@
+# ADR-0010: Declare collection element types with an attribute, not a docblock parser
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 3.3 · spec FR-01, FR-03 · [RFC-0001](../rfc/0001-egl-utils-library.md) ·
+  [ADR-0006](0006-shared-reflection-metadata-cache.md) (which deferred this, expecting a parser) ·
+  [ADR-0008](0008-dto-hydration-strictness-and-shared-hydrator.md)
+
+## Context
+
+Spec FR-03 asks for a `Collection<T>` whose genericity is *"static-analysis-level only
+(`@template` + PHPStan max); optional runtime `instanceof` guard flag"*. Spec FR-01 additionally
+requires that `Collection<T>` **properties hydrate recursively** — a `Collection<AddressDto>`
+declared on a DTO must turn an array of arrays into a collection of `AddressDto`s.
+
+Those two pull in opposite directions. PHP has no runtime generics, so `Collection<AddressDto>`
+exists only in an annotation — and the hydrator, at run time, has to learn `AddressDto` from
+somewhere.
+
+ADR-0006 deferred this question to here and named the expected answer: *"that parser belongs
+with `Collection` itself (roadmap 3.3)"* — i.e. read the docblock. Before writing one, what a
+docblock actually hands back was measured:
+
+```php
+namespace App\Model;
+use App\Dto\AddressDto as Addr;
+
+/** @param Collection<Addr> $stops */
+```
+
+The regex yields the token **`'Addr'`**. Turning that into `App\Dto\AddressDto` requires knowing
+the file's namespace, its `use` statements, **and** that `Addr` is an alias — none of which is in
+the docblock, and none of which reflection exposes. Grouped `use` declarations, function/const
+imports and relative names make it worse. Nothing short of a real PHP parser resolves it
+correctly, and a regex that resolves it *incorrectly* fails silently, hydrating into the wrong
+class or none at all.
+
+An attribute argument has none of that problem: `#[CollectionOf(AddressDto::class)]` is resolved
+**by PHP itself** at compile time and arrives as a class-string — which PHPStan also type-checks
+at the declaration site.
+
+## Decision
+
+**The element type of a hydratable `Collection` parameter is declared with
+`#[CollectionOf(Foo::class)]`. No docblock parser is written.** The `@param Collection<Foo>`
+annotation stays and remains the item's `@template` discipline — it is what PHPStan reads. The
+two say the same thing to two different audiences: the annotation to the static analyser, the
+attribute to the run time.
+
+Supporting decisions:
+
+- **`Collection` is immutable and its template is `@template-covariant`.** That is a statement
+  about the design, not a way to quiet the analyser: covariance is sound precisely because there
+  is no `add()`, no `set()`, no mutation at all. An appendable collection could not safely
+  declare it.
+- **`filter()` carries the guard across; `map()` drops it.** Filtering cannot change the element
+  type; mapping is *for* changing it, and carrying the old `instanceof` check would reject the
+  transformations `map()` exists to perform.
+- **`reduce()` requires an initial value.** A fold with no starting value is undefined on an
+  empty collection, and the usual workaround — returning `null` — hands the caller a type the
+  callback never produces.
+- **`ParameterMetadata` gained an `attributes` field typed `list<object>`, uninterpreted.**
+  `Support` caches the instances and never learns what any of them mean; `Dto` reads
+  `CollectionOf` out of them. Naming the attribute in `Support` would import a group *upward*
+  and break RFC-0001's layering rule, and re-reflecting per hydration would undo the caching
+  NFR-01 depends on. Generic-and-cached is the only option that does neither.
+- **Without the attribute, elements pass through untouched.** That is what a `Collection<string>`
+  wants, and it is the honest response when the element type is genuinely unknown: guessing that
+  an array of arrays means an array of DTOs would invent a mapping the declaration never made.
+
+## Alternatives Considered
+
+- **A docblock generic parser**, as ADR-0006 anticipated — rejected on the evidence above: the
+  token is unresolvable without a full parser, and a partial one fails silently and wrongly.
+  Recorded as a *changed* decision rather than a quiet substitution, since ADR-0006 named the
+  parser explicitly.
+- **Requiring fully-qualified names in the docblock** (`Collection<\App\Dto\AddressDto>`) — this
+  makes a regex sufficient, and is rejected because it puts a rule in a comment that nothing
+  enforces: a short name still analyses cleanly under PHPStan and would silently not hydrate.
+- **A generic runtime `Collection` that records its element type on construction** — does not
+  help. The hydrator's problem is knowing what to build *before* anything exists.
+- **Naming the `CollectionOf` attribute inside `Support`** so the cache could interpret it —
+  rejected: it inverts the dependency RFC-0001 fixes, for the convenience of one field.
+- **Rejecting a `Collection` parameter with no attribute** — rejected as heavy-handed: it would
+  outlaw `Collection<string>`, which needs no element hydration at all.
+
+## Consequences
+
+- **`Collection<T>` properties hydrate**, closing the gap item 3.1 named in its own roadmap
+  entry. Paths compose through the index, so a failure says `stops.1.postcode` rather than
+  "something in the collection".
+- **A hydrated collection carries the declared guard**, so the attribute's claim is checked
+  rather than trusted to the hydration loop.
+- **The element type is declared twice** — once in the docblock for PHPStan, once in the
+  attribute for run time — and they could drift. That is the real cost of this decision and it is
+  named rather than glossed: a mechanical check that the two agree is possible and is *not* built
+  here, because the failure it guards against is visible (a collection of raw arrays) rather than
+  silent.
+- **Genericity remains unenforced at run time unless asked for**, which is what spec FR-03 says
+  and what the optional guard is for. A test asserts an unguarded collection accepts anything, so
+  the honesty of that claim is mechanical rather than prose.
+
+## References
+
+- Spec FR-01 (recursive hydration of `Collection<T>` properties), FR-03 (`Collection` itself)
+- ADR-0006 — the deferral, and the parser it expected; superseded on this point by measurement
+- PHP manual: attributes on promoted constructor parameters (verified readable via
+  `ReflectionParameter::getAttributes()`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0007](0007-measure-total-line-coverage-against-a-floor.md) | Enforce the coverage floor as total line coverage, measured once | Accepted |
 | [0008](0008-dto-hydration-strictness-and-shared-hydrator.md) | Strict-by-default hydration, and how a static entry point reaches shared state | Accepted |
 | [0009](0009-withers-rebuild-rather-than-clone.md) | Withers rebuild through the constructor rather than cloning | Accepted |
+| [0010](0010-collection-generics-by-attribute.md) | Declare collection element types with an attribute, not a docblock parser | Accepted |

--- a/docs/journal/2026/08/2026-08-04-collection.md
+++ b/docs/journal/2026/08/2026-08-04-collection.md
@@ -1,0 +1,82 @@
+# 2026-08-04 — `Collection<T>`, and changing a decision a previous ADR had already named
+
+Roadmap item **3.3**. Route `standard / medium`; session model matched. It also closes the
+`Collection<T>` hydration gap item 3.1 named in its own roadmap entry.
+
+## ADR-0006 said "write a docblock parser". Measurement said don't.
+
+Spec FR-01 requires `Collection<T>` properties to hydrate recursively; PHP has no runtime
+generics, so the hydrator must learn the element type from somewhere. ADR-0006 deferred the
+question to this item and named the expected answer — *"that parser belongs with `Collection`
+itself"*.
+
+Before writing one, what a docblock actually hands back was measured:
+
+```php
+namespace App\Model;
+use App\Dto\AddressDto as Addr;
+/** @param Collection<Addr> $stops */
+```
+
+The regex yields the token **`'Addr'`**. Turning that into `App\Dto\AddressDto` needs the file's
+namespace, its `use` statements, **and** the knowledge that `Addr` is an alias — none of which is
+in the docblock, and none of which reflection exposes. Grouped `use` declarations and relative
+names make it worse. Nothing short of a real PHP parser resolves it, and a regex that resolves it
+*wrongly* fails **silently**: hydrating into the wrong class, or not at all.
+
+`#[CollectionOf(AddressDto::class)]` has none of that problem. PHP resolves the argument at
+compile time and hands over a class-string; PHPStan type-checks it at the declaration site.
+
+So the decision changed, and [ADR-0010](../../adr/0010-collection-generics-by-attribute.md)
+records it *as* a change rather than substituting quietly — ADR-0006 named the parser explicitly,
+and a later reader deserves to find out why it never appeared.
+
+The cost is named too: the element type is now declared twice — docblock for PHPStan, attribute
+for run time — and they can drift. A mechanical check that they agree is possible and deliberately
+not built, because that particular failure is *visible* (a collection of raw arrays) rather than
+silent.
+
+## A layering constraint shaped the plumbing
+
+The hydrator needs the attribute; the attribute lives in `Dto`; the metadata cache lives in
+`Support` — and RFC-0001 forbids `Support` depending on a group above it.
+
+`ParameterMetadata` therefore gained `attributes` typed `list<object>`, **uninterpreted**.
+`Support` caches the instances and never learns what any of them mean; `Dto` picks `CollectionOf`
+out of them. Naming the attribute class in `Support` would have inverted the dependency; having
+the hydrator re-reflect per call would have undone the caching NFR-01 rests on. Generic-and-cached
+does neither.
+
+## Covariance is a design statement, not an escape hatch
+
+PHPStan rejected `Collection<object>` where `Collection<mixed>` was declared and suggested
+`@template-covariant`. That suggestion happens to be *correct here*, and for a reason worth
+writing down: covariance is sound only for a container that cannot be written to, and this one
+cannot — no `add()`, no `set()`, no mutation anywhere. An appendable collection could not safely
+declare it. Taking the analyser's hint because it is right is different from taking it because it
+silences the error.
+
+## Two smaller decisions
+
+- **`filter()` carries the guard; `map()` drops it.** Filtering cannot change the element type;
+  mapping is *for* changing it, and carrying the old `instanceof` across would reject exactly the
+  transformations `map()` exists to perform. Both directions are asserted.
+- **`reduce()` requires an initial value** rather than defaulting to `null`: a fold with no
+  starting value is undefined on an empty collection, and returning `null` hands the caller a type
+  the callback never produces.
+
+## Proved non-vacuous
+
+Two probes, each reverted and both files restored byte-identical:
+
+1. **Made `filter()` drop the guard** → 1 failure.
+2. **Ignored the `CollectionOf` attribute** (elements stay raw arrays) → 6 failures.
+
+236 tests, 454 assertions (7 skipped, Windows-only). PHPStan max clean; PHP-CS-Fixer clean.
+
+## Next
+
+**3.4 — the T-01 hydration matrix suite.** Like item 2.6 before it, most of what it names now
+exists: the `#[Group('T-01')]` tag already spans DTO hydration, withers and collection
+hydration. Whether 3.4 is fresh work or bookkeeping is worth checking against the spec before
+starting, rather than assuming either.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Collection<T>, and changing a decision a previous ADR had already named](2026/08/2026-08-04-collection.md)
 - [2026-08-04 — Withers: meeting a "per-version" requirement by not depending on the version](2026/08/2026-08-04-withers-trait.md)
 - [2026-08-04 — Milestone 3 opens: DTO hydration, and PHP disagreeing with the requirement](2026/08/2026-08-04-dto-hydration.md)
 - [2026-08-04 — Closing the coverage floor, and measuring it for the first time](2026/08/2026-08-04-coverage-floor-gate.md)

--- a/src/main/php/d4np/utils/Dto/Collection.php
+++ b/src/main/php/d4np/utils/Dto/Collection.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Dto;
+
+use ArrayIterator;
+use Countable;
+use D4np\Utils\Support\TypeMismatchException;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * An immutable, functional wrapper over a list (spec FR-03, ADR-0010).
+ *
+ * ```php
+ * // @var Collection<OrderDto> $orders
+ * $totals = $orders->map(static fn (OrderDto $o): float => $o->total)
+ *                  ->filter(static fn (float $t): bool => $t > 100.0);
+ * ```
+ *
+ * **Genericity here is static-analysis-level only, and that is stated rather than implied.**
+ * PHP has no runtime generics: `Collection<OrderDto>` exists in `@template`/`@var` annotations
+ * and is enforced by PHPStan at max level, not by the engine. A `Collection<OrderDto>` handed a
+ * `UserDto` at run time is a type error PHPStan catches and PHP does not.
+ *
+ * For the cases where that is not enough — a payload from outside the type system, say — the
+ * constructor takes an **optional** `$itemType`, and every element is then checked with
+ * `instanceof` at construction. It is opt-in because it costs a pass over the items, and because
+ * inside a codebase that runs PHPStan it is a second belt on the same trousers.
+ *
+ * Every operation returns a new instance; nothing here mutates.
+ *
+ * `T` is declared **covariant**, and that is a statement about the design rather than a way to
+ * quiet the analyser: covariance is only sound for a container that cannot be written to, and
+ * this one cannot — there is no `add()`, no `set()`, no mutation of any kind. A
+ * `Collection<AddressDto>` is therefore usable wherever a `Collection<object>` is wanted, which
+ * an appendable collection could never safely allow.
+ *
+ * @template-covariant T
+ *
+ * @implements IteratorAggregate<int, T>
+ */
+final class Collection implements Countable, IteratorAggregate
+{
+    /** @var list<T> */
+    private readonly array $items;
+
+    /**
+     * @param iterable<T>          $items
+     * @param class-string<T>|null $itemType when given, every element is checked with
+     *                                       `instanceof` and a mismatch raises immediately,
+     *                                       naming the index it failed at
+     *
+     * @throws TypeMismatchException
+     */
+    public function __construct(
+        iterable $items = [],
+        private readonly ?string $itemType = null,
+    ) {
+        $list = is_array($items) ? array_values($items) : iterator_to_array($items, false);
+
+        if ($itemType !== null) {
+            foreach ($list as $index => $item) {
+                if (!$item instanceof $itemType) {
+                    throw TypeMismatchException::at((string) $index, $itemType, get_debug_type($item));
+                }
+            }
+        }
+
+        $this->items = $list;
+    }
+
+    /**
+     * A collection of `$items`, each checked against `$itemType`.
+     *
+     * The named constructor exists because `new Collection($items, Foo::class)` reads as though
+     * the second argument were data; `Collection::of(Foo::class, $items)` reads as what it is.
+     *
+     * @template TItem
+     *
+     * @param class-string<TItem> $itemType
+     * @param iterable<TItem>     $items
+     *
+     * @return self<TItem>
+     *
+     * @throws TypeMismatchException
+     */
+    public static function of(string $itemType, iterable $items = []): self
+    {
+        return new self($items, $itemType);
+    }
+
+    /**
+     * A new collection with `$callback` applied to every element.
+     *
+     * The result is **unguarded** even when this collection is: `$callback` may return a
+     * different type entirely, and carrying the old `instanceof` check across would reject
+     * exactly the transformations `map()` exists for.
+     *
+     * @template TOut
+     *
+     * @param callable(T): TOut $callback
+     *
+     * @return self<TOut>
+     */
+    public function map(callable $callback): self
+    {
+        return new self(array_map($callback, $this->items));
+    }
+
+    /**
+     * A new collection of the elements `$callback` accepts, keys discarded.
+     *
+     * The element type is unchanged, so the guard — if any — is carried across.
+     *
+     * @param callable(T): bool $callback
+     *
+     * @return self<T>
+     */
+    public function filter(callable $callback): self
+    {
+        return new self(array_values(array_filter($this->items, $callback)), $this->itemType);
+    }
+
+    /**
+     * Fold the collection into a single value.
+     *
+     * `$initial` is required rather than defaulting to `null`: a fold with no starting value is
+     * undefined on an empty collection, and the usual workaround — returning `null` — hands the
+     * caller a type the callback never produces.
+     *
+     * @template TAcc
+     *
+     * @param callable(TAcc, T): TAcc $callback
+     * @param TAcc                    $initial
+     *
+     * @return TAcc
+     */
+    public function reduce(callable $callback, mixed $initial): mixed
+    {
+        return array_reduce($this->items, $callback, $initial);
+    }
+
+    /**
+     * The elements, as a plain list.
+     *
+     * @return list<T>
+     */
+    public function toArray(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * The first element, or `null` when empty.
+     *
+     * @return T|null
+     */
+    public function first(): mixed
+    {
+        return $this->items[0] ?? null;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->items === [];
+    }
+
+    public function count(): int
+    {
+        return \count($this->items);
+    }
+
+    /**
+     * The element type this collection checks against, or `null` when unguarded.
+     *
+     * @return class-string<T>|null
+     */
+    public function itemType(): ?string
+    {
+        return $this->itemType;
+    }
+
+    /**
+     * @return Traversable<int, T>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+}

--- a/src/main/php/d4np/utils/Dto/CollectionOf.php
+++ b/src/main/php/d4np/utils/Dto/CollectionOf.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Dto;
+
+use Attribute;
+
+/**
+ * Declares the element type of a `Collection` constructor parameter, so hydration can build it
+ * (spec FR-01/FR-03, ADR-0010).
+ *
+ * ```php
+ * final class OrderDto extends DataTransferObject
+ * {
+ *     /** @param Collection<LineDto> $lines *\/
+ *     public function __construct(
+ *         #[CollectionOf(LineDto::class)]
+ *         public readonly Collection $lines,
+ *     ) {}
+ * }
+ * ```
+ *
+ * **Why an attribute and not the docblock.** PHP has no runtime generics, so `Collection<LineDto>`
+ * lives in an annotation — and reading it back gives a *token*, not a class. Resolving that token
+ * needs the file's namespace, its `use` statements, and any aliases among them: a docblock
+ * reading `Collection<Addr>` may mean `App\Dto\AddressDto` imported under an alias, and nothing
+ * short of a real PHP parser can tell. An attribute argument is resolved **by PHP itself** at
+ * compile time and arrives as a class-string, which PHPStan also type-checks at the call site.
+ *
+ * The docblock generic is still worth writing — it is what PHPStan uses, and it is the item's
+ * stated `@template` discipline. The two say the same thing to two different readers: the
+ * annotation to the static analyser, the attribute to the run time.
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class CollectionOf
+{
+    /**
+     * @param class-string $type the class every element of the collection must be
+     */
+    public function __construct(
+        public readonly string $type,
+    ) {
+    }
+}

--- a/src/main/php/d4np/utils/Dto/Hydrator.php
+++ b/src/main/php/d4np/utils/Dto/Hydrator.php
@@ -218,6 +218,10 @@ final class Hydrator
             throw TypeMismatchException::at($path, $parameter->declaredType ?? $type, 'null');
         }
 
+        if ($type === Collection::class) {
+            return $this->coerceCollection($value, $parameter, $lenient, $path);
+        }
+
         if (!$parameter->isBuiltin) {
             // A non-builtin type name is only a class-string if it actually resolves. The
             // reflection cache proved the *declaring* class loadable, not the types of its
@@ -245,6 +249,64 @@ final class Hydrator
         }
 
         return $value;
+    }
+
+    /**
+     * Build a {@see Collection} for a `Collection`-typed parameter.
+     *
+     * The element type comes from the parameter's `#[CollectionOf]` attribute, because PHP has no
+     * runtime generics and the docblock `Collection<Foo>` yields a token that only a real parser
+     * could resolve through the file's `use` statements and aliases (ADR-0010).
+     *
+     * **Without the attribute the elements are passed through untouched**, which is what a
+     * `Collection<string>` wants and is the honest thing to do when the element type is genuinely
+     * unknown: guessing that an array of arrays means an array of DTOs would be inventing a
+     * mapping the declaration never expressed.
+     *
+     * The return is `Collection<mixed>`: the element type is only known at run time, from the
+     * attribute, so there is nothing for the static type to be parameterised by here. The
+     * caller's own `@param Collection<Foo>` docblock is what PHPStan checks against — which is
+     * exactly the division of labour ADR-0010 describes.
+     *
+     * @return Collection<mixed>
+     *
+     * @throws HydrationException
+     */
+    private function coerceCollection(mixed $value, ParameterMetadata $parameter, bool $lenient, string $path): Collection
+    {
+        if ($value instanceof Collection) {
+            return $value;
+        }
+
+        if (!is_iterable($value)) {
+            throw TypeMismatchException::at($path, Collection::class, get_debug_type($value));
+        }
+
+        $of = $parameter->attribute(CollectionOf::class);
+        if ($of === null) {
+            return new Collection($value);
+        }
+
+        $items = [];
+        $index = 0;
+        foreach ($value as $element) {
+            $elementPath = self::join($path, (string) $index);
+
+            if ($element instanceof $of->type) {
+                $items[] = $element;
+            } elseif (is_a($of->type, DataTransferObject::class, true) && is_array($element)) {
+                /** @var array<string, mixed> $element */
+                $items[] = $this->hydrateAt($of->type, $element, $lenient, $elementPath);
+            } else {
+                throw TypeMismatchException::at($elementPath, $of->type, get_debug_type($element));
+            }
+
+            $index++;
+        }
+
+        // Guarded with the declared element type: the attribute said what these are, so the
+        // collection carries the check rather than trusting that this loop got it right.
+        return Collection::of($of->type, $items);
     }
 
     /**

--- a/src/main/php/d4np/utils/Support/ParameterMetadata.php
+++ b/src/main/php/d4np/utils/Support/ParameterMetadata.php
@@ -38,6 +38,11 @@ final class ParameterMetadata
      *                                  does not silently describe `...$args` as an ordinary
      *                                  parameter — being truthful about what was reflected is the
      *                                  cache's entire job
+     * @param list<object> $attributes  the parameter's attribute instances, **uninterpreted**.
+     *                                  Deliberately untyped beyond `object`: a consumer group
+     *                                  (`Dto`, `Container`) knows what its own attributes mean,
+     *                                  and `Support` must not — naming one here would import a
+     *                                  group upward and break the layering rule RFC-0001 sets
      */
     public function __construct(
         public readonly string $name,
@@ -48,7 +53,28 @@ final class ParameterMetadata
         public readonly bool $hasDefault,
         public readonly mixed $default,
         public readonly bool $isVariadic,
+        public readonly array $attributes = [],
     ) {
+    }
+
+    /**
+     * The parameter's attribute of type `$class`, or `null` when it carries none.
+     *
+     * @template A of object
+     *
+     * @param class-string<A> $class
+     *
+     * @return A|null
+     */
+    public function attribute(string $class): ?object
+    {
+        foreach ($this->attributes as $attribute) {
+            if ($attribute instanceof $class) {
+                return $attribute;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/main/php/d4np/utils/Support/ReflectionCache.php
+++ b/src/main/php/d4np/utils/Support/ReflectionCache.php
@@ -121,7 +121,30 @@ final class ReflectionCache
             hasDefault: $parameter->isDefaultValueAvailable(),
             default: self::defaultOf($parameter),
             isVariadic: $parameter->isVariadic(),
+            attributes: self::attributesOf($parameter),
         );
+    }
+
+    /**
+     * The parameter's attribute instances, cached with the rest of the metadata.
+     *
+     * Instantiated here rather than handed back as `ReflectionAttribute`s so the cost is paid
+     * once per class like everything else, and stored as plain `object`s so this layer never
+     * learns what any of them mean — that belongs to the group that declared them.
+     *
+     * @return list<object>
+     */
+    private static function attributesOf(ReflectionParameter $parameter): array
+    {
+        $instances = [];
+        foreach ($parameter->getAttributes() as $attribute) {
+            // A failure here is a broken attribute class, not a condition to paper over: it
+            // surfaces as the UtilsException `for()` already documents rather than being
+            // swallowed into a silently attribute-less parameter.
+            $instances[] = $attribute->newInstance();
+        }
+
+        return $instances;
     }
 
     private static function declaredTypeOf(?\ReflectionType $type): ?string

--- a/src/test/php/d4np/utils/Dto/CollectionHydrationTest.php
+++ b/src/test/php/d4np/utils/Dto/CollectionHydrationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto;
+
+use D4np\Utils\Dto\Collection;
+use D4np\Utils\Support\TypeMismatchException;
+use D4np\Utils\Tests\Dto\Fixture\AddressDto;
+use D4np\Utils\Tests\Dto\Fixture\BasketDto;
+use D4np\Utils\Tests\Dto\Fixture\TagsDto;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Hydrating `Collection` properties — the gap item 3.1 named in its own roadmap entry and
+ * deferred to here, and part of **T-01**'s "collections" column (spec §7).
+ *
+ * The element type comes from `#[CollectionOf]` rather than the docblock, because a docblock
+ * yields a *token* that only a real PHP parser could resolve through the file's `use` statements
+ * and aliases, while an attribute argument arrives already resolved (ADR-0010).
+ */
+#[Group('T-01')]
+final class CollectionHydrationTest extends TestCase
+{
+    public function testElementsAreHydratedIntoTheDeclaredType(): void
+    {
+        $basket = BasketDto::fromArray([
+            'label' => 'route',
+            'stops' => [
+                ['street' => '1 Main St', 'postcode' => 'AB1 2CD'],
+                ['street' => '2 Other Rd', 'postcode' => 'XY9 8ZW'],
+            ],
+        ]);
+
+        self::assertInstanceOf(Collection::class, $basket->stops);
+        self::assertCount(2, $basket->stops);
+
+        $first = $basket->stops->first();
+        self::assertInstanceOf(AddressDto::class, $first, 'the raw arrays became DTOs');
+        self::assertSame('AB1 2CD', $first->postcode);
+    }
+
+    public function testTheHydratedCollectionCarriesTheDeclaredGuard(): void
+    {
+        // The attribute said what these are, so the collection checks rather than trusting the
+        // hydration loop got it right.
+        $basket = BasketDto::fromArray(['label' => 'route', 'stops' => []]);
+
+        self::assertSame(AddressDto::class, $basket->stops->itemType());
+    }
+
+    public function testAnEmptyCollectionHydrates(): void
+    {
+        $basket = BasketDto::fromArray(['label' => 'route', 'stops' => []]);
+
+        self::assertTrue($basket->stops->isEmpty());
+    }
+
+    public function testAlreadyBuiltElementsArePassedThrough(): void
+    {
+        $address = AddressDto::fromArray(['street' => 'S', 'postcode' => 'P']);
+
+        $basket = BasketDto::fromArray(['label' => 'route', 'stops' => [$address]]);
+
+        self::assertSame($address, $basket->stops->first());
+    }
+
+    public function testAnAlreadyBuiltCollectionIsPassedThrough(): void
+    {
+        $stops = Collection::of(AddressDto::class, [AddressDto::fromArray(['street' => 'S', 'postcode' => 'P'])]);
+
+        $basket = BasketDto::fromArray(['label' => 'route', 'stops' => $stops]);
+
+        self::assertSame($stops, $basket->stops);
+    }
+
+    /**
+     * The reason paths compose at all: in a collection of nested objects, the index is the only
+     * thing that says *which* element was wrong.
+     */
+    public function testAFailingElementNamesItsIndexInThePath(): void
+    {
+        try {
+            BasketDto::fromArray([
+                'label' => 'route',
+                'stops' => [
+                    ['street' => '1 Main St', 'postcode' => 'AB1 2CD'],
+                    ['street' => '2 Other Rd', 'postcode' => 12345],
+                ],
+            ]);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('stops.1.postcode', $e->path());
+        }
+    }
+
+    public function testAnElementOfTheWrongTypeEntirelyIsRejectedWithItsIndex(): void
+    {
+        try {
+            BasketDto::fromArray(['label' => 'route', 'stops' => ['not an address']]);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('stops.0', $e->path());
+        }
+    }
+
+    public function testANonIterableValueForACollectionIsRejected(): void
+    {
+        try {
+            BasketDto::fromArray(['label' => 'route', 'stops' => 'nope']);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('stops', $e->path());
+        }
+    }
+
+    /**
+     * Without the attribute the element type is genuinely unknown, so elements pass through
+     * untouched — which is what a `Collection<string>` wants. Guessing that an array of arrays
+     * means an array of DTOs would be inventing a mapping the declaration never expressed.
+     */
+    public function testWithoutTheAttributeElementsPassThroughUntouched(): void
+    {
+        $dto = TagsDto::fromArray(['tags' => ['php', 'dto', 'utils']]);
+
+        self::assertSame(['php', 'dto', 'utils'], $dto->tags->toArray());
+        self::assertNull($dto->tags->itemType(), 'nothing was declared, so nothing is guarded');
+    }
+
+    public function testLeniencyPropagatesIntoCollectionElements(): void
+    {
+        $basket = BasketDto::lenient()->fromArray([
+            'label' => 'route',
+            'unknownAtRoot' => 1,
+            'stops' => [['street' => 'S', 'postcode' => 'P', 'unknownInElement' => 2]],
+        ]);
+
+        self::assertSame('P', $basket->stops->first()?->postcode);
+    }
+
+    public function testStrictModeRejectsAnUnknownKeyInsideAnElement(): void
+    {
+        try {
+            BasketDto::fromArray([
+                'label' => 'route',
+                'stops' => [['street' => 'S', 'postcode' => 'P', 'county' => 'X']],
+            ]);
+            self::fail('expected a hydration failure');
+        } catch (\D4np\Utils\Support\UnknownKeyException $e) {
+            self::assertSame('stops.0.county', $e->path());
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Dto/CollectionTest.php
+++ b/src/test/php/d4np/utils/Dto/CollectionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto;
+
+use D4np\Utils\Dto\Collection;
+use D4np\Utils\Support\TypeMismatchException;
+use D4np\Utils\Tests\Dto\Fixture\AddressDto;
+use D4np\Utils\Tests\Dto\Fixture\UserDto;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Collection` — spec FR-03, ADR-0010.
+ *
+ * The property under test is that it is a *value*: immutable, and every operation returning a
+ * new instance. Genericity itself is not testable at run time — PHP has none — which is the
+ * point of the optional `instanceof` guard, and of saying so rather than implying otherwise.
+ */
+final class CollectionTest extends TestCase
+{
+    // --------------------------------------------------------------- basics
+
+    public function testAnEmptyCollection(): void
+    {
+        $c = new Collection();
+
+        self::assertTrue($c->isEmpty());
+        self::assertCount(0, $c);
+        self::assertSame([], $c->toArray());
+        self::assertNull($c->first());
+    }
+
+    public function testKeysAreDiscardedSoTheResultIsAList(): void
+    {
+        // A collection is a sequence, not a map: string or gapped keys would make `first()`,
+        // iteration order and `toArray()` ambiguous.
+        $c = new Collection(['a' => 1, 'z' => 2]);
+
+        self::assertSame([1, 2], $c->toArray());
+        self::assertSame(1, $c->first());
+    }
+
+    public function testItAcceptsAnyIterableNotJustAnArray(): void
+    {
+        $generator = (static function (): \Generator {
+            yield 1;
+            yield 2;
+        })();
+
+        self::assertSame([1, 2], (new Collection($generator))->toArray());
+    }
+
+    public function testItIsIterableAndCountable(): void
+    {
+        $c = new Collection([1, 2, 3]);
+
+        self::assertCount(3, $c);
+        self::assertSame([1, 2, 3], iterator_to_array($c));
+    }
+
+    // ---------------------------------------------------------- functional
+
+    public function testMapProducesANewCollectionAndLeavesTheOriginalUntouched(): void
+    {
+        $c = new Collection([1, 2, 3]);
+
+        $doubled = $c->map(static fn (int $n): int => $n * 2);
+
+        self::assertSame([2, 4, 6], $doubled->toArray());
+        self::assertSame([1, 2, 3], $c->toArray(), 'the receiver is unchanged');
+        self::assertNotSame($c, $doubled);
+    }
+
+    public function testFilterKeepsOnlyWhatThePredicateAcceptsAndReindexes(): void
+    {
+        $c = new Collection([1, 2, 3, 4]);
+
+        $even = $c->filter(static fn (int $n): bool => $n % 2 === 0);
+
+        // Re-indexed: array_filter preserves keys, which would leave gaps and break `first()`.
+        self::assertSame([2, 4], $even->toArray());
+        self::assertSame(2, $even->first());
+    }
+
+    public function testReduceFoldsToASingleValue(): void
+    {
+        $c = new Collection([1, 2, 3, 4]);
+
+        self::assertSame(10, $c->reduce(static fn (int $acc, int $n): int => $acc + $n, 0));
+    }
+
+    public function testReduceOnAnEmptyCollectionReturnsTheInitialValue(): void
+    {
+        // Why the initial value is required rather than defaulting to null: this is the case
+        // that would otherwise hand the caller a type the callback never produces.
+        self::assertSame(0, (new Collection())->reduce(static fn (int $a, int $b): int => $a + $b, 0));
+    }
+
+    public function testOperationsChain(): void
+    {
+        $result = (new Collection([1, 2, 3, 4, 5]))
+            ->filter(static fn (int $n): bool => $n % 2 === 1)
+            ->map(static fn (int $n): int => $n * 10)
+            ->reduce(static fn (int $acc, int $n): int => $acc + $n, 0);
+
+        self::assertSame(90, $result);
+    }
+
+    // ------------------------------------------------------- the type guard
+
+    public function testTheGuardAcceptsMatchingElements(): void
+    {
+        $a = AddressDto::fromArray(['street' => 'S', 'postcode' => 'P']);
+
+        $c = Collection::of(AddressDto::class, [$a]);
+
+        self::assertSame(AddressDto::class, $c->itemType());
+        self::assertSame([$a], $c->toArray());
+    }
+
+    public function testTheGuardRejectsAMismatchAndNamesTheIndex(): void
+    {
+        $address = AddressDto::fromArray(['street' => 'S', 'postcode' => 'P']);
+        $user = UserDto::fromArray(['email' => 'a@b.c', 'name' => 'Ada']);
+
+        try {
+            Collection::of(AddressDto::class, [$address, $user]);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('1', $e->path(), 'the failing index is named');
+            self::assertStringContainsString(AddressDto::class, $e->getMessage());
+        }
+    }
+
+    public function testAnUnguardedCollectionAcceptsAnythingWhichIsThePointOfTheFlagBeingOptional(): void
+    {
+        // Genericity is static-analysis-level only. Without the opt-in guard, PHP does not and
+        // cannot check — asserted so the honesty of that claim is mechanical rather than prose.
+        $mixed = new Collection([1, 'two', new \stdClass()]);
+
+        self::assertCount(3, $mixed);
+        self::assertNull($mixed->itemType());
+    }
+
+    public function testFilterCarriesTheGuardAcross(): void
+    {
+        $a = AddressDto::fromArray(['street' => 'S', 'postcode' => 'AB1']);
+        $b = AddressDto::fromArray(['street' => 'T', 'postcode' => 'XY9']);
+
+        $filtered = Collection::of(AddressDto::class, [$a, $b])
+            ->filter(static fn (AddressDto $x): bool => $x->postcode === 'AB1');
+
+        self::assertSame(AddressDto::class, $filtered->itemType(), 'the element type is unchanged, so the guard survives');
+        self::assertSame([$a], $filtered->toArray());
+    }
+
+    public function testMapDropsTheGuardBecauseTheElementTypeChanges(): void
+    {
+        // Carrying the old guard across would reject exactly the transformations map() exists
+        // for — the callback may return anything at all.
+        $a = AddressDto::fromArray(['street' => 'S', 'postcode' => 'AB1']);
+
+        $postcodes = Collection::of(AddressDto::class, [$a])
+            ->map(static fn (AddressDto $x): string => $x->postcode);
+
+        self::assertNull($postcodes->itemType());
+        self::assertSame(['AB1'], $postcodes->toArray());
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/BasketDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/BasketDto.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\Collection;
+use D4np\Utils\Dto\CollectionOf;
+use D4np\Utils\Dto\DataTransferObject;
+
+/** A Collection of nested DTOs, element type declared by attribute. */
+final class BasketDto extends DataTransferObject
+{
+    /** @param Collection<AddressDto> $stops */
+    public function __construct(
+        public readonly string $label,
+        #[CollectionOf(AddressDto::class)]
+        public readonly Collection $stops,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/TagsDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/TagsDto.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\Collection;
+use D4np\Utils\Dto\DataTransferObject;
+
+/**
+ * A Collection with NO attribute. The element type is genuinely unknown to the hydrator, so
+ * elements pass through untouched - which is what a Collection of scalars wants.
+ */
+final class TagsDto extends DataTransferObject
+{
+    /** @param Collection<string> $tags */
+    public function __construct(
+        public readonly Collection $tags,
+    ) {
+    }
+}


### PR DESCRIPTION
## Context

Roadmap item **3.3**. It also closes the `Collection<T>` **hydration** gap item 3.1 named in its
own roadmap entry.

## ADR-0006 said "write a docblock parser". Measurement said don't.

Spec FR-01 requires `Collection<T>` properties to hydrate recursively; PHP has no runtime
generics, so the hydrator must learn the element type from somewhere. ADR-0006 deferred that
question to this item and named the expected answer — *"that parser belongs with `Collection`
itself"*.

Before writing one, what a docblock actually hands back was measured:

```php
namespace App\Model;
use App\Dto\AddressDto as Addr;
/** @param Collection<Addr> $stops */
```

The regex yields the token **`'Addr'`**. Turning that into `App\Dto\AddressDto` needs the file's
namespace, its `use` statements, **and** the knowledge that `Addr` is an alias — none of which is
in the docblock, and none of which reflection exposes. Nothing short of a real PHP parser
resolves it, and a regex that resolves it *wrongly* fails **silently**: hydrating into the wrong
class, or not at all.

`#[CollectionOf(AddressDto::class)]` has none of that problem — PHP resolves the argument at
compile time into a class-string, and PHPStan type-checks it at the declaration site.

**[ADR-0010](docs/adr/0010-collection-generics-by-attribute.md) records this as a *changed*
decision** rather than a quiet substitution: ADR-0006 named the parser explicitly, and a later
reader deserves to find out why it never appeared. The cost is named too — the element type is
now declared twice (docblock for PHPStan, attribute for run time) and can drift; a check that
they agree is possible and deliberately **not** built, because that failure is *visible* (a
collection of raw arrays) rather than silent.

## A layering constraint shaped the plumbing

The hydrator needs the attribute; the attribute lives in `Dto`; the metadata cache lives in
`Support` — which RFC-0001 forbids from depending upward.

`ParameterMetadata` therefore gained `attributes` typed `list<object>`, **uninterpreted**:
`Support` caches the instances and never learns what any of them mean; `Dto` picks `CollectionOf`
out of them. Naming the class in `Support` would invert the dependency; re-reflecting per call
would undo the caching NFR-01 rests on.

## Covariance is a design statement, not an escape hatch

PHPStan suggested `@template-covariant`, and it is **correct here** for a reason worth writing
down: covariance is sound only for a container that cannot be written to, and this one cannot —
no `add()`, no `set()`, no mutation anywhere. An appendable collection could not safely declare
it. Taking the analyser's hint because it is right differs from taking it because it silences an
error.

## Two smaller decisions

- **`filter()` carries the guard across; `map()` drops it.** Filtering cannot change the element
  type; mapping is *for* changing it, and carrying the old `instanceof` would reject exactly the
  transformations `map()` exists to perform. Both directions asserted.
- **`reduce()` requires an initial value** rather than defaulting to `null` — a fold with no
  starting value is undefined on an empty collection, and returning `null` hands the caller a
  type the callback never produces.

## Verification — proved non-vacuous

Two probes, each reverted and both files restored **byte-identical**:

1. **Made `filter()` drop the guard** → 1 failure.
2. **Ignored the `CollectionOf` attribute** (elements stay raw arrays) → 6 failures.

**236 tests, 454 assertions** (7 skipped, Windows-only) · PHPStan max clean · PHP-CS-Fixer clean ·
`consistency_lint` and `action_pin_lint --verify-upstream` both OK.

Hydration failures compose the index into the path — `stops.1.postcode` — and an unguarded
collection is asserted to accept anything, so the "genericity is static-analysis-level only"
claim is mechanical rather than prose.

**Cross-links:** spec FR-01, FR-03 · ADR-0006 (superseded on this point), ADR-0008, **ADR-0010** ·
roadmap item 3.3 · milestone `v0.3.0`. Type label: `feat`; `enhancement` set as the closest
available default until `.github/labels.yml` is imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
