### PR TITLE
feat(quality): enforce RFC-0001's layering rule with deptrac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ htmlcov/
 /build/logs/
 /.phpstan.cache/
 .php-cs-fixer.cache
+.deptrac.cache
 
 # IDE / editor
 /.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,17 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   recorded honestly rather than adjusted to pass, shipped non-blocking by explicit maintainer
   decision, with closing the gap filed as roadmap item 3.7. The `benchmark` CI job (self-skipped
   since item 1.9) is now active, since `phpbench.json.dist` exists.
+- `deptrac.yaml` (**ADR-0012**) turns on the layering gate RFC-0001 named but nothing enforced:
+  *groups depend downward on Support only; no cross-group imports*. One layer per component group
+  plus `Support` and `Version`, collected by **directory** (bound to the source tree RFC-0001 §A-9
+  fixes, rather than a second class-name-regex vocabulary that could drift from it), analysed over
+  `src/main` only — tests and benchmarks legitimately cross groups and are out of scope. The empty
+  `Support: ~` ruleset is the load-bearing half: it makes the `Support → Dto` inversion that
+  ADR-0006 and ADR-0010 each designed around a build failure rather than a review opinion.
+  Verified failing on a planted `Support → Dto` import and on a planted peer `Http → Dto` import,
+  and verified *passing* on an allowed `Http → Support` import, so the gate is known to
+  discriminate rather than merely reject. The CI `layering` job (self-skipped since item 1.9) is
+  now active. `deptrac/deptrac` is held at `^4.4` by the PHP 8.1 platform pin — 4.7 requires 8.2.
 - `composer.json`'s `config.audit.abandoned` set to `"report"` (was implicitly `"fail"`):
   phpbench pulls in `doctrine/annotations` as its own transitive dependency, flagged abandoned
   on Packagist. Not a security vulnerability and not a package this library depends on directly,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — First real benchmarks, and a genuine number the maintainer had to weigh in on](docs/journal/2026/08/2026-08-04-phpbench-hydration-memory.md).
+  [2026-08-04 — Enforcing a rule two ADRs had already been obeying by hand](docs/journal/2026/08/2026-08-04-deptrac-layering-gate.md).
 
 ## Model & effort routing (advisory)
 
@@ -162,13 +162,18 @@ Typed, mass-assignment-safe data transfer (RFC-0001).
       standalone instead. Measured ratio: **~15.4×**, well over budget; shipped non-blocking per
       the maintainer's explicit choice, with the gap filed as item 3.7. Absolute-µs/nightly
       regression tracking stays item 7.1's job, unchanged.*
-- [ ] 3.6 Add `deptrac.yaml` and turn on the layering gate. RFC-0001's dependency rule — *groups
+- [x] 3.6 Add `deptrac.yaml` and turn on the layering gate. RFC-0001's dependency rule — *groups
       depend downward on Support only; no cross-group imports* — has had nothing enforcing it:
       the CI `layering` job self-skips until the config lands (the step-level guard from item
       1.9). Until item 3.1 there was only one group, so the rule was vacuous; now that `Dto`
       depends on `Support` it is a real constraint with a real direction, and the next four
       milestones each add a group that could violate it. Prove the gate can fail by planting a
