### PR TITLE
perf(dto): compile a hydration closure for the scalar shape (NFR-01: 15.40x → 2.74x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,21 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   recorded honestly rather than adjusted to pass, shipped non-blocking by explicit maintainer
   decision, with closing the gap filed as roadmap item 3.7. The `benchmark` CI job (self-skipped
   since item 1.9) is now active, since `phpbench.json.dist` exists.
+- `D4np\Utils\Dto\HydrationCompiler` (**ADR-0013**) closes NFR-01's performance gap: hydrating a
+  10-scalar-property DTO went from **15.40× to 2.74×** manual constructor assignment
+  (14.155 µs → 2.511 µs), meeting both halves of the budget for the first time. Four approaches
+  were measured before any code was written, and the budget proved **unreachable** by tuning the
+  interpreted loop (best case 4.80×) — so the hydrator now generates a per-class closure, but only
+  for the all-scalar shape NFR-01 actually specifies (non-variadic builtin `int`/`float`/`string`/
+  `bool`, no defaults). **Nested DTOs, `Collection`, enums, unions, `array`, variadics and
+  defaulted parameters are not compiled** and run the existing interpreter unchanged, at roughly
+  their previous cost — so this makes the specified shape fast, not every DTO. `HydrationParityTest`
+  runs every case down both paths and compares them against each other, and `new
+  HydrationCompiler(false)` turns generation off entirely for anyone who would rather no `eval`
+  ran in their process. Full before/after with the environment, the rejected alternatives, and the
+  ≈5.5-hydrations-per-process break-even for `eval`'s uncacheable compile cost is recorded in
+  [`docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md`](docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md).
+  NFR-04's 10 000-hydration benchmark improved as a side effect (149.7 ms → 37.8 ms).
 - `deptrac.yaml` (**ADR-0012**) turns on the layering gate RFC-0001 named but nothing enforced:
   *groups depend downward on Support only; no cross-group imports*. One layer per component group
   plus `Support` and `Version`, collected by **directory** (bound to the source tree RFC-0001 §A-9

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Enforcing a rule two ADRs had already been obeying by hand](docs/journal/2026/08/2026-08-04-deptrac-layering-gate.md).
+  [2026-08-04 — Measuring what was reachable before deciding what to build](docs/journal/2026/08/2026-08-04-nfr01-compiled-hydration.md).
 
 ## Model & effort routing (advisory)
 
@@ -174,12 +174,20 @@ Typed, mass-assignment-safe data transfer (RFC-0001).
       and ADR-0010 designed around) fails, `Http→Dto` (peer) fails, `Http→Support` (allowed)
       passes — so the gate distinguishes rather than just rejecting. 0 violations, **0 uncovered**,
       33 allowed. deptrac held at `^4.4` by the 8.1 platform pin; 4.7 needs PHP 8.2.*
-- [ ] 3.7 Close NFR-01's ratio gap: hydration currently measures ~15.4× the cost of manual
+- [x] 3.7 Close NFR-01's ratio gap: hydration currently measures ~15.4× the cost of manual
       constructor assignment against a ≤3× budget (item 3.5, **ADR-0011**). Likely a
       compiled/cached-closure hydration strategy — generate and cache a per-class hydration
       closure alongside `ClassMetadata` instead of walking `ParameterMetadata` and coercing on
       every call — evaluated on its own merits with its own measurement-first discipline —
-      route: TBD (route at pickup)
+      route: standard / high · **ADR-0013**. *Closed: **15.40× → 2.74×** (14.155 µs → 2.511 µs),
+      meeting both halves of NFR-01, recorded in
+      [`docs/benchmarks/`](docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md). Measured
+      four approaches first: the budget is **unreachable** by tuning the interpreted loop (best
+      case 4.80×), so a generated closure it is — but scoped narrowly to the all-scalar shape
+      NFR-01 actually names, with the interpreter kept for nested DTOs, collections, enums, unions
+      and defaults, and `HydrationParityTest` holding the two to identical observable behavior.
+      NFR-04 improved for free (149.7 ms → 37.8 ms). Honest limit: only the eligible shape is
+      fast.*
 
 ---
 

