### PR TITLE
feat(dto): hydrate backed enum properties from their scalar value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   to LF so Windows checkouts match what CI lints.
 - `D4np\Utils\Version::VERSION` (`Version.php`) as the single source of truth for the
   released version, kept in lockstep with the README badge by `tools/consistency_lint.py`.
+- Enum-typed DTO properties: a **backed** enum (`enum Status: string { … }`) hydrates from its
+  scalar backing value via `tryFrom()`; an invalid value is a `TypeMismatchException` naming the
+  valid ones. A **pure** (non-backed) enum has no scalar to resolve from and stays
+  instance-only. `#[Group('T-01')]` covers the case.
 - `D4np\Utils\Dto\Collection` (**ADR-0010**) — an immutable, functional list wrapper with
   `map()`/`filter()`/`reduce()`, `@template-covariant` (sound because nothing mutates), and an
   **optional** runtime `instanceof` guard: PHP has no runtime generics, so `Collection<Foo>` is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Collection<T>, and changing a decision a previous ADR had already named](docs/journal/2026/08/2026-08-04-collection.md).
+  [2026-08-04 — Checking what T-01 actually still needed, before writing anything](docs/journal/2026/08/2026-08-04-t01-enum-hydration.md).
 
 ## Model & effort routing (advisory)
 
@@ -148,7 +148,12 @@ Typed, mass-assignment-safe data transfer (RFC-0001).
       `Collection<T>` hydration gap item 3.1 deferred here — via a `#[CollectionOf]` attribute
       rather than the docblock parser ADR-0006 anticipated, because a docblock yields an
       unresolvable alias token while an attribute argument arrives already resolved by PHP.*
-- [ ] 3.4 T-01 hydration matrix suite (RFC-0001) — route: fast / low
+- [x] 3.4 T-01 hydration matrix suite (RFC-0001) — route: fast / low. *Most of the matrix
+      (nested, nullables, strict/lenient, withers, missing-key, collections) already existed,
+      landed with items 3.1–3.3. The one gap: spec §7 names "enums" and nothing had hydrated
+      one. Closed here — a backed enum resolves from its scalar value via `tryFrom()`; a pure
+      enum has no scalar to resolve from and stays instance-only, verified by planting a
+      pure-enum fixture and confirming the distinction is enforced.*
 - [ ] 3.5 phpbench: NFR-01 hydration + NFR-04 memory benchmarks (RFC-0001) (step:optimize) —
       route: fast / medium
 - [ ] 3.6 Add `deptrac.yaml` and turn on the layering gate. RFC-0001's dependency rule — *groups