-      cross-group import — route: standard / medium
+      cross-group import — route: standard / medium · **ADR-0012**. *Layers collected by
+      `directory` (bound to the tree RFC-0001 §A-9 fixes, not a second name-regex vocabulary),
+      over `src/main` only. Proved in all three directions: `Support→Dto` (the inversion ADR-0006
+      and ADR-0010 designed around) fails, `Http→Dto` (peer) fails, `Http→Support` (allowed)
+      passes — so the gate distinguishes rather than just rejecting. 0 violations, **0 uncovered**,
+      33 allowed. deptrac held at `^4.4` by the 8.1 platform pin; 4.7 needs PHP 8.2.*
 - [ ] 3.7 Close NFR-01's ratio gap: hydration currently measures ~15.4× the cost of manual
       constructor assignment against a ≤3× budget (item 3.5, **ADR-0011**). Likely a
       compiled/cached-closure hydration strategy — generate and cache a per-class hydration

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "psr/log": "^3.0"
     },
     "require-dev": {
+        "deptrac/deptrac": "^4.4",
         "ergebnis/composer-normalize": "^2.44",
         "friendsofphp/php-cs-fixer": "^3.75",
         "phpbench/phpbench": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce0087eb56396f87913b7476ae905aee",
+    "content-hash": "860b4655786c83a254e9e1f067094974",
     "packages": [
         {
             "name": "psr/container",
@@ -395,6 +395,91 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "deptrac/deptrac",
+            "version": "4.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/deptrac/deptrac.git",
+                "reference": "3058cb1b5908a25711ccc0f4c96b64e6fd704114"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/deptrac/deptrac/zipball/3058cb1b5908a25711ccc0f4c96b64e6fd704114",
+                "reference": "3058cb1b5908a25711ccc0f4c96b64e6fd704114",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^3.0",
+                "jetbrains/phpstorm-stubs": "2024.3",
+                "nikic/php-parser": "^5",
+                "php": "^8.1",
+                "phpdocumentor/graphviz": "^2.1",
+                "phpdocumentor/type-resolver": "^1.9.0",
+                "phpstan/phpdoc-parser": "^1.5.0|^2.1.0",
+                "phpstan/phpstan": "^2.0",
+                "psr/container": "^2.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/event-dispatcher-contracts": "^3.4",
+                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8",
+                "ergebnis/composer-normalize": "^2.45",
+                "ext-libxml": "*",
+                "symfony/stopwatch": "^6.4"
+            },
+            "suggest": {
+                "ext-dom": "For using the JUnit output formatter"
+            },
+            "bin": [
+                "deptrac"
+            ],
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Deptrac\\Deptrac\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Glabisch"
+                },
+                {
+                    "name": "Simon Mönch"
+                },
+                {
+                    "name": "Denis Brumann"
+                }
+            ],
+            "description": "Deptrac is a static code analysis tool that helps to enforce rules for dependencies between software layers.",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/deptrac/deptrac/issues",
+                "source": "https://github.com/deptrac/deptrac/tree/4.4.0"
+            },
+            "time": "2025-12-08T08:14:18+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "2.0.2",
             "source": {
@@ -470,6 +555,54 @@
             },
             "abandoned": true,
             "time": "2024-09-05T10:17:24+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1297,6 +1430,53 @@
             "time": "2026-07-30T15:46:02+00:00"
         },
         {
+            "name": "jetbrains/phpstorm-stubs",
+            "version": "v2024.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JetBrains/phpstorm-stubs.git",
+                "reference": "0e82bdfe850c71857ee4ee3501ed82a9fc5d043c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/0e82bdfe850c71857ee4ee3501ed82a9fc5d043c",
+                "reference": "0e82bdfe850c71857ee4ee3501ed82a9fc5d043c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "v3.64.0",
+                "nikic/php-parser": "v5.3.1",
+                "phpdocumentor/reflection-docblock": "5.6.0",
+                "phpunit/phpunit": "11.4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "PhpStormStubsMap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "PHP runtime & extensions header files for PhpStorm",
+            "homepage": "https://www.jetbrains.com/phpstorm",
+            "keywords": [
+                "autocomplete",
+                "code",
+                "inference",
+                "inspection",
+                "jetbrains",
+                "phpstorm",
+                "stubs",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/JetBrains/phpstorm-stubs/tree/v2024.3"
+            },
+            "time": "2024-12-14T08:03:12+00:00"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "6.10.0",
             "source": {
@@ -1882,6 +2062,217 @@
                 }
             ],
             "time": "2025-11-06T19:07:31+00:00"