--- a/docs/adr/0013-compile-a-hydration-closure-for-the-scalar-shape.md
+++ b/docs/adr/0013-compile-a-hydration-closure-for-the-scalar-shape.md
@@ -1,0 +1,139 @@
+# ADR-0013: Compile a hydration closure for the scalar shape, keep the interpreter for everything else
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 3.7 (filed by item 3.5) · spec NFR-01, NFR-06 ·
+  [RFC-0001](../rfc/0001-egl-utils-library.md) ·
+  [ADR-0011](0011-benchmark-scope-and-the-measured-hydration-ratio.md) (which measured the gap and
+  deliberately deferred closing it) · [ADR-0008](0008-dto-hydration-strictness-and-shared-hydrator.md) ·
+  [ADR-0006](0006-shared-reflection-metadata-cache.md) ·
+  **Benchmark record:** [`docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md`](../benchmarks/2026/08/nfr01-hydration-compiled-closure.md)
+
+## Context
+
+Spec NFR-01 budgets DTO hydration (10 scalar props, warm) at **≤ 5 µs** and **≤ 3× manual
+constructor assignment**. Item 3.5 measured it for the first time and found **15.40×** — five times
+over budget. ADR-0011 recorded that honestly, shipped the benchmark non-blocking, and filed item
+3.7 to close the gap rather than lowering the budget or blocking CI on a number nobody had yet
+tried to fix.
+
+Item 3.7 opened by measuring four approaches before writing production code, because the useful
+question was not "is the hydrator slow" but "**what is actually reachable**":
+
+| approach | µs/op | ratio | meets ≤3×? |
+|---|---|---|---|
+| interpreted (the hydrator as it was) | 13.86 | 16.6× | ✗ |
+| interpreted, every avoidable waste removed | 3.97 | 4.80× | ✗ |
+| one pre-built closure per parameter (no `eval`) | 3.31 | 4.00× | ✗ |
+| **generated closure** | **1.93** | **2.28×** | ✓ |
+
+The second row matters most. It is the ceiling of "just make the existing loop tighter": memoise
+`parameterNames()` (rebuilt on *every* call today), replace the `in_array` unknown-key scan with a
+hash lookup, drop named-argument spread for positional, build the error path lazily. All of that
+together reaches 4.80× — and that prototype was **optimistic**, carrying no path building, no
+exception construction and none of the nested-DTO branches production needs. **NFR-01's budget is
+not reachable by tuning an interpreted reflection-driven loop in PHP.** That is a measured
+conclusion, and it is what justifies a mechanism as heavy as code generation.
+
+Profiling also produced two results that contradicted plausible intuitions, both worth recording
+because acting on either would have made things worse:
+
+- Iterating `ParameterMetadata` **objects** is *faster* than iterating flattened plain arrays
+  (0.63 µs vs 1.59 µs per pass). "Flatten the metadata into arrays" is a pessimisation.
+- Named-argument spread (`new $c(...$named)`) costs roughly **twice** a positional call
+  (1.49 µs vs 0.80 µs).
+
+## Decision
+
+**Generate a per-class hydration closure for the narrow shape NFR-01 names, and keep the existing
+interpreter as the implementation for everything else.**
+
+- **Eligibility is deliberately small**: every constructor parameter a non-variadic **builtin
+  scalar** (`int`, `float`, `string`, `bool`) with **no declared default**. Nested DTOs,
+  `Collection`, enums, unions, `mixed`, `array`, variadics and defaults are **not compiled** and
+  behave exactly as before.
+- **Nullable parameters are eligible.** RFC-0001 R-4 passes `null` explicitly for a
+  nullable-without-default parameter, so its argument is always present and no argument position
+  shifts.
+- **Defaulted parameters are not eligible**, because the generated call passes arguments
+  positionally — which is where the win comes from — and a positional call cannot skip an
+  argument. Generating branching to reconstruct named-argument semantics would buy back the cost
+  it saves *and* give the fast path a second way to disagree with the interpreter.
+- **`HydrationCompiler` takes an `enabled` flag.** Disabled, it declines every class and the
+  library runs entirely on the interpreter. This is what `HydrationParityTest` uses to run both
+  paths, and it is also the supported escape hatch for anyone who would rather their dependencies
+  did not evaluate generated source in their process.
+- **The two paths are held together by `HydrationParityTest`**, which runs every case down *both*
+  and compares the outcomes with each other — constructed state, exception class, message and
+  path — rather than against hand-written expectations that would only prove the compiled path
+  matches what this ADR's author believed.
+
+**Result: 15.40× → 2.74×** (2.511 µs), meeting both halves of NFR-01, with the full suite green.
+
+### The cost, quantified rather than waved at
+
+`eval()`'d code is not cached by OPcache, so the closure is built once per class **per process**,
+not once per deployment:
+
+| | |
+|---|---|
+| compile cost | 66.9 µs per class per process |
+| saving | 12.3 µs per hydration |
+| **break-even** | **≈5.5 hydrations of one class per process** |
+
+Any bulk mapping (an API page, a result set) clears that immediately; a process that hydrates one
+or two objects of a class and exits is marginally *slower* than before. That trade was measured
+and accepted, not assumed away.
+
+## Alternatives Considered
+
+- **Tighten the interpreted loop and accept ~4.8×** — rejected as the *primary* answer because it
+  does not meet the spec's budget, which was the whole point of item 3.7. Offered explicitly to the
+  maintainer alongside the compiled option; not chosen.
+- **Revise NFR-01's budget to a number an interpreted hydrator can meet (~5×)** — also offered and
+  not chosen. It remains the honest fallback if the compiled path is ever removed, and the
+  measurements in the benchmark record are what such a revision would be argued from.
+- **Closure composition (one pre-built closure per parameter), avoiding `eval` entirely** —
+  measured at 4.00×. Rejected on the number: it keeps a call per parameter, which is most of what
+  makes the interpreted loop slow.
+- **Write generated code to a cache file and `include` it** (OPcache-friendly, no `eval`) —
+  rejected: it makes a general-purpose utility library require a writable cache directory and a
+  cache-invalidation story, which is a substantially larger operational imposition on every
+  consumer than an in-process `eval` whose cost is bounded and measured.
+- **Compiling the full semantics** (nested DTOs, collections, enums, unions) — rejected for now.
+  The value of a second implementation is inversely proportional to its size: a small compiled path
+  can be checked for equivalence case by case, and a complete one effectively cannot.
+- **Making the fast path implicit and undocumented** — rejected. A DTO with a nested property is
+  still ~14 µs, and a reader who sees "hydration is 2.7× manual" without that qualification has
+  been misled. It is stated in the class docblock, in the benchmark record, and here.
+
+## Consequences
+
+- **NFR-01 is met** for the shape it specifies: 2.74× (budget ≤ 3×) and 2.511 µs (budget ≤ 5 µs),
+  stable across independent runs (2.74× / 2.75×), recorded with full environment in the benchmark
+  report. `tools/bench_ratio_gate.py` exits 0 against `--max-ratio 3` for the first time.
+- **NFR-04 improved as a side effect**: 10 000 hydrations went 149.7 ms → 37.8 ms, its 16 MiB peak
+  assertion still passing, without that budget being touched.
+- **The library now contains a code generator, and `eval()`.** That is a real increase in what a
+  reader must understand and what a security review will ask about. The mitigations are the narrow
+  eligibility, the parity suite, and the documented off switch — not a claim that the cost is zero.
+- **Two implementations of one behavior now exist and could drift.** `HydrationParityTest` is the
+  control, and it was verified non-vacuous by planting three divergences (dropping `float`'s
+  int-widening; moving the unknown-key scan after the parameter checks so a payload that is both
+  missing a key and carrying an unknown one reports the wrong one; and making nothing eligible at
+  all) and confirming each was caught — the last of these is what proves the suite is not silently
+  comparing the interpreter with itself.
+- **Only the eligible shape is fast.** Nested/collection/enum DTOs remain on the interpreter at
+  roughly their previous cost. Extending compilation to them is possible and is deliberately not
+  attempted here.
+- **A hardened environment that forbids `eval` can turn it off** via `new HydrationCompiler(false)`
+  and lose only speed.
+
+## References
+
+- Spec NFR-01 (the budget), NFR-06 (benchmark methodology and reference machine)
+- Benchmark record: `docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md` — before/after
+  with environment, the four measured alternatives, and the break-even analysis
+- ADR-0011 — measured the gap, deferred closing it, filed item 3.7
+- `HydrationParityTest` — the equivalence control, and the three planted divergences that show it works

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,3 +28,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0010](0010-collection-generics-by-attribute.md) | Declare collection element types with an attribute, not a docblock parser | Accepted |
 | [0011](0011-benchmark-scope-and-the-measured-hydration-ratio.md) | Benchmarks measure NFR-01/NFR-04 now; absolute regression tracking and the measured ~15× ratio gap are deliberately deferred | Accepted |
 | [0012](0012-enforce-the-layering-rule-by-directory-over-src-main.md) | Enforce RFC-0001's layering rule by directory, over `src/main` only | Accepted |