--- a/docs/journal/2026/08/2026-08-04-t01-enum-hydration.md
+++ b/docs/journal/2026/08/2026-08-04-t01-enum-hydration.md
@@ -1,0 +1,57 @@
+# 2026-08-04 — Checking what T-01 actually still needed, before writing anything
+
+Roadmap item **3.4**. Route: no signals, floor `fast / low`; session model matched.
+
+## Checked before assuming
+
+Item 2.6 taught the shape: a roadmap line naming a suite spec §7 defines does not automatically
+mean new tests. Spec T-01's matrix names *"nested, collections, nullables, enums, strict/lenient,
+withers, missing-key cases"*. Checked each against what `#[Group('T-01')]` already covered
+(items 3.1–3.3): nested — yes. Nullables — yes. Strict/lenient — yes. Withers — yes. Missing-key
+— yes. Collections — yes. **Enums — no fixture anywhere uses one.**
+
+That is a real gap, not bookkeeping, so this item did real work rather than only tagging
+existing tests.
+
+## The gap, and the distinction that matters
+
+Reflecting an enum-typed parameter: `isBuiltin()` is `false`, so today's hydrator routes it to
+`coerceObject()` — which passes through an already-constructed instance, tries nested-DTO
+hydration (fails, an enum is not a `DataTransferObject`), and otherwise throws. So a payload
+carrying the enum's own **scalar backing value** (`'active'` for `Status::Active`) was rejected,
+even though `Status::tryFrom('active')` could construct it.
+
+The fix has one edge worth being careful about, verified before writing code:
+
+```php
+enum Status: string { case Active = 'active'; }   // BackedEnum: has ::tryFrom()
+enum Direction { case Up; case Down; }             // UnitEnum only: no scalar mapping at all
+```
+
+Only `BackedEnum` gets scalar coercion. A pure enum has no backing value to key from —
+`Direction::cases()` gives names, not a lookup — so it stays instance-only, which the existing
+pass-through already handles correctly.
+
+**`tryFrom()`, not `from()`.** `from()` throws a bare `\ValueError` on no match, which is not
+part of ADR-0004's exception family and would let an uncaught error escape a hydration call.
+`tryFrom()` returns `null`, converted here into `TypeMismatchException` naming every valid
+backing value — more useful than "expected Status, got string" on its own.
+
+## Proved non-vacuous
+
+Two probes, each reverted and the implementation restored byte-identical:
+
+1. **Widened the check from `BackedEnum` to `UnitEnum`** (both share the interface) → 3 errors
+   and 2 failures. The errors are the interesting part: calling `tryFrom()` on `Direction`, which
+   does not have that method, is a fatal error, not a graceful rejection — the narrower check
+   exists precisely to avoid it.
+2. **Swapped `tryFrom()` for `from()`** → a bare `\ValueError` propagated instead of a caught
+   `TypeMismatchException`, exactly as predicted.
+
+243 tests, 464 assertions (7 skipped, Windows-only). PHPStan max clean on the first pass.
+
+## State of Milestone 3
+
+3.1–3.4 done. Remaining: **3.5** (phpbench benchmarks against NFR-01/NFR-04) and **3.6**, filed
+at item 3.1 — the `deptrac.yaml` layering gate, now covering two real component groups
+(`Support`, `Dto`) instead of the vacuous single-group case it would have been before 3.1.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Checking what T-01 actually still needed, before writing anything](2026/08/2026-08-04-t01-enum-hydration.md)
 - [2026-08-04 — Collection<T>, and changing a decision a previous ADR had already named](2026/08/2026-08-04-collection.md)
 - [2026-08-04 — Withers: meeting a "per-version" requirement by not depending on the version](2026/08/2026-08-04-withers-trait.md)
 - [2026-08-04 — Milestone 3 opens: DTO hydration, and PHP disagreeing with the requirement](2026/08/2026-08-04-dto-hydration.md)

--- a/src/main/php/d4np/utils/Dto/Hydrator.php
+++ b/src/main/php/d4np/utils/Dto/Hydrator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace D4np\Utils\Dto;
 
+use BackedEnum;
 use D4np\Utils\Support\HydrationException;
 use D4np\Utils\Support\MissingKeyException;
 use D4np\Utils\Support\ParameterMetadata;
@@ -329,7 +330,54 @@ final class Hydrator
             return $this->hydrateAt($type, $value, $lenient, $path);
         }
 
+        if (is_a($type, BackedEnum::class, true) && (is_int($value) || is_string($value))) {
+            return $this->coerceBackedEnum($value, $type, $path);
+        }
+
         throw TypeMismatchException::at($path, $type, get_debug_type($value));