+        },
+        {
+            "name": "phpdocumentor/graphviz",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/GraphViz.git",
+                "reference": "115999dc7f31f2392645aa825a94a6b165e1cedf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/GraphViz/zipball/115999dc7f31f2392645aa825a94a6b165e1cedf",
+                "reference": "115999dc7f31f2392645aa825a94a6b165e1cedf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "mockery/mockery": "^1.2",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^8.2 || ^9.2",
+                "psalm/phar": "^4.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\GraphViz\\": "src/phpDocumentor/GraphViz",
+                    "phpDocumentor\\GraphViz\\PHPStan\\": "./src/phpDocumentor/PHPStan"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "description": "Wrapper for Graphviz",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/GraphViz/issues",
+                "source": "https://github.com/phpDocumentor/GraphViz/tree/2.1.0"
+            },
+            "time": "2021-12-13T19:03:21+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+            },
+            "time": "2025-11-21T15:09:14+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+            },
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -4004,6 +4395,85 @@
             "time": "2026-06-12T11:32:29+00:00"
         },
         {
+            "name": "symfony/config",
+            "version": "v6.4.43",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "e39cdd91b2adf67a117bea29660b73d896937d86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e39cdd91b2adf67a117bea29660b73d896937d86",
+                "reference": "e39cdd91b2adf67a117bea29660b73d896937d86",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<5.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v6.4.43"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-21T09:46:53+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v6.4.43",
             "source": {
@@ -4100,6 +4570,91 @@
                 }
             ],
             "time": "2026-07-26T14:44:19+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v6.4.43",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "f11815fd2f5f80ce94bf527b5ecfd4bd0b1cc905"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f11815fd2f5f80ce94bf527b5ecfd4bd0b1cc905",
+                "reference": "f11815fd2f5f80ce94bf527b5ecfd4bd0b1cc905",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4.20|^7.2.5"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2",
+                "symfony/config": "<6.1",
+                "symfony/finder": "<5.4",
+                "symfony/proxy-manager-bridge": "<6.3",
+                "symfony/yaml": "<5.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^6.1|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.43"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-20T15:13:12+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5430,6 +5985,163 @@
                 }
             ],
             "time": "2026-07-28T07:28:15+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v6.4.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "15e670e0218bfe4efbc0556b8a12ad1304f4c7f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/15e670e0218bfe4efbc0556b8a12ad1304f4c7f4",
+                "reference": "15e670e0218bfe4efbc0556b8a12ad1304f4c7f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.42"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-27T08:12:01+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v6.4.43",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d2ee2daa59be8cd0864835ea918ea209149796a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d2ee2daa59be8cd0864835ea918ea209149796a3",
+                "reference": "d2ee2daa59be8cd0864835ea918ea209149796a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.4.43"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-20T15:18:49+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,0 +1,90 @@
+# RFC-0001's dependency rule, made mechanical:
+#
+#     groups depend downward on Support only; no cross-group imports
+#
+# Stated in RFC-0001 §Decision and named there as "enforced by `deptrac` in CI" — but nothing
+# enforced it until this file landed (roadmap item 3.6). The CI `layering` job has been
+# self-skipping on the absence of this exact filename since item 1.9; adding it turns the job on.
+#
+# Layers are collected by **directory**, not by class-name pattern, because RFC-0001 §Placement
+# notes (A-9) fixes the mapping to the source tree itself: "the deptrac layer globs are defined
+# against that exact tree, with the group directories (`Dto/`, `Container/`, …) case-exact below
+# it". A `classLike` regex would re-state the same grouping in a second, drift-prone vocabulary.
+#
+# Note that deptrac's `directory` collector compiles its value as a **case-insensitive** regex
+# (`#...#i`, see `DefaultBehavior/Layer/DirectoryCollector.php`), so this file cannot itself be
+# what enforces RFC-0001's "case-exact" wording — `tools/consistency_lint.py` owns that, and the
+# PSR-4 autoloader would fail loudly on a case mismatch long before deptrac ran.
+#
+# Only `src/main` is analysed. Tests and benchmarks legitimately reach across every group (a DTO
+# test constructs DTOs and asserts on Support exceptions; a benchmark hydrates a DTO), so holding
+# them to a production layering rule would report violations that are not violations.
+deptrac:
+  paths:
+    - ./src/main/php/d4np/utils
+
+  layers:
+    # The six component groups of RFC-0001's table, in its order.
+    - name: Dto
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Dto/.*
+    - name: Container
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Container/.*
+    - name: Database
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Database/.*
+    - name: Security
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Security/.*
+    - name: Http
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Http/.*
+    - name: Errors
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Errors/.*
+
+    # The layer every group is allowed to depend on, and which may depend on none of them.
+    - name: Support
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Support/.*
+
+    # `Version` sits at the namespace root, in no group — it is a single version constant. Given
+    # its own layer rather than left uncollected so that "every production class belongs to a
+    # declared layer" stays a fact this config states, rather than an assumption.
+    - name: Version
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Version\.php
+
+  ruleset:
+    # Each group may reach downward into Support, and nowhere else. Adding a group to any of
+    # these lists is exactly the cross-group import RFC-0001 forbids.
+    Dto:
+      - Support
+    Container:
+      - Support
+    Database:
+      - Support
+    Security:
+      - Support
+    Http:
+      - Support
+    Errors:
+      - Support
+
+    # Support is the bottom of the library: it depends on no group. An empty list here is the
+    # load-bearing half of the rule — it is what makes a Support -> Dto import (the inversion
+    # ADR-0010 had to design around for `ParameterMetadata::$attributes`) a build failure rather
+    # than a code-review opinion.
+    Support: ~
+
+    # A version constant depends on nothing.
+    Version: ~

--- a/docs/adr/0012-enforce-the-layering-rule-by-directory-over-src-main.md
+++ b/docs/adr/0012-enforce-the-layering-rule-by-directory-over-src-main.md
@@ -1,0 +1,106 @@
+# ADR-0012: Enforce RFC-0001's layering rule by directory, over `src/main` only
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 3.6 · [RFC-0001](../rfc/0001-egl-utils-library.md) §Decision, §Placement
+  notes (A-9) · [ADR-0003](0003-pin-ci-actions-by-commit-sha.md) and
+  [ADR-0007](0007-measure-total-line-coverage-against-a-floor.md) (the other two CI gates) ·
+  [ADR-0006](0006-shared-reflection-metadata-cache.md),
+  [ADR-0010](0010-collection-generics-by-attribute.md) (both designed around the rule this
+  now enforces)
+
+## Context
+
+RFC-0001 states the library's one structural rule — *"groups depend downward on Support only; no
+cross-group imports"* — and names its enforcement in the same sentence: *"enforced by `deptrac`
+in CI"*. Nothing enforced it. The CI `layering` job has been self-skipping on the absence of
+`deptrac.yaml` since item 1.9, so the rule has been a prose claim for three milestones.
+
+Until item 3.1 there was only one group, and the rule was vacuous. It is not vacuous now: `Dto`
+depends on `Support`, which is a real edge with a real direction, and two prior ADRs already had
+to *design around* this rule without a machine checking their work —
+
+- **ADR-0006** kept `ParameterMetadata::$attributes` as uninterpreted `list<object>` specifically
+  so `Support` would not have to name a `Dto` type.
+- **ADR-0010** re-affirmed that, rejecting "name the `CollectionOf` attribute inside `Support`"
+  as *"it inverts the dependency RFC-0001 fixes"*.
+
+Both were correct, and both were held in place by review attention alone. The next four
+milestones each add a group that could violate the rule.
+
+## Decision
+
+**Ship `deptrac.yaml` declaring one layer per RFC-0001 group plus `Support` and `Version`,
+collected by `directory`, analysed over `src/main` only.** The CI `layering` job self-enables on
+the file's presence and fails the build on any violation.
+
+Three choices inside that are worth recording:
+
+- **Layers are collected by `directory`, not by a `classLike` name regex.** RFC-0001 §A-9 already
+  binds the grouping to the source tree — *"the deptrac layer globs are defined against that exact
+  tree, with the group directories (`Dto/`, `Container/`, …) case-exact below it"*. A name-pattern
+  collector would restate the same grouping in a second, independently-driftable vocabulary; a
+  class could then match a layer it does not live in, or live in a directory no layer claims.
+- **Only `src/main` is analysed; tests and benchmarks are out of scope.** The rule constrains the
+  *library's* architecture. A test legitimately reaches across groups (a `Dto` test asserts on
+  `Support` exceptions; `HydrationBench` hydrates a DTO), and holding test code to a production
+  layering rule would report violations that are not violations — which trains readers to ignore
+  the gate, the failure mode a gate exists to avoid.
+- **`Version` gets its own layer rather than being left uncollected.** It is a lone version
+  constant at the namespace root, in no group. Declaring it makes *"every production class belongs
+  to a declared layer"* a fact the config asserts and deptrac confirms (`Uncovered: 0`) rather than
+  an assumption nobody checks.
+
+**`Support: ~` — the empty ruleset — is the load-bearing half.** It is what makes a `Support → Dto`
+import a build failure instead of a code-review opinion, and it is precisely the constraint
+ADR-0006 and ADR-0010 were manually respecting.
+
+`deptrac/deptrac` is pinned at `^4.4`, not the current `^4.7`: 4.7 requires PHP `^8.2`, and
+`config.platform.php: 8.1.34` (item 1.3) correctly refused to resolve it. That is the platform
+pin doing its job — the library supports 8.1, so its tooling must run there.
+
+## Alternatives Considered
+
+- **`classLike` / `classNameRegex` collectors** — rejected above: a second source of truth for a
+  grouping RFC-0001 already binds to the directory tree.
+- **Including `src/test` and `src/bench` in the analysed paths**, with tests as their own layer
+  allowed to depend on everything — rejected as ceremony that buys nothing: such a layer forbids
+  no edge that matters, while adding config that must be maintained as groups are added.
+- **Leaving `Version` uncollected** — rejected: deptrac would report it as uncovered, and the
+  honest choices are then to declare it or to suppress the report. Declaring it is cheaper and
+  says something true.
+- **Relying on PHPStan or code review instead of a dedicated tool** — rejected: PHPStan checks
+  types, not architecture, and review is exactly what ADR-0006/ADR-0010 already depended on. RFC-
+  0001 named deptrac specifically.
+- **Adding the rule but not proving it can fail** — rejected on this project's standing practice:
+  a gate that has never been observed failing is indistinguishable from a gate that cannot fail.
+
+## Consequences
+
+- The rule RFC-0001 stated is now mechanical. Verified in all three directions before landing,
+  each probe reverted and the tree confirmed byte-identical afterward:
+  1. `Support → Dto` (the inversion ADR-0006/ADR-0010 designed around) — **1 violation, exit 1**,
+     naming the file and line.
+  2. `Http → Dto` (a peer cross-group import) — **1 violation**.
+  3. `Http → Support` (the allowed downward direction) — **0 violations**, allowed edges 33 → 34,
+     confirming the gate distinguishes rather than simply rejecting.
+- Current state: 0 violations, 0 uncovered, 33 allowed dependencies.
+- Adding a group to another group's `ruleset` list is now an explicit, reviewable act — which is
+  the point. A future genuine need to cross groups has to argue for itself in a diff to this file
+  rather than arriving unnoticed inside a feature PR.
+- The `layering` CI job runs for real from this commit, so it now costs a composer install and an
+  analysis on every push, and can block a merge.
+- deptrac's `directory` collector compiles case-**insensitively** (`#…#i`), so this file is not
+  what enforces RFC-0001's "case-exact" wording. `tools/consistency_lint.py` owns that, and PSR-4
+  autoloading fails loudly on a case mismatch long before deptrac runs — noted so a reader does
+  not credit this gate with a guarantee it does not provide.
+
+## References
+
+- RFC-0001 §Decision (the rule and its named enforcement), §Placement notes A-9 (layer globs bound
+  to the source tree)
+- ADR-0006, ADR-0010 — the two decisions that manually respected this rule before it was enforced
+- `vendor/deptrac/deptrac/src/DefaultBehavior/Layer/DirectoryCollector.php` (case-insensitive
+  regex over the normalized path)
+- `vendor/deptrac/deptrac/src/Contract/Config/CollectorType.php` (the collector vocabulary)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0009](0009-withers-rebuild-rather-than-clone.md) | Withers rebuild through the constructor rather than cloning | Accepted |
 | [0010](0010-collection-generics-by-attribute.md) | Declare collection element types with an attribute, not a docblock parser | Accepted |
 | [0011](0011-benchmark-scope-and-the-measured-hydration-ratio.md) | Benchmarks measure NFR-01/NFR-04 now; absolute regression tracking and the measured ~15× ratio gap are deliberately deferred | Accepted |
+| [0012](0012-enforce-the-layering-rule-by-directory-over-src-main.md) | Enforce RFC-0001's layering rule by directory, over `src/main` only | Accepted |

--- a/docs/journal/2026/08/2026-08-04-deptrac-layering-gate.md
+++ b/docs/journal/2026/08/2026-08-04-deptrac-layering-gate.md
@@ -1,0 +1,74 @@
+# 2026-08-04 — Enforcing a rule two ADRs had already been obeying by hand
+
+Roadmap item **3.6**. Route: the item declares `standard / medium`; session model is Opus 5, the
+standard tier — match. (`route_advice.py` on a bare `enhancement` label suggests `fast/low`, but
+the roadmap's own per-item route is the specific one and it is what I went by.)
+
+## What was actually missing
+
+RFC-0001 states the rule and names its enforcement in the same breath: *"groups depend downward on
+Support only; no cross-group imports — enforced by `deptrac` in CI"*. The CI `layering` job has
+existed since item 1.9 and has been self-skipping on the absence of `deptrac.yaml` ever since. So
+the rule was prose.
+
+What made this worth doing carefully rather than mechanically: **two prior ADRs had already had to
+design around this rule with nothing checking them.** ADR-0006 kept
+`ParameterMetadata::$attributes` as uninterpreted `list<object>` precisely so `Support` need not
+name a `Dto` type; ADR-0010 re-rejected moving `CollectionOf` into `Support` because *"it inverts
+the dependency RFC-0001 fixes"*. Both correct, both held in place by review attention alone. That
+is the thing this item converts into a machine check.
+
+## Choices that weren't automatic
+
+**Directory collectors, not `classLike` name regexes.** RFC-0001 §A-9 already binds the grouping to
+the tree — *"the deptrac layer globs are defined against that exact tree… case-exact below it"*. A
+name-pattern collector would restate the same grouping in a second vocabulary that can drift from
+the first: a class could match a layer it doesn't live in, or live in a directory no layer claims.
+
+**`src/main` only.** Tests and benchmarks cross groups legitimately — a `Dto` test asserts on
+`Support` exceptions, `HydrationBench` hydrates a DTO. Reporting those as violations trains people
+to ignore the gate, which is the one failure mode a gate can't survive.
+
+**`Version` gets its own layer.** It's a lone constant at the namespace root, in no group. Left
+uncollected, deptrac reports it uncovered and the honest options become "declare it" or "suppress
+the report". Declaring it makes `Uncovered: 0` mean something.
+
+## Proving it can fail — and can pass
+
+The roadmap item asks for a planted cross-group import. I ran three probes, not one, because
+"fails on a bad import" alone doesn't distinguish a working gate from one that rejects everything:
+
+1. **`Support → Dto`** — the exact inversion ADR-0006/ADR-0010 designed around, planted in
+   `ParameterMetadata`. **1 violation, exit 1**, naming file and line.
+2. **`Http → Dto`** — a peer cross-group import, the rule's other half. **1 violation.**
+3. **`Http → Support`** — the *allowed* downward direction. **0 violations**, and allowed edges
+   went 33 → 34, so the gate is measurably distinguishing rather than blanket-rejecting.
+
+Each probe reverted; `git status` confirms `src/main` byte-identical. Final state: 0 violations,
+0 uncovered, 33 allowed.
+
+## The platform pin earning its keep
+
+`composer require --dev deptrac/deptrac` resolved to **4.4.0**, not 4.7.1, with composer saying so
+out loud: *"Cannot use deptrac/deptrac's latest version 4.7.1 as it requires php ^8.2 which is not
+satisfied by your platform."* That's `config.platform.php: 8.1.34` from item 1.3 doing exactly what
+it was added for — the library supports 8.1, so its tooling has to run there. Worth noting because
+this is the first time that pin has visibly changed an outcome rather than just sitting in config.
+
+Also of note: `qossmic/deptrac` is abandoned and redirects to `deptrac/deptrac`. Took the
+maintained one.
+
+## One local-only discrepancy, understood not hand-waved
+
+`php-cs-fixer` flags `src/test/php/d4np/utils/BootstrapTest.php` locally while CI passes on it.
+`git ls-files --eol` says `i/lf w/crlf` — LF in the index, CRLF in my Windows working tree. CI
+checks out LF and sees nothing to fix. A working-tree artifact, not a finding, and not something
+this item should "fix" by rewriting an untouched file.
+
+Full bar green otherwise: PHPUnit 243/464 (7 skipped, unchanged), PHPStan max clean,
+`consistency_lint.py` OK, `composer normalize`/`validate --strict` clean, `composer audit` exit 0.
+
+## State of Milestone 3
+
+3.1–3.6 done. Remaining: **3.7** — the NFR-01 hydration ratio gap filed by item 3.5 (~15.4× against
+a ≤3× budget), still unrouted and untouched by design.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Enforcing a rule two ADRs had already been obeying by hand](2026/08/2026-08-04-deptrac-layering-gate.md)
 - [2026-08-04 — First real benchmarks, and a genuine number the maintainer had to weigh in on](2026/08/2026-08-04-phpbench-hydration-memory.md)
 - [2026-08-04 — Checking what T-01 actually still needed, before writing anything](2026/08/2026-08-04-t01-enum-hydration.md)
 - [2026-08-04 — Collection<T>, and changing a decision a previous ADR had already named](2026/08/2026-08-04-collection.md)


### PR DESCRIPTION
## Summary

Roadmap item 3.6. RFC-0001 states *"groups depend downward on Support only; no cross-group imports — enforced by `deptrac` in CI"* — and nothing enforced it. The CI `layering` job has self-skipped on the absence of `deptrac.yaml` since item 1.9, so the rule has been prose for three milestones.

It wasn't idle in the meantime: **ADR-0006** kept `ParameterMetadata::$attributes` as uninterpreted `list<object>` specifically so `Support` need not name a `Dto` type, and **ADR-0010** re-rejected moving `CollectionOf` into `Support` because *"it inverts the dependency RFC-0001 fixes"*. Both correct, both held in place by review attention alone. This makes it a machine check.

Design choices (**ADR-0012**):
- Layers collected by **`directory`**, not a `classLike` name regex — RFC-0001 §A-9 already binds the grouping to the source tree; a name pattern restates it in a second, driftable vocabulary.
- **`src/main` only** — tests and benchmarks cross groups legitimately, and reporting those as violations trains readers to ignore the gate.
- **`Version` gets its own layer**, so `Uncovered: 0` is asserted rather than assumed.
- The empty **`Support: ~`** ruleset is the load-bearing half: it makes a `Support → Dto` import a build failure instead of an opinion.

`deptrac/deptrac` resolves to **4.4.0**, not 4.7.1 — 4.7 requires PHP `^8.2` and `config.platform.php` is pinned to `8.1.34` (item 1.3). First time that pin has visibly changed an outcome. Took `deptrac/deptrac`; `qossmic/deptrac` is abandoned.

## Test plan

Proved in **three** directions, not one — "fails on a bad import" alone can't distinguish a working gate from one that rejects everything. Each probe reverted, `src/main` confirmed byte-identical after:

- [x] `Support → Dto` (the ADR-0006/ADR-0010 inversion) — **1 violation, exit 1**, naming file and line
- [x] `Http → Dto` (peer cross-group) — **1 violation**
- [x] `Http → Support` (allowed downward) — **0 violations**, allowed edges 33 → 34
- [x] Final state: **0 violations, 0 uncovered, 33 allowed**, exit 0
- [x] `vendor/bin/phpunit` — 243 tests, 464 assertions, 7 skipped (unchanged)
- [x] `vendor/bin/phpstan analyse` — level max, clean
- [x] `python tools/consistency_lint.py` — OK
- [x] `python tools/action_pin_lint.py --verify-upstream` — OK
- [x] `composer normalize --dry-run` / `validate --strict` / `audit` — all clean
- [ ] CI `layering` job (now active for the first time) — watching after push

Also gitignores `.deptrac.cache`, a build artifact the first local run produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)