+| [0013](0013-compile-a-hydration-closure-for-the-scalar-shape.md) | Compile a hydration closure for the scalar shape, keep the interpreter for everything else | Accepted |

--- a/docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md
+++ b/docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md
@@ -1,0 +1,114 @@
+# Benchmark Report: NFR-01 DTO hydration — compiled closure vs. interpreted hydrator
+
+- **Date:** 2026-08-04
+- **Version / commit:** v0.0.0 @ `9c6828a` (baseline) → this branch (`perf/hydrator-compiled-closure`)
+- **Environment:** 12th Gen Intel Core i7-12700, 31.7 GB RAM, Windows 11 Pro 10.0.26200,
+  PHP 8.3.1 CLI, phpbench 1.4.3, OPcache **off**, JIT **off**, Xdebug **off**
+  (`--php-disable-ini`; spec NFR-06's methodology, on this machine rather than its named
+  reference machine — see Interpretation)
+- **Command:** `vendor/bin/phpbench run src/bench/php/d4np/utils/HydrationBench.php --report=aggregate`
+
+## Scenario
+
+Spec **NFR-01** budgets hydrating a DTO of 10 scalar properties, warm (reflection already cached),
+at **≤ 5 µs** and **≤ 3× manual constructor assignment**. `HydrationBench` measures both halves at
+once: `benchHydrateWarm` calls `TenScalarPropsDto::fromArray()`, and `benchManualConstruction`
+builds the identical object by hand from the identical payload, so the ratio cancels out the
+machine's absolute clock speed.
+
+Roadmap item **3.5** recorded the first measurement of this and found the ratio ~5× over budget.
+Item **3.7** — this report — is the change that closes it.
+
+Methodology per NFR-06: 10 iterations × 100 revs, 5% retry threshold, PHP 8.3, OPcache and JIT off.
+
+## Results
+
+**Before** (interpreted hydrator, commit `9c6828a`):
+
+| Metric | Value | Spread |
+|--------|-------|--------|
+| `benchHydrateWarm` (mode) | 14.155 µs | ±1.48% rstdev |
+| `benchManualConstruction` (mode) | 0.919 µs | ±1.30% rstdev |
+| **ratio** | **15.40×** | budget ≤ 3× ❌ |
+| absolute | 14.155 µs | budget ≤ 5 µs ❌ |
+
+**After** (compiled closure for the eligible shape, ADR-0013), two independent runs:
+
+| Metric | Run 1 | Run 2 | Spread |
+|--------|-------|-------|--------|
+| `benchHydrateWarm` (mode) | 2.511 µs | 2.524 µs | ±1.60% / ±1.87% |
+| `benchManualConstruction` (mode) | 0.915 µs | 0.919 µs | ±1.91% / ±1.76% |
+| **ratio** | **2.74×** | **2.75×** | budget ≤ 3× ✅ |
+| absolute | 2.511 µs | 2.524 µs | budget ≤ 5 µs ✅ |
+
+**Headline: 15.40× → 2.74×** (5.6× faster), meeting both halves of NFR-01.
+
+NFR-04's companion benchmark improved as a side effect, without its budget being touched:
+`MemoryBench::benchHydrateTenThousand` went **149.693 ms → 37.786 ms**, and its 16 MiB peak
+assertion still passes.
+
+### The alternatives that were measured and rejected
+
+The change was chosen from measurement, not preference. Every approach that does **not** generate
+code lands above budget:
+
+| approach | µs/op | ratio | meets ≤3×? |
+|---|---|---|---|
+| interpreted (the hydrator as it was) | 13.86 | 16.6× | ✗ |
+| interpreted, all avoidable waste removed | 3.97 | 4.80× | ✗ |
+| one pre-built closure per parameter (no `eval`) | 3.31 | 4.00× | ✗ |
+| **generated closure** | **1.93** | **2.28×** | ✓ |
+
+Those three rejected prototypes were *optimistic* — none carried path building, exception
+construction, or the nested-DTO branches production needs — so their real numbers would be worse,
+not better. Two secondary findings from the same profiling run, both counter-intuitive enough to
+be worth recording: iterating `ParameterMetadata` **objects** is faster than iterating flattened
+plain arrays (0.63 µs vs 1.59 µs per pass), so "flatten the metadata" would have been a
+pessimisation; and named-argument spread (`new $c(...$named)`) costs roughly **twice** a positional
+call (1.49 µs vs 0.80 µs), which is why eligibility excludes defaulted parameters.
+
+### Cost of the mechanism
+
+`eval()`'d code is not cached by OPcache, so the closure is built once per class **per process**:
+
+| Metric | Value |
+|--------|-------|
+| compile cost (per class, per process) | 66.9 µs |
+| saving per hydration | 12.3 µs |
+| **break-even** | **≈5.5 hydrations of one class per process** |
+
+## Interpretation
+
+Both halves of NFR-01 are met, with ~9% headroom on the ratio and ~50% on the absolute figure.
+
+**The ratio is the trustworthy half of this result.** Both subjects run in the same process on the
+same hardware in the same invocation, so the machine cancels out — which matters here because this
+run is on an i7-12700, not the Ryzen 7 5800X that NFR-06 names as the reference machine. The
+absolute 2.511 µs should be read as "comfortably inside 5 µs on a machine of this class", not as a
+number directly comparable to the spec's reference. Establishing an absolute baseline on reference
+hardware, and gating regressions against it, remains roadmap item **7.1**.
+
+**What is compiled is narrow, and the headline number only covers that shape.** Only an all-scalar
+constructor (non-variadic builtin `int`/`float`/`string`/`bool`, no defaults) is eligible — which
+is exactly the shape NFR-01 specifies, but it means a DTO with a nested DTO, a `Collection`, an
+enum, a union or a defaulted parameter still runs the interpreter and is still ~14 µs. That is
+stated plainly rather than left for a reader to infer from a headline: this change meets the
+spec's stated budget for the spec's stated shape, and does not make every DTO fast.
+
+**Caveats.** Measured on Windows with OPcache off, on an otherwise-idle but not
+specially-quiesced machine; rstdev stayed under 2% across all reported runs and phpbench's 5%
+retry threshold rejected and re-ran the one variant that exceeded it, so the run-to-run agreement
+(2.74× vs 2.75×) is the better evidence of stability than any single figure.
+
+## Reproduce
+
+```bash
+composer install && vendor/bin/phpbench run src/bench/php/d4np/utils/HydrationBench.php --report=aggregate --dump-file=build/logs/after.xml && python tools/bench_ratio_gate.py build/logs/after.xml --numerator benchHydrateWarm --denominator benchManualConstruction --max-ratio 3
+```
+
+To measure the interpreter instead of the compiled path, construct the hydrator with compilation
+declined — the same switch `HydrationParityTest` uses:
+
+```bash
+php -r "require 'vendor/autoload.php'; \$h = new D4np\Utils\Dto\Hydrator(new D4np\Utils\Support\ReflectionCache(), new D4np\Utils\Dto\HydrationCompiler(false));"
+```

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -23,6 +23,4 @@ One report per measured scenario, from [`template.md`](template.md). Keep the in
 
 | Date | Scenario | Version | Headline result | Report |
 |------|----------|---------|-----------------|--------|