+    }
+
+    /**
+     * Resolve a backed enum from its scalar backing value.
+     *
+     * `UnitEnum::cases()` has no scalar to key from, so a pure (non-backed) enum stays
+     * instance-only — this branch fires only for `BackedEnum`, which is exactly what
+     * {@see coerceObject()} already checked before calling here.
+     *
+     * `tryFrom()` rather than `from()`: `from()` throws `\ValueError`, which is not part of
+     * ADR-0004's family and would let a bare error escape a hydration call. `tryFrom()` returns
+     * `null` on no match, converted here into the library's own exception with the path.
+     *
+     * @param class-string $type
+     *
+     * @throws TypeMismatchException
+     */
+    private function coerceBackedEnum(int|string $value, string $type, string $path): mixed
+    {
+        $case = $type::tryFrom($value);
+        if ($case === null) {
+            throw TypeMismatchException::at(
+                $path,
+                sprintf('%s (one of: %s)', $type, self::backingValuesOf($type)),
+                get_debug_type($value) . ' ' . var_export($value, true),
+            );
+        }
+
+        return $case;
+    }
+
+    /**
+     * @param class-string $type a `BackedEnum`
+     */
+    private static function backingValuesOf(string $type): string
+    {
+        /** @var list<BackedEnum> $cases */
+        $cases = $type::cases();
+
+        return implode(', ', array_map(
+            static fn (BackedEnum $case): string => var_export($case->value, true),
+            $cases,
+        ));
     }
 
     /**

--- a/src/test/php/d4np/utils/Dto/EnumHydrationTest.php
+++ b/src/test/php/d4np/utils/Dto/EnumHydrationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto;
+
+use D4np\Utils\Support\TypeMismatchException;
+use D4np\Utils\Tests\Dto\Fixture\Direction;
+use D4np\Utils\Tests\Dto\Fixture\Priority;
+use D4np\Utils\Tests\Dto\Fixture\Status;
+use D4np\Utils\Tests\Dto\Fixture\TicketDto;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Hydrating enum-typed properties — the "enums" column of spec §7's T-01 matrix, the one case
+ * the DTO/withers/collection items had not yet exercised.
+ *
+ * Only **backed** enums are hydrated from a scalar. A pure (`UnitEnum`) case has no backing
+ * value to key from — `Status::cases()` gives names, not a lookup — so it stays instance-only,
+ * which is already covered by the general "already the right object" pass-through.
+ */
+#[Group('T-01')]
+final class EnumHydrationTest extends TestCase
+{
+    public function testAStringBackedEnumHydratesFromItsBackingValue(): void
+    {
+        $ticket = TicketDto::fromArray(['title' => 'Fix bug', 'status' => 'active']);
+
+        self::assertSame(Status::Active, $ticket->status);
+    }
+
+    public function testAnIntBackedEnumHydratesFromItsBackingValue(): void
+    {
+        // A second backed type, so the claim rests on more than one fixture: proves the branch
+        // checks BackedEnum generically rather than happening to work for strings.
+        $ticket = TicketDto::fromArray(['title' => 'Fix bug', 'status' => 'active', 'priority' => 2]);
+
+        self::assertSame(Priority::High, $ticket->priority);
+    }
+
+    public function testAnAlreadyConstructedEnumInstanceIsPassedThrough(): void
+    {
+        $ticket = TicketDto::fromArray(['title' => 'Fix bug', 'status' => Status::Inactive]);
+
+        self::assertSame(Status::Inactive, $ticket->status);
+    }
+
+    public function testAnAbsentDefaultedEnumParameterKeepsItsDefault(): void
+    {
+        $ticket = TicketDto::fromArray(['title' => 'Fix bug', 'status' => 'active']);
+
+        self::assertSame(Priority::Low, $ticket->priority);
+    }
+
+    public function testAnInvalidBackingValueIsATypeMismatchNamingTheValidOnes(): void
+    {
+        try {
+            TicketDto::fromArray(['title' => 'Fix bug', 'status' => 'archived']);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('status', $e->path());
+            self::assertStringContainsString('active', $e->getMessage());
+            self::assertStringContainsString('inactive', $e->getMessage());
+        }
+    }
+
+    public function testANonScalarValueForABackedEnumIsATypeMismatch(): void
+    {
+        $this->expectException(TypeMismatchException::class);
+
+        TicketDto::fromArray(['title' => 'Fix bug', 'status' => ['active']]);
+    }
+
+    /**
+     * The distinguishing case: a PURE enum given its backing-shaped value (a case name as a
+     * string) is still rejected, because `Direction` has no `tryFrom()` to resolve it with —
+     * only an already-constructed `Direction` instance is accepted.
+     */
+    public function testAPureEnumIsNotHydratedFromAStringAndStaysInstanceOnly(): void
+    {
+        try {
+            TicketDto::fromArray(['title' => 'Fix bug', 'status' => 'active', 'direction' => 'Up']);
+            self::fail('expected a TypeMismatchException');
+        } catch (TypeMismatchException $e) {
+            self::assertSame('direction', $e->path());
+        }
+
+        $ticket = TicketDto::fromArray(['title' => 'Fix bug', 'status' => 'active', 'direction' => Direction::Up]);
+        self::assertSame(Direction::Up, $ticket->direction);
+    }
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/Direction.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/Direction.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+/**
+ * A pure (non-backed) enum: no scalar to key from, so it stays instance-only. Distinguishing
+ * this from Status is the point of checking BackedEnum specifically rather than UnitEnum.
+ */
+enum Direction
+{
+    case Up;
+    case Down;
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/Priority.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/Priority.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+/** An int-backed enum: proves the branch is not string-only. */
+enum Priority: int
+{
+    case Low = 1;
+    case High = 2;
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/Status.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/Status.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+/** A string-backed enum: the ordinary case, hydrated from its backing value. */
+enum Status: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}

--- a/src/test/php/d4np/utils/Dto/Fixture/TicketDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/TicketDto.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/** The enum case spec §7's T-01 matrix names, plus a pure-enum property alongside it. */
+final class TicketDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly string $title,
+        public readonly Status $status,
+        public readonly Priority $priority = Priority::Low,
+        public readonly ?Direction $direction = null,
+    ) {
+    }
+}