-| —    | —        | —       | —               | —      |
-
-_No benchmarks recorded yet._
+| 2026-08-04 | NFR-01 DTO hydration (10 scalar props), compiled closure vs. interpreter | v0.0.0 | **15.40× → 2.74×** manual construction (14.155 µs → 2.511 µs); NFR-01 met | [report](2026/08/nfr01-hydration-compiled-closure.md) |

--- a/docs/journal/2026/08/2026-08-04-nfr01-compiled-hydration.md
+++ b/docs/journal/2026/08/2026-08-04-nfr01-compiled-hydration.md
@@ -1,0 +1,107 @@
+# 2026-08-04 — Measuring what was reachable before deciding what to build
+
+Roadmap item **3.7**, run under `/eados optimize` — the measure-first procedure, which refuses to
+touch code without a numeric target and refuses to accept a change without a before/after.
+
+## The target, and the question worth asking
+
+NFR-01: hydration of 10 scalar props ≤ 5 µs and ≤ 3× manual construction. Baseline **15.40×**
+(14.155 µs), recorded at item 3.5 and left open on purpose by ADR-0011.
+
+The useful question wasn't "is the hydrator slow" — item 3.5 already answered that. It was
+**"what is actually reachable?"** So before writing anything I profiled the existing path and then
+prototyped every candidate, including the ones I expected to lose.
+
+Stage profile of the 13.86 µs: `parameterNames()` **rebuilt on every single call** (1.13 µs), the
+`in_array` unknown-key scan (2.16 µs), the per-parameter loop with a `coerce()` method call each
+(3.22 µs), named-argument spread at construction (1.49 µs), and the rest in call-chain overhead.
+
+Two profile results contradicted plausible intuitions, and acting on either would have made things
+worse:
+
+- Iterating `ParameterMetadata` **objects** is *faster* than iterating flattened plain arrays
+  (0.63 vs 1.59 µs). The obvious "flatten the metadata for speed" is a pessimisation.
+- Named-argument spread costs about **twice** a positional call (1.49 vs 0.80 µs).
+
+## The measurement that decided the design
+
+| approach | µs | ratio |
+|---|---|---|
+| interpreted (as-is) | 13.86 | 16.6× |
+| interpreted, every avoidable waste removed | 3.97 | 4.80× |
+| one closure per parameter (no `eval`) | 3.31 | 4.00× |
+| generated closure | 1.93 | 2.28× |
+
+Row two is the one that mattered: it is the *ceiling* of "just tighten the loop" — memoised names,
+hash-based key check, positional args, lazy error paths, all of it — and it lands at 4.80×, still
+over budget. And that prototype was optimistic: no path building, no exception construction, none
+of the nested-DTO branches production needs.
+
+So: **NFR-01's budget is not reachable by tuning an interpreted reflection-driven loop in PHP.**
+That's a measured conclusion, and it's the only thing that justifies a mechanism as heavy as code
+generation. Without it I'd have been arguing from taste.
+
+## Stopping to ask
+
+Three defensible paths existed — compile and meet the budget, tighten and miss it honestly, or
+treat the measurement as evidence the budget itself is wrong — and picking among them isn't mine to
+do. Put to the maintainer with the numbers; the compiled path was chosen.
+
+I also measured the thing that could have invalidated it in production: `eval`'d code isn't cached
+by OPcache, so under PHP-FPM the closure is rebuilt every request. Compile 66.9 µs, saving 12.3 µs
+per hydration → **break-even ≈5.5 hydrations of one class per process**. Bulk mapping clears that
+instantly; a request hydrating one or two objects is marginally slower. Worth knowing before
+shipping, not after.
+
+## Keeping two implementations honest
+
+The real risk isn't speed, it's **drift** — two implementations of one behavior that slowly
+disagree. Mitigations, in order of how much they actually buy:
+
+1. **Eligibility is tiny.** Only all-scalar constructors with no defaults. Everything else — nested
+   DTOs, collections, enums, unions, variadics, defaults — stays on the interpreter, untouched.
+2. **`HydrationParityTest` compares the two paths against *each other***, not against expectations
+   I wrote. Constructed state, exception class, message, path. If they diverge anywhere, it fails.
+3. **A documented off switch.** `new HydrationCompiler(false)` declines everything. That's what the
+   parity test uses, and it's the honest answer for anyone who doesn't want `eval` in their process.
+
+Proved non-vacuous with three planted divergences, each caught, each reverted:
+
+- Dropped `float`'s int-widening → only the `int widening into float` case failed.
+- Moved the unknown-key scan after the parameter checks → only `unknown key AND missing key`
+  failed, which is the case that distinguishes reporting order.
+- Made *nothing* eligible → `testTheFixtureIsActuallyOnTheCompiledPath` failed while every parity
+  case still passed. That third one is the important one: without that guard the whole suite could
+  be comparing the interpreter with itself, green and proving nothing.
+
+## A correctness trap I set for myself and then caught
+
+My first prototype hit 2.28× partly by skipping the unknown-key scan when `count($data)` matched
+the parameter count. That's **wrong**: a payload carrying one undeclared key *and* missing one
+declared key has the expected count, so the shortcut skips the scan and reports the missing key —
+where today's interpreter reports the unknown one. I'd already written that exact case into the
+parity suite, so when I moved to production code without the shortcut and came in at 3.47×, the
+fix had to be something sound rather than something fast. `array_diff_key` — one C call, correct
+order preserved — got it to 2.74%.
+
+Worth noting the sequence: production first measured **3.47×**, *over budget*, because the closure
+was only part of it and the naive scan was the rest. Profiling again rather than assuming the
+design had failed is what found the real cost.
+
+## Result
+
+**15.40× → 2.74×** (14.155 → 2.511 µs), stable across two independent runs (2.74× / 2.75×). Both
+halves of NFR-01 met; `bench_ratio_gate.py` exits 0 against `--max-ratio 3` for the first time.
+NFR-04 improved for free: 10 000 hydrations 149.7 ms → 37.8 ms, its 16 MiB assertion still passing.
+
+Suite 258 tests / 491 assertions green (up from 243 — the parity cases). PHPStan max clean,
+deptrac 0 violations / 0 uncovered, consistency lint OK.
+
+**The honest limit, stated plainly:** only the eligible shape is fast. A DTO with a nested DTO or a
+`Collection` is still ~14 µs. This meets the spec's budget for the spec's stated shape; it does not
+make every DTO fast, and the ADR, the class docblock and the benchmark record all say so rather
+than letting a headline number imply otherwise.
+
+## State of Milestone 3
+
+3.1–3.7 all done. Milestone 3 is complete.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Measuring what was reachable before deciding what to build](2026/08/2026-08-04-nfr01-compiled-hydration.md)
 - [2026-08-04 — Enforcing a rule two ADRs had already been obeying by hand](2026/08/2026-08-04-deptrac-layering-gate.md)
 - [2026-08-04 — First real benchmarks, and a genuine number the maintainer had to weigh in on](2026/08/2026-08-04-phpbench-hydration-memory.md)
 - [2026-08-04 — Checking what T-01 actually still needed, before writing anything](2026/08/2026-08-04-t01-enum-hydration.md)

--- a/src/main/php/d4np/utils/Dto/HydrationCompiler.php
+++ b/src/main/php/d4np/utils/Dto/HydrationCompiler.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Dto;
+
+use Closure;
+use D4np\Utils\Support\ClassMetadata;
+use D4np\Utils\Support\MissingKeyException;
+use D4np\Utils\Support\ParameterMetadata;
+use D4np\Utils\Support\TypeMismatchException;
+use D4np\Utils\Support\UnknownKeyException;
+
+/**
+ * Generates a per-class hydration closure for the shape NFR-01 measures (ADR-0013).
+ *
+ * NFR-01 budgets DTO hydration at **≤ 3× manual constructor assignment**. Four approaches were
+ * measured against that budget before this class was written (roadmap item 3.7; the numbers and
+ * the environment are recorded in `docs/benchmarks/`):
+ *
+ * | approach                                  | µs/op | ratio  |
+ * |-------------------------------------------|-------|--------|
+ * | interpreted (the {@see Hydrator} loop)     | 13.86 | 16.6×  |
+ * | interpreted, all avoidable waste removed   |  3.97 |  4.80× |
+ * | one pre-built closure per parameter        |  3.31 |  4.00× |
+ * | **generated closure (this class)**         |  1.93 |  2.28× |
+ *
+ * Every option that does not generate code lands above the budget, and those prototypes were
+ * *optimistic* — none carried path building, exception construction, or the nested-DTO branches
+ * production needs. The budget is not reachable by tuning an interpreted loop; that is a measured
+ * conclusion, not a preference.
+ *
+ * **What is compiled is deliberately narrow.** Only the shape NFR-01 actually names — *"10 scalar
+ * props"* — is eligible: every constructor parameter a non-variadic builtin `int`/`float`/
+ * `string`/`bool`, with no declared default. Anything else (nested DTOs, `Collection`, enums,
+ * unions, `mixed`, variadics, defaults) is **not compiled** and runs on {@see Hydrator}'s
+ * interpreter exactly as before. That boundary is the point: a compiled path is only worth having
+ * if it is small enough to be obviously equivalent to the path it replaces, and
+ * `HydrationParityTest` asserts the two agree case by case rather than trusting that claim.
+ *
+ * **Why "no default" is part of eligibility.** The generated call passes arguments *positionally*,
+ * which is what makes it fast — named-argument spread (`new $c(...$named)`) costs roughly twice a
+ * positional call, measured. A positional call cannot skip an argument, so a parameter whose
+ * default PHP would otherwise apply cannot be omitted. Rather than generate branching that
+ * reconstructs named-argument semantics — and give the fast path a second way to disagree with the
+ * interpreter — a class with any defaulted parameter simply is not eligible. Nullable parameters
+ * *are* eligible: RFC-0001 R-4 passes `null` explicitly for them, so the argument is always
+ * present and the position never shifts.
+ *
+ * **On `eval()`.** Generating source and evaluating it is the mechanism, and it has a real cost:
+ * OPcache does not cache eval'd code, so the closure is built once per class *per process* rather
+ * than once per deployment. Measured at ≈67 µs against a saving of ≈12 µs per hydration, the
+ * break-even is **≈5.5 hydrations of one class in one process** — comfortably paid back by any
+ * bulk mapping (an API page, a result set), and a small net loss for a process that hydrates one
+ * or two objects of a class and exits. That trade was quantified and accepted deliberately
+ * (ADR-0013), not assumed away.
+ */
+final class HydrationCompiler
+{
+    /**
+     * The builtin types the generated code knows how to check, mapped to the check itself.
+     *
+     * `float` accepts an `int` because PHP performs that widening even under `strict_types=1` —
+     * the same rule {@see Hydrator::satisfiesBuiltin()} applies, kept identical here on purpose:
+     * two spellings of one rule is exactly how the paths would drift.
+     */
+    private const CHECKS = [
+        'int' => 'is_int(%s)',
+        'float' => '(is_float(%s) || is_int(%s))',
+        'string' => 'is_string(%s)',
+        'bool' => 'is_bool(%s)',
+    ];
+
+    /**
+     * @param bool $enabled whether to generate anything at all. Disabling it makes
+     *                      {@see compile()} decline every class, so {@see Hydrator} runs entirely
+     *                      on its interpreter — the behavior is identical, only slower.
+     *
+     *                      This exists for two reasons, and only one of them is testing.
+     *                      `HydrationParityTest` uses it to run the same fixtures down both paths
+     *                      and assert they agree, which is what makes the fast path trustworthy.
+     *                      It is also the honest escape hatch for anyone who would rather their
+     *                      dependencies did not evaluate generated source in their process: that
+     *                      is a legitimate position, and the cost of respecting it is a documented
+     *                      constructor argument rather than a fork.
+     */
+    public function __construct(
+        private readonly bool $enabled = true,
+    ) {
+    }
+
+    /**
+     * A closure hydrating `$metadata`'s class, or `null` when the class is not eligible.
+     *
+     * The returned closure has the signature
+     * `static function (array $data, string $prefix, bool $lenient): object`, and throws the same
+     * exceptions, carrying the same paths, that {@see Hydrator} would for the same payload.
+     *
+     * @return Closure(array<string, mixed>, string, bool): object|null
+     */
+    public function compile(ClassMetadata $metadata): ?Closure
+    {
+        if (!$this->isEligible($metadata)) {
+            return null;
+        }
+
+        /** @var Closure(array<string, mixed>, string, bool): object */
+        return eval($this->sourceFor($metadata));
+    }
+
+    /**
+     * Whether every constructor parameter is one the generated code can handle on its own.
+     *
+     * A class with no constructor parameters is *not* eligible — there is nothing to speed up, and
+     * the interpreter already handles it in one step.
+     */
+    private function isEligible(ClassMetadata $metadata): bool
+    {
+        if (!$this->enabled || !$metadata->isInstantiable || $metadata->parameters === []) {
+            return false;
+        }
+
+        foreach ($metadata->parameters as $parameter) {
+            if ($parameter->isVariadic || $parameter->hasDefault || !$parameter->isBuiltin) {
+                return false;
+            }
+
+            if ($parameter->type === null || !isset(self::CHECKS[$parameter->type])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * The PHP source of the closure for this class.
+     *
+     * Written as source rather than assembled from smaller closures because that is where the
+     * measured win comes from: the generated body is straight-line code with no per-parameter
+     * call, no loop, and no array of metadata to walk.
+     */
+    private function sourceFor(ClassMetadata $metadata): string
+    {
+        $class = $metadata->className;
+        $body = [];
+
+        // Strict mode rejects an undeclared key before anything else, which is the order
+        // Hydrator::hydrateAt() uses — unknown keys are reported ahead of missing ones, and a
+        // payload that is both wrong in both ways must report the same one it reports today.
+        $allowed = [];
+        foreach ($metadata->parameters as $parameter) {
+            $allowed[] = var_export($parameter->name, true) . ' => true';
+        }
+
+        // `array_diff_key` answers "is any key undeclared?" in one C call, where the equivalent
+        // PHP-level `foreach` + `isset` costs a loop iteration and a string cast per key — the
+        // single largest remaining cost in the generated body, measured.
+        //
+        // The tempting shortcut here — `count($data) !== count($allowed)` — is *wrong*, and the
+        // parity suite has the case that proves it: a payload carrying one undeclared key while
+        // also missing one declared key has the expected count, so the shortcut skips the scan and
+        // the hydration goes on to report the missing key. Today's interpreter reports the unknown
+        // key, because it rejects undeclared keys before it looks at parameters. `array_diff_key`
+        // keeps that order without the loop.
+        $body[] = sprintf(
+            'if (!$lenient) { static $allowed = [%s]; $extra = array_diff_key($data, $allowed); '
+            . 'if ($extra !== []) { $name = (string) array_key_first($extra); throw \\%s::forKey('
+            . '$prefix === \'\' ? $name : $prefix . \'.\' . $name, %s); } }',
+            implode(', ', $allowed),
+            UnknownKeyException::class,
+            var_export($class, true),
+        );
+
+        $arguments = [];
+        foreach ($metadata->parameters as $index => $parameter) {
+            $variable = '$v' . $index;
+            $arguments[] = $variable;
+            $body[] = $this->parameterSource($parameter, $variable, $class);
+        }
+
+        return sprintf(
+            'return static function (array $data, string $prefix, bool $lenient) { %s return new \\%s(%s); };',
+            implode(' ', $body),
+            $class,
+            implode(', ', $arguments),
+        );
+    }
+
+    /**
+     * The generated statements that resolve one parameter into `$variable`.
+     */
+    private function parameterSource(ParameterMetadata $parameter, string $variable, string $class): string
+    {
+        $name = var_export($parameter->name, true);
+        $path = sprintf('($prefix === \'\' ? %s : $prefix . \'.\' . %s)', $name, $name);
+
+        /** @var string $type */
+        $type = $parameter->type;
+        $check = str_replace('%s', $variable, self::CHECKS[$type]);
+        $declared = var_export($parameter->declaredType ?? $type, true);
+
+        // Absence, per RFC-0001 R-4. Eligibility already excluded defaults, so there are only two
+        // cases left: nullable becomes an explicit null (PHP treats nullable-without-default as
+        // required, so it must be passed), and anything else is a missing key.
+        $absent = $parameter->allowsNull
+            ? sprintf('%s = null;', $variable)
+            : sprintf('throw \\%s::forKey(%s, %s);', MissingKeyException::class, $path, var_export($class, true));
+
+        // A nullable parameter accepts an explicit null in the payload as well as an absent key.
+        $guard = $parameter->allowsNull
+            ? sprintf('%s !== null && !%s', $variable, $check)
+            : sprintf('!%s', $check);
+
+        return sprintf(
+            'if (!array_key_exists(%s, $data)) { %s } else { %s = $data[%s]; if (%s) { '
+            . 'throw \\%s::at(%s, %s, get_debug_type(%s)); } }',
+            $name,
+            $absent,
+            $variable,
+            $name,
+            $guard,
+            TypeMismatchException::class,
+            $path,
+            $declared,
+            $variable,
+        );
+    }
+}

--- a/src/main/php/d4np/utils/Dto/Hydrator.php
+++ b/src/main/php/d4np/utils/Dto/Hydrator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace D4np\Utils\Dto;
 
 use BackedEnum;
+use Closure;
 use D4np\Utils\Support\HydrationException;
 use D4np\Utils\Support\MissingKeyException;
 use D4np\Utils\Support\ParameterMetadata;
@@ -25,9 +26,24 @@ use TypeError;
  */
 final class Hydrator
 {
+    /**
+     * Per-class compiled closures, or `false` for a class the compiler declined (ADR-0013).
+     *
+     * `false` rather than simply "absent" so an ineligible class is asked about once and then
+     * answered from this array — otherwise every hydration of, say, a nested-DTO class would
+     * re-run the eligibility walk to reach the same "no" it reached last time.
+     *
+     * @var array<class-string, Closure(array<string, mixed>, string, bool): object|false>
+     */
+    private array $compiled = [];
+
+    private readonly HydrationCompiler $compiler;
+
     public function __construct(
         private readonly ReflectionCache $cache,
+        ?HydrationCompiler $compiler = null,
     ) {
+        $this->compiler = $compiler ?? new HydrationCompiler();
     }
 
     /**
@@ -123,6 +139,17 @@ final class Hydrator
      */
     private function hydrateAt(string $class, array $data, bool $lenient, string $prefix): object
     {
+        // The compiled fast path (ADR-0013). Only the all-scalar shape NFR-01 measures is
+        // eligible; everything else returns `false` here and falls through to the interpreter
+        // below, which remains the only implementation for nested DTOs, collections, enums,
+        // unions, variadics and defaults. `HydrationParityTest` holds the two to the same
+        // observable behavior.
+        $fast = $this->compiled[$class] ??= $this->compiler->compile($this->cache->for($class)) ?? false;
+        if ($fast !== false) {
+            /** @var T */
+            return $fast($data, $prefix, $lenient);
+        }
+
         $meta = $this->cache->for($class);
 
         if (!$meta->isInstantiable) {

--- a/src/test/php/d4np/utils/Dto/Fixture/CompilableDto.php
+++ b/src/test/php/d4np/utils/Dto/Fixture/CompilableDto.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/**
+ * Eligible for the compiled fast path (ADR-0013): every parameter a builtin scalar with no
+ * declared default. The nullable one is deliberate — nullable-without-default is eligible
+ * (RFC-0001 R-4 always passes it, so its argument position never shifts), and it is the case most
+ * likely to diverge between the two paths, so parity has something real to check.
+ */
+final class CompilableDto extends DataTransferObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly int $count,
+        public readonly float $ratio,
+        public readonly bool $active,
+        public readonly ?string $note,
+    ) {
+    }
+}

--- a/src/test/php/d4np/utils/Dto/HydrationParityTest.php
+++ b/src/test/php/d4np/utils/Dto/HydrationParityTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Dto;
+
+use D4np\Utils\Dto\HydrationCompiler;
+use D4np\Utils\Dto\Hydrator;
+use D4np\Utils\Support\HydrationException;
+use D4np\Utils\Support\ReflectionCache;
+use D4np\Utils\Tests\Dto\Fixture\CompilableDto;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * The compiled fast path (ADR-0013) and the interpreter must be indistinguishable from outside.
+ *
+ * This is the test that makes the fast path safe to have at all. Item 3.7 bought NFR-01's budget
+ * by giving the hydrator a *second* implementation for one narrow shape; the standing risk of any
+ * such split is that the two drift and a payload starts behaving differently depending on which
+ * one claimed it. So rather than testing the compiled path against hand-written expectations —
+ * which would only prove it matches what the author of *this* file believed — every case below is
+ * run through both paths and the two results are compared with each other.
+ *
+ * The interpreter is reached by handing {@see Hydrator} a compiler constructed with
+ * `enabled: false`, which declines every class.
+ */
+#[Group('T-01')]
+final class HydrationParityTest extends TestCase
+{
+    private function compiling(): Hydrator
+    {
+        return new Hydrator(new ReflectionCache(), new HydrationCompiler(true));
+    }
+
+    private function interpreting(): Hydrator
+    {
+        return new Hydrator(new ReflectionCache(), new HydrationCompiler(false));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, bool}>
+     */
+    public static function payloads(): iterable
+    {
+        $valid = ['name' => 'a', 'count' => 1, 'ratio' => 1.5, 'active' => true, 'note' => 'n'];
+
+        yield 'all present, strict' => [$valid, false];
+        yield 'all present, lenient' => [$valid, true];
+        yield 'explicit null in nullable' => [['name' => 'a', 'count' => 1, 'ratio' => 1.5, 'active' => true, 'note' => null], false];
+        yield 'nullable key absent (R-4)' => [['name' => 'a', 'count' => 1, 'ratio' => 1.5, 'active' => true], false];
+        yield 'int widening into float' => [['name' => 'a', 'count' => 1, 'ratio' => 2, 'active' => true, 'note' => null], false];
+
+        // Failure cases: the two paths must fail the same way, not merely both fail.
+        yield 'missing required key' => [['count' => 1, 'ratio' => 1.5, 'active' => true, 'note' => null], false];
+        yield 'wrong scalar type' => [['name' => 'a', 'count' => 'not-an-int', 'ratio' => 1.5, 'active' => true, 'note' => null], false];
+        yield 'null into non-nullable' => [['name' => null, 'count' => 1, 'ratio' => 1.5, 'active' => true, 'note' => null], false];
+        yield 'unknown key, strict' => [$valid + ['extra' => 1], false];
+        yield 'unknown key, lenient' => [$valid + ['extra' => 1], true];
+        yield 'unknown key AND missing key' => [['count' => 1, 'ratio' => 1.5, 'active' => true, 'note' => null, 'extra' => 1], false];
+        yield 'float given for int' => [['name' => 'a', 'count' => 1.5, 'ratio' => 1.5, 'active' => true, 'note' => null], false];
+        yield 'string given for bool' => [['name' => 'a', 'count' => 1, 'ratio' => 1.5, 'active' => 'yes', 'note' => null], false];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('payloads')]
+    public function testCompiledAndInterpretedAgree(array $payload, bool $lenient): void
+    {
+        $compiled = self::outcomeOf(fn (): object => $this->compiling()->hydrate(CompilableDto::class, $payload, $lenient));
+        $interpreted = self::outcomeOf(fn (): object => $this->interpreting()->hydrate(CompilableDto::class, $payload, $lenient));
+
+        self::assertSame(
+            $interpreted,
+            $compiled,
+            'the compiled fast path and the interpreter disagreed on this payload',
+        );
+    }
+
+    /**
+     * A comparable description of what a hydration did — the constructed state, or the exception
+     * class, message and path. Compared as data so a difference in *any* of those shows up as a
+     * failed assertion rather than only a difference in success/failure.
+     *
+     * @param callable(): object $run
+     *
+     * @return array<string, mixed>
+     */
+    private static function outcomeOf(callable $run): array
+    {
+        try {
+            $dto = $run();
+        } catch (Throwable $e) {
+            return [
+                'outcome' => 'threw',
+                'class' => $e::class,
+                'message' => $e->getMessage(),
+                'path' => $e instanceof HydrationException ? $e->path() : null,
+            ];
+        }
+
+        self::assertInstanceOf(CompilableDto::class, $dto);
+
+        return [
+            'outcome' => 'built',
+            'name' => $dto->name,
+            'count' => $dto->count,
+            'ratio' => $dto->ratio,
+            'active' => $dto->active,
+            'note' => $dto->note,
+        ];
+    }
+
+    public function testTheFixtureIsActuallyOnTheCompiledPath(): void
+    {
+        // Without this, every assertion above could be comparing the interpreter with itself and
+        // still pass — the test would be green and prove nothing.
+        $meta = (new ReflectionCache())->for(CompilableDto::class);
+
+        self::assertNotNull(
+            (new HydrationCompiler(true))->compile($meta),
+            'CompilableDto is no longer eligible for compilation, so the parity cases above are '
+            . 'comparing the interpreter with itself and are no longer testing anything.',
+        );
+    }
+
+    public function testDisabledCompilerDeclinesAnEligibleClass(): void
+    {
+        $meta = (new ReflectionCache())->for(CompilableDto::class);
+
+        self::assertNull((new HydrationCompiler(false))->compile($meta));
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item 3.7, run under the `/eados optimize` measure-first procedure. Closes the gap item 3.5 measured and **ADR-0011** deliberately left open.

**Result: 15.40× → 2.74×** (14.155 µs → 2.511 µs). Both halves of NFR-01 met for the first time; `bench_ratio_gate.py` exits 0 against `--max-ratio 3`. NFR-04 improved for free (10 000 hydrations 149.7 ms → 37.8 ms, its 16 MiB assertion still passing).

### Four approaches were measured before any production code was written

| approach | µs | ratio | ≤3×? |
|---|---|---|---|
| interpreted (as-is) | 13.86 | 16.6× | ✗ |
| interpreted, every avoidable waste removed | 3.97 | 4.80× | ✗ |
| one pre-built closure per parameter (no `eval`) | 3.31 | 4.00× | ✗ |
| **generated closure** | **1.93** | **2.28×** | ✓ |

Row two is the ceiling of *"just tighten the loop"* — memoised `parameterNames()` (rebuilt on every call today), hash-based key check, positional args, lazy error paths — and it still misses, while carrying none of the path building, exception construction or nested-DTO branches production needs. **NFR-01's budget is not reachable by tuning an interpreted reflection-driven loop in PHP.** That measured conclusion is what justifies code generation.

Profiling also contradicted two plausible intuitions: iterating `ParameterMetadata` **objects** is *faster* than flattened plain arrays (0.63 vs 1.59 µs), so "flatten the metadata" is a pessimisation; and named-argument spread costs ~2× a positional call.

### Scope is deliberately narrow

Only the all-scalar shape NFR-01 names is eligible (non-variadic builtin `int`/`float`/`string`/`bool`, no defaults). **Nested DTOs, `Collection`, enums, unions, `array`, variadics and defaults are not compiled** and run the interpreter unchanged.

**Honest limit:** only the eligible shape is fast — a DTO with a nested DTO is still ~14 µs. The ADR, class docblock and benchmark record all say so rather than letting the headline imply otherwise.

### Keeping two implementations honest

- Eligibility small enough to check case by case
- `HydrationParityTest` runs every case down **both** paths and compares them **against each other** (state, exception class, message, path) — not against expectations I wrote
- `new HydrationCompiler(false)` declines everything: what the parity test uses, and the escape hatch for anyone who doesn't want `eval` in their process

### Cost, measured not waved at

`eval`'d code isn't OPcache-cached, so the closure is rebuilt per class **per process**: compile 66.9 µs vs 12.3 µs saved per hydration → **break-even ≈5.5 hydrations/class/process**. Bulk mapping clears it instantly; a process hydrating one or two objects is marginally slower.

## Test plan

- [x] **Parity proved non-vacuous** with three planted divergences, each caught and reverted: dropped `float`'s int-widening (only that case failed); moved the unknown-key scan after parameter checks (only `unknown key AND missing key` failed — the case where reporting *order* differs); made nothing eligible (the guard failed while parity cases still passed — proving the suite isn't silently comparing the interpreter with itself)
- [x] `vendor/bin/phpunit` — 258 tests, 491 assertions, 7 skipped (up from 243)
- [x] Two independent benchmark runs: 2.74× / 2.75× — stable
- [x] `vendor/bin/phpstan analyse` max — clean
- [x] `vendor/bin/deptrac analyse` — 0 violations, 0 uncovered
- [x] `consistency_lint.py`, `action_pin_lint.py --verify-upstream` — OK
- [ ] CI

One trap worth flagging for review: the first prototype hit 2.28× partly by skipping the unknown-key scan when `count($data)` matched the parameter count. That's **wrong** — a payload with one undeclared key *and* one missing declared key has the expected count, so it reports the missing key where the interpreter reports the unknown one. The parity suite already had that case, so production came in at 3.47× (over budget) until the sound fix: `array_diff_key`, one C call, order preserved.

Full before/after with environment in [`docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md`](docs/benchmarks/2026/08/nfr01-hydration-compiled-closure.md); decision record in **ADR-0013**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)