### PR DESCRIPTION
## Context

Roadmap item **3.4** — the T-01 hydration matrix suite. Checked what it actually still needed
before writing anything, the lesson item 2.6 already taught: spec §7's T-01 names *"nested,
collections, nullables, enums, strict/lenient, withers, missing-key cases"*, and every case
except **enums** already existed across items 3.1–3.3. Only enums was a real gap.

## The gap

An enum-typed parameter reflects with `isBuiltin() === false`, so it reached `coerceObject()`,
which passes through an already-constructed instance but has no path for the enum's own **scalar
backing value** — `Status::tryFrom('active')` could construct it, but the payload
`['status' => 'active']` was rejected anyway.

## The distinction that matters, verified before writing code

Only `BackedEnum` gets scalar coercion:

```php
enum Status: string { case Active = 'active'; }   // BackedEnum: has ::tryFrom()
enum Direction { case Up; case Down; }             // UnitEnum only: no scalar mapping at all
```

A **pure** enum has no backing value to key from — `Direction::cases()` gives names, not a
lookup — so it stays **instance-only**, which the existing pass-through already handles
correctly. A fixture pins the distinction directly.

**`tryFrom()`, not `from()`.** `from()` throws a bare `\ValueError`, outside ADR-0004's exception
family — it would let an uncaught error escape a hydration call. `tryFrom()` returns `null`,
converted here into `TypeMismatchException` naming every valid backing value.

## Verification — proved non-vacuous

Two probes, each reverted and the implementation restored **byte-identical**:

1. **Widened the check from `BackedEnum` to `UnitEnum`** (both share the interface) →
   **3 errors, 2 failures**. The errors are the interesting part: calling `tryFrom()` on a class
   that does not have that method (`Direction`) is a **fatal error**, not a graceful rejection —
   the narrower check exists precisely to avoid it.
2. **Swapped `tryFrom()` for `from()`** → a bare `\ValueError` propagated instead of a caught
   `TypeMismatchException`, exactly as predicted.

**243 tests, 464 assertions** (7 skipped, Windows-only) · PHPStan max clean on the first pass ·
PHP-CS-Fixer clean · `consistency_lint` and `action_pin_lint --verify-upstream` both OK.

No ADR: no new architectural decision, an extension inside ADR-0008's existing hydration design.

**Cross-links:** spec §7 T-01 · ADR-0004, ADR-0008 · roadmap item 3.4 · milestone `v0.3.0`.
Type label: `feat`; `enhancement` set as the closest available default until
`.github/labels.yml` is imported.

**Remaining in Milestone 3:** 3.5 (phpbench against NFR-01/NFR-04) and 3.6 (the `deptrac.yaml`
layering gate, filed at item 3.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
