### PR TITLE
feat(database): DatabaseConnection with FR-06's pinned safe defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,20 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   recorded honestly rather than adjusted to pass, shipped non-blocking by explicit maintainer
   decision, with closing the gap filed as roadmap item 3.7. The `benchmark` CI job (self-skipped
   since item 1.9) is now active, since `phpbench.json.dist` exists.
+- `D4np\Utils\Database\DatabaseConnection` (**ADR-0014**) — opens Milestone 4. Wraps a
+  **consumer-owned** `PDO` (RFC-0001: the library opens no connections) and pins spec FR-06's four
+  safe defaults: `ERRMODE_EXCEPTION`, real prepares (`EMULATE_PREPARES=false`), `FETCH_ASSOC`, and
+  `SET NAMES utf8mb4` on MySQL. A connection that will not take a pinned default is **refused**
+  with a `DatabaseException` rather than handed back weakened — `PDO::setAttribute()` signals
+  refusal by *returning `false`*, not by throwing, so the obvious implementation would let a
+  security-relevant default fail silently. The ambiguous `false` is disambiguated by reading the
+  attribute back: a driver with no emulation concept at all (SQLite) is fine; one that is still
+  emulating is refused. The order the defaults are applied in is load-bearing and documented —
+  `SET NAMES` is only safe *because* real prepares are already on, leaving no client-side escaping
+  to fool. `select()`, `selectOne()` (returns `null`, not PDO's `false`) and `execute()` always
+  bind values; identifiers cannot be bound and belong to `QueryBuilder` (item 4.2). Failures wrap
+  `PDOException` per ADR-0004 and deliberately **omit the SQL** from the message, since a failing
+  statement's text is the likeliest place for data that should not reach a log.
 - `D4np\Utils\Dto\HydrationCompiler` (**ADR-0013**) closes NFR-01's performance gap: hydrating a
   10-scalar-property DTO went from **15.40× to 2.74×** manual constructor assignment
   (14.155 µs → 2.511 µs), meeting both halves of the budget for the first time. Four approaches

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Measuring what was reachable before deciding what to build](docs/journal/2026/08/2026-08-04-nfr01-compiled-hydration.md).
+  [2026-08-04 — Milestone 4 opens: the security default that fails by returning false](docs/journal/2026/08/2026-08-04-pinned-pdo-defaults.md).
 
 ## Model & effort routing (advisory)
 
@@ -195,8 +195,16 @@ Typed, mass-assignment-safe data transfer (RFC-0001).
 
 Safe-by-default PDO access (RFC-0001).
 
-- [ ] 4.1 `DatabaseConnection` with pinned defaults: ERRMODE_EXCEPTION, utf8mb4, real prepares,
-      FETCH_ASSOC (RFC-0001) (severity:high — core guarantee) — route: standard / high
+- [x] 4.1 `DatabaseConnection` with pinned defaults: ERRMODE_EXCEPTION, utf8mb4, real prepares,
+      FETCH_ASSOC (RFC-0001) (severity:high — core guarantee) — route: standard / high ·
+      **ADR-0014**. *Wraps a **consumer-owned** PDO per RFC-0001, and **refuses** a connection that
+      will not take a pinned default rather than degrading silently — `PDO::setAttribute()` signals
+      refusal by returning `false`, not by throwing, so the natural implementation would let a
+      security default fail invisibly. `false` is disambiguated by reading the attribute back:
+      SQLite has no emulation concept (fine), a driver still emulating is refused. Order is
+      load-bearing: real prepares must be off before `SET NAMES utf8mb4`, because `SET NAMES` is
+      only safe once there is no client-side escaping left to fool. Honest gap: the MySQL-only
+      `SET NAMES` path is unexecuted by the suite (no MySQL in CI) — T-02 (item 4.4) owns that.*
 - [ ] 4.2 `QueryBuilder`: bound values, identifier allowlist + driver quoting, `Sort` enum,
       int-cast LIMIT/OFFSET (RFC-0001) (security — protected floor) —
       route: frontier-reasoning / extra

--- a/docs/adr/0014-pin-pdo-defaults-on-a-consumer-owned-connection.md
+++ b/docs/adr/0014-pin-pdo-defaults-on-a-consumer-owned-connection.md
@@ -1,0 +1,121 @@
+# ADR-0014: Pin PDO's safe defaults on a consumer-owned connection, and refuse one that will not take them
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 4.1 (opens Milestone 4) · spec FR-06 · items 4.2 (`QueryBuilder`),
+  4.3 (`Transaction`), 4.4 (T-02 injection suite) · [RFC-0001](../rfc/0001-egl-utils-library.md)
+  §"Data & schema" · [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md)
+
+## Context
+
+Spec FR-06 asks for *"a PDO wrapper with pinned safe defaults — ERRMODE_EXCEPTION, utf8mb4 on
+MySQL, real prepares (EMULATE_PREPARES=false), FETCH_ASSOC"*. Two things about that sentence
+needed settling before any of it could be written.
+
+**Who owns the connection.** RFC-0001 answers this directly in its "Data & schema" section: *"The
+library owns no persistent state: `Database` components wrap **consumer-owned** PDO connections."*
+So this is not a connection factory. It takes a `PDO` the caller already built, and the "pinning"
+is something done *to* an object someone else owns — which makes the failure modes below matter
+more, not less.
+
+**What PDO actually does when a driver disagrees.** Probed before designing, because the answer
+turned out to be the crux:
+
+| call | SQLite result |
+|---|---|
+| `setAttribute(ATTR_EMULATE_PREPARES, false)` | returns **`false`** — no exception |
+| `getAttribute(ATTR_EMULATE_PREPARES)` | **throws** `SQLSTATE[IM001] Driver does not support this function` |
+
+`setAttribute()` signalling refusal by return value rather than by throwing is the whole problem.
+The natural way to write this code — call `setAttribute()` four times and move on — would let a
+**security-relevant default fail silently**, which is precisely the outcome FR-06 exists to
+prevent. And the `false` is ambiguous on its own: SQLite returns it because it has no emulation
+mode at all (it prepares natively — nothing is wrong), while a driver that *has* the concept and
+declined would return the same `false` with client-side interpolation left on.
+
+## Decision
+
+**Pin the defaults in the constructor, verify each one took, and refuse the connection when a
+guarantee cannot be made.**
+
+- **Order is load-bearing, not cosmetic.** `ERRMODE_EXCEPTION` is applied **first**, so everything
+  after it fails loudly instead of returning `false`. Emulation is turned off **before any SQL is
+  sent**. `SET NAMES utf8mb4` (MySQL only) is applied **last**.
+
+  That last ordering is the non-obvious one. `SET NAMES` is the classic *wrong* answer to charset
+  configuration **when the client is also escaping**, because the client library's notion of the
+  connection charset does not change with it, and a multibyte charset can then be used to smuggle
+  a quote past client-side escaping. With emulation already off there is no client-side escaping
+  left to fool — values travel to the server as bound parameters, out of band from the SQL text.
+  **The two pinned defaults are not independent hardening measures: real prepares is what licenses
+  `SET NAMES`.** Reordering them would reintroduce a real vulnerability, so the order is documented
+  in the class rather than left to look arbitrary.
+
+- **`false` from `setAttribute()` is disambiguated, not ignored.** For `ATTR_EMULATE_PREPARES`,
+  a `false` return is followed by reading the attribute back: if the read **throws**, the driver
+  has no emulation concept and all is well; if it **succeeds and reports emulation still on**, the
+  connection is refused with a `DatabaseException`. For the other attributes a `false` return is
+  refused outright.
+
+- **Refuse rather than degrade.** A connection that will not take a pinned default cannot offer
+  the guarantees this class exists to make, so it raises instead of being handed back in a weaker
+  state. A silently-weakened security default is worse than a loud failure precisely because
+  nothing downstream can detect it.
+
+- **Values are always bound; identifiers are out of scope.** No method here accepts an interpolated
+  value, on the reasoning that the method that did would be the one that got used. Identifiers
+  cannot be bound at all and are `QueryBuilder`'s problem (item 4.2), where they are allowlisted.
+
+- **`pdo()` is a deliberate escape hatch.** This library does not intend to re-wrap all of PDO;
+  `lastInsertId()`, driver-specific attributes and `Transaction`'s savepoints (item 4.3) reach the
+  real object, which already carries the pinned defaults.
+
+## Alternatives Considered
+
+- **Open the connection from a DSN** — rejected: RFC-0001 explicitly scopes these components to
+  consumer-owned connections, and a factory would drag credential handling into a utility library.
+  It remains addable later without a BC break; the reverse would not be true.
+- **Set the charset via the DSN (`charset=utf8mb4`) instead of `SET NAMES`** — genuinely the
+  better mechanism, and **not available here**: the connection already exists by the time this
+  class sees it. Recorded because a reader who knows the DSN form is better deserves to know it
+  was considered and why it is unreachable, rather than assuming the weaker form was chosen
+  carelessly. It is also the reason the emulation ordering above is documented so heavily.
+- **Ignore `setAttribute()`'s return value** (the common idiom) — rejected on the probe: it makes
+  a security default fail silently on any driver that declines it.
+- **Treat every `false` return as fatal** — rejected because it is wrong in the other direction:
+  SQLite would be refused for having nothing to disable. Probed — it fails every SQLite test in the
+  suite.
+- **Verify emulation by inspecting driver behaviour** (e.g. issuing a statement and checking the
+  server's query log) — rejected as far too invasive for a constructor, and impossible without a
+  server round-trip.
+- **Skip pinning and merely document the recommended attributes** — rejected: FR-06 asks for a
+  guarantee, and a guarantee nothing enforces is a README paragraph.
+
+## Consequences
+
+- A `DatabaseConnection` either carries all four guarantees or does not exist. Callers do not have
+  to check.
+- **The most security-relevant branch is testable and tested.** No driver reachable from this suite
+  behaves like a stubborn emulator — SQLite has no emulation mode, MySQL honours the attribute — so
+  the refusal path would otherwise have been present, plausible and never executed.
+  `StubbornlyEmulatingPdo`, a real `PDO` subclass overriding exactly two attribute calls, exists to
+  run it.
+- **`SET NAMES utf8mb4` remains unexecuted by the suite**, because it is MySQL-only and no MySQL
+  server is available in CI. What *is* tested is the driver dispatch around it. This is stated
+  plainly rather than papered over; T-02 (item 4.4) is where a real driver matrix belongs.
+- The constructor mutates a `PDO` the caller owns. That is inherent — PDO attributes are connection
+  state, not wrapper state — and is documented, but it does mean a caller sharing one `PDO` between
+  a `DatabaseConnection` and other code will see these settings there too. That is the intent.
+- Pinning happens once per wrapper construction, not per query, so it costs nothing on the hot path.
+- Writing the failing SQL into the exception message was deliberately **not** done: a failing
+  statement's text is the most likely place for data that should not reach a log. The driver's own
+  message and SQLSTATE survive as `getPrevious()`.
+
+## References
+
+- Spec FR-06 (the four pinned defaults), FR-07 (identifiers, `QueryBuilder`'s problem)
+- RFC-0001 §"Data & schema" — components wrap consumer-owned connections
+- ADR-0004 — why a driver failure surfaces as `DatabaseException` rather than a bare `PDOException`
+- Probed directly: `PDO::setAttribute()` return-value semantics and `getAttribute()`'s
+  `SQLSTATE[IM001]` on an unsupported attribute (PHP 8.3.1, `pdo_sqlite`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,3 +29,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0011](0011-benchmark-scope-and-the-measured-hydration-ratio.md) | Benchmarks measure NFR-01/NFR-04 now; absolute regression tracking and the measured ~15× ratio gap are deliberately deferred | Accepted |
 | [0012](0012-enforce-the-layering-rule-by-directory-over-src-main.md) | Enforce RFC-0001's layering rule by directory, over `src/main` only | Accepted |
 | [0013](0013-compile-a-hydration-closure-for-the-scalar-shape.md) | Compile a hydration closure for the scalar shape, keep the interpreter for everything else | Accepted |
+| [0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) | Pin PDO's safe defaults on a consumer-owned connection, and refuse one that will not take them | Accepted |

--- a/docs/journal/2026/08/2026-08-04-pinned-pdo-defaults.md
+++ b/docs/journal/2026/08/2026-08-04-pinned-pdo-defaults.md
@@ -1,0 +1,101 @@
+# 2026-08-04 — Milestone 4 opens: the security default that fails by returning false
+
+Roadmap item **4.1**. Route: the item declares `standard / high`; Opus 5 is the standard tier —
+match.
+
+## Two things to settle before writing anything
+
+**Who owns the connection.** RFC-0001 answers it outright in a section I nearly skipped, because
+it is titled "Data & schema — omitted": *"the library owns no persistent state: `Database`
+components wrap **consumer-owned** PDO connections."* So this is not a connection factory. It pins
+settings on an object someone else owns — which makes every failure mode below matter more.
+
+**What PDO does when a driver disagrees.** Probed rather than assumed, and the answer turned out
+to be the whole item:
+
+```
+setAttribute(ATTR_EMULATE_PREPARES, false)  ->  returns FALSE. No exception.
+getAttribute(ATTR_EMULATE_PREPARES)         ->  THROWS SQLSTATE[IM001]
+```
+
+`setAttribute()` signalling refusal **by return value** is the crux. The natural way to write this
+— four `setAttribute()` calls in a row — would let a security-relevant default fail **silently**,
+which is exactly what FR-06 exists to prevent. And the `false` is ambiguous on its own: SQLite
+returns it because it has no emulation mode at all (nothing is wrong), while a driver that *has*
+the concept and declined returns the identical `false` with client-side interpolation left on.
+
+Reading the attribute back separates them: throws → no such concept → fine; returns true → still
+emulating → refuse the connection.
+
+## The ordering is a security property, not tidiness
+
+`SET NAMES utf8mb4` is the long-standing *wrong* answer to charset configuration — but only when
+the client is also escaping, because the client library's idea of the connection charset doesn't
+change with it and a multibyte charset can smuggle a quote past client-side escaping. With
+emulation already off there is no client-side escaping left to fool; values travel as bound
+parameters, out of band from the SQL text.
+
+So the two pinned defaults aren't independent hardening measures. **Real prepares is what licenses
+`SET NAMES`.** Reordering them reintroduces a real vulnerability. That's now documented in the
+class rather than left looking arbitrary — and it's why I recorded, in the ADR, that the *better*
+mechanism (`charset=utf8mb4` in the DSN) is genuinely unreachable here: the connection already
+exists by the time this class sees it. A reader who knows the DSN form is better deserves to know
+it was considered, not to assume carelessness.
+
+## Testing the branch no real driver reaches
+
+The refusal path — "this driver is still emulating, so I will not hand you this connection" — is
+the single most security-relevant line in the item. And nothing reachable from the suite executes
+it: SQLite has no emulation mode, MySQL honours the attribute, and there's no MySQL in CI.
+
+So `StubbornlyEmulatingPdo`: a real `PDO` on a real SQLite connection, subclassed to override
+exactly two attribute calls. Everything else behaves like the genuine article. Without it that
+branch would be present, plausible, and never once run.
+
+## A probe that found a real hole in my own test
+
+Standard practice here is to plant each bug a test claims to catch. Four probes:
+
+| planted | caught by |
+|---|---|
+| don't pin `FETCH_ASSOC` | `testDefaultFetchModeIsPinnedToAssoc` — **but not the row-shape test** |
+| don't pin `ERRMODE` | `testErrorModeIsPinnedToExceptions` |
+| treat every `false` as fatal | every SQLite test (6 failures) |
+| leak the SQL into the message | `testTheFailureMessageDoesNotEchoTheStatement` |
+
+Row one is the useful one. I'd written `testRowsComeBackAsAssociativeArraysOnly` believing it
+tested the pin. It doesn't — `select()` passes `FETCH_ASSOC` to `fetchAll()` **explicitly**, so it
+stays green with the pin removed. The test was real, but it tested `select()`'s own contract, not
+the pinned default, and its name claimed otherwise.
+
+Fixed by renaming it to what it actually covers and adding
+`testThePinnedFetchModeAppliesToStatementsRunOnTheRawPdo`, which runs a query through `pdo()` with
+no fetch mode passed anywhere — so whatever comes back is the pin's doing. Re-ran the probe: now
+two tests fail instead of one. That's the coverage the item was supposed to have.
+
+Worth noting the pattern — this is the second item running where the probe found something I'd
+have otherwise shipped believing it was covered.
+
+## Deliberately not done
+
+The failing SQL is **not** in the exception message. A failing statement's text is the likeliest
+place for data nobody wants in a log line; the driver's message and SQLSTATE survive as
+`getPrevious()`.
+
+## Honest gap
+
+`SET NAMES utf8mb4` is MySQL-only and no MySQL server exists in CI, so that line is unexecuted by
+the suite. What *is* tested is the driver dispatch around it. Stated in the ADR, the roadmap note
+and here rather than papered over — a real driver matrix belongs to **T-02** (item 4.4).
+
+## Bar
+
+274 tests / 509 assertions green (up from 258). PHPStan max clean. Deptrac 0 violations, 0
+uncovered, 52 allowed — the layering gate from item 3.6 now has a second real group (`Database`)
+depending downward on `Support`, which is the first time it has constrained anything beyond `Dto`.
+cs-fixer flagged my new file for mixed line endings (my own Python rewrites on Windows); fixed.
+
+## Next
+
+**4.2** `QueryBuilder` — identifiers can't be bound, so the allowlist is the only defence there is.
+Routed `frontier-reasoning / extra`, above this session's tier.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Milestone 4 opens: the security default that fails by returning false](2026/08/2026-08-04-pinned-pdo-defaults.md)
 - [2026-08-04 — Measuring what was reachable before deciding what to build](2026/08/2026-08-04-nfr01-compiled-hydration.md)
 - [2026-08-04 — Enforcing a rule two ADRs had already been obeying by hand](2026/08/2026-08-04-deptrac-layering-gate.md)
 - [2026-08-04 — First real benchmarks, and a genuine number the maintainer had to weigh in on](2026/08/2026-08-04-phpbench-hydration-memory.md)

--- a/src/main/php/d4np/utils/Database/DatabaseConnection.php
+++ b/src/main/php/d4np/utils/Database/DatabaseConnection.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Database;
+
+use D4np\Utils\Support\DatabaseException;
+use PDO;
+use PDOException;
+use PDOStatement;
+
+/**
+ * A PDO connection with the safe defaults spec FR-06 pins (ADR-0014).
+ *
+ * RFC-0001 is explicit that the `Database` group wraps **consumer-owned** PDO connections — the
+ * library owns no persistent state and opens nothing. So this takes a `PDO` the caller already
+ * built and *pins* four settings on it:
+ *
+ * | setting | value | why |
+ * |---|---|---|
+ * | `ATTR_ERRMODE` | `ERRMODE_EXCEPTION` | a failed statement raises rather than returning `false` |
+ * | `ATTR_EMULATE_PREPARES` | `false` | the driver prepares; no client-side interpolation |
+ * | `ATTR_DEFAULT_FETCH_MODE` | `FETCH_ASSOC` | rows are maps, not duplicated numeric+named pairs |
+ * | `SET NAMES utf8mb4` | MySQL only | the full Unicode range, not MySQL's 3-byte `utf8` |
+ *
+ * **The order these are applied in is load-bearing, not cosmetic.**
+ *
+ * `ERRMODE_EXCEPTION` goes first so that everything after it fails loudly rather than silently
+ * returning `false`. Emulation is turned off **before** any SQL is sent, and that is what makes
+ * the `SET NAMES utf8mb4` step safe: issuing `SET NAMES` is the long-standing wrong answer to
+ * charset configuration *when the client is also doing its own escaping*, because the client
+ * library's idea of the connection charset does not change with it, and a multibyte charset can
+ * then be used to smuggle a quote past client-side escaping. With emulation off there is no
+ * client-side escaping left to fool — values are sent to the server as bound parameters, out of
+ * band from the SQL text. The two pinned defaults are not independent hardening measures; the
+ * second is what licenses the fourth.
+ *
+ * **A driver that does not honour a pinned default is an error, not a shrug.** `PDO::setAttribute()`
+ * returns `false` rather than throwing when a driver rejects an attribute (verified: SQLite
+ * returns `false` for `ATTR_EMULATE_PREPARES`), so ignoring the return value would let a
+ * security-relevant default fail silently — exactly the failure FR-06 exists to prevent. What
+ * this class does instead is distinguish the two cases: a driver with no notion of emulation at
+ * all (SQLite prepares natively; reading the attribute back throws
+ * `SQLSTATE[IM001] Driver does not support this function`) is fine, while a driver that *has*
+ * the concept and is still emulating after being told not to is a {@see DatabaseException}.
+ *
+ * Every query method binds its values as parameters. There is no method on this class that
+ * accepts an interpolated value, because the one that did would be the one that got used.
+ * Identifiers are a different problem — they cannot be bound — and belong to `QueryBuilder`
+ * (roadmap 4.2), which allowlists them.
+ */
+final class DatabaseConnection
+{
+    /**
+     * @throws DatabaseException when a pinned default cannot be applied
+     */
+    public function __construct(
+        private readonly PDO $pdo,
+    ) {
+        $this->pin();
+    }
+
+    /**
+     * The underlying PDO.
+     *
+     * An escape hatch, and deliberately one: this library does not intend to wrap all of PDO, and
+     * a consumer needing `lastInsertId()`, a driver-specific attribute, or `Transaction`'s
+     * savepoint handling (roadmap 4.3) should reach the real object rather than wait for a
+     * pass-through method. The pinned defaults are already applied to it.
+     */
+    public function pdo(): PDO
+    {
+        return $this->pdo;
+    }
+
+    /**
+     * The PDO driver name — `mysql`, `sqlite`, `pgsql`, …
+     */
+    public function driver(): string
+    {
+        /** @var string */
+        return $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    }
+
+    /**
+     * Every row of a query, as associative arrays.
+     *
+     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
+     *
+     * @return list<array<string, mixed>>
+     *
+     * @throws DatabaseException
+     */
+    public function select(string $sql, array $parameters = []): array
+    {
+        /** @var list<array<string, mixed>> */
+        return $this->run($sql, $parameters)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * The first row of a query, or `null` when it returns none.
+     *
+     * `null` rather than PDO's `false`, so the empty case is expressible in the type system and a
+     * caller cannot confuse "no row" with "a row whose first column was falsy".
+     *
+     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
+     *
+     * @return array<string, mixed>|null
+     *
+     * @throws DatabaseException
+     */
+    public function selectOne(string $sql, array $parameters = []): ?array
+    {
+        $row = $this->run($sql, $parameters)->fetch(PDO::FETCH_ASSOC);
+
+        /** @var array<string, mixed>|false $row */
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * Run a statement that changes rows, and return how many it affected.
+     *
+     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
+     *
+     * @throws DatabaseException
+     */
+    public function execute(string $sql, array $parameters = []): int
+    {
+        return $this->run($sql, $parameters)->rowCount();
+    }
+
+    /**
+     * Prepare and execute, converting PDO's failure into this library's own (ADR-0004).
+     *
+     * @param array<string|int, mixed> $parameters
+     *
+     * @throws DatabaseException
+     */
+    private function run(string $sql, array $parameters): PDOStatement
+    {
+        try {
+            $statement = $this->pdo->prepare($sql);
+            $statement->execute($parameters === [] ? null : $parameters);
+
+            return $statement;
+        } catch (PDOException $e) {
+            // The SQL is deliberately not in the message. It is frequently logged, and a failing
+            // statement's text is the most likely place for data a consumer would rather not see
+            // in a log line. The driver's own message and SQLSTATE are preserved via getPrevious().
+            throw new DatabaseException(
+                sprintf('Database statement failed: %s', $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+    }
+
+    /**
+     * Apply the pinned defaults, in the order the class docblock explains.
+     *
+     * @throws DatabaseException
+     */
+    private function pin(): void
+    {
+        // First, so that everything below fails loudly rather than returning false.
+        $this->pinAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION, 'ATTR_ERRMODE');
+
+        $this->requireRealPrepares();
+
+        $this->pinAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC, 'ATTR_DEFAULT_FETCH_MODE');
+
+        // Only MySQL has the 3-byte-`utf8` problem this fixes, and only MySQL understands the
+        // statement. Safe here specifically because real prepares are already on — see the class
+        // docblock.
+        if ($this->driver() === 'mysql') {
+            try {
+                $this->pdo->exec('SET NAMES utf8mb4');
+            } catch (PDOException $e) {
+                throw new DatabaseException(
+                    'Could not set the connection charset to utf8mb4: ' . $e->getMessage(),
+                    0,
+                    $e,
+                );
+            }
+        }
+    }
+
+    /**
+     * @throws DatabaseException
+     */
+    private function pinAttribute(int $attribute, mixed $value, string $label): void
+    {
+        if (!$this->pdo->setAttribute($attribute, $value)) {
+            throw new DatabaseException(sprintf(
+                'The PDO driver "%s" refused the pinned default %s. This connection cannot offer '
+                . 'the guarantees DatabaseConnection exists to make, so it is refused rather than '
+                . 'used with a weaker setting.',
+                $this->driver(),
+                $label,
+            ));
+        }
+    }
+
+    /**
+     * Turn off emulated prepares, tolerating drivers that have no such concept.
+     *
+     * `setAttribute()` returning `false` is ambiguous on its own: it means both "this driver does
+     * not know this attribute" (SQLite, which always prepares natively — nothing is wrong) and
+     * "this driver knows it and declined" (which would leave client-side interpolation on, and is
+     * a security failure). Reading the attribute back separates them.
+     *
+     * @throws DatabaseException
+     */
+    private function requireRealPrepares(): void
+    {
+        if ($this->pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false)) {
+            return;
+        }
+
+        try {
+            $stillEmulating = (bool) $this->pdo->getAttribute(PDO::ATTR_EMULATE_PREPARES);
+        } catch (PDOException) {
+            // The driver does not expose the attribute at all, which means it has no emulation
+            // mode to turn off. SQLite is the case in point.
+            return;
+        }
+
+        if ($stillEmulating) {
+            throw new DatabaseException(sprintf(
+                'The PDO driver "%s" is still emulating prepared statements after being told not '
+                . 'to. Emulated prepares interpolate values into the SQL text client-side, which '
+                . 'is the behaviour FR-06 pins this default to prevent, so this connection is '
+                . 'refused rather than used unsafely.',
+                $this->driver(),
+            ));
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Database/DatabaseConnectionTest.php
+++ b/src/test/php/d4np/utils/Database/DatabaseConnectionTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database;
+
+use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Support\DatabaseException;
+use D4np\Utils\Tests\Database\Fixture\StubbornlyEmulatingPdo;
+use PDO;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-06's pinned defaults, against a real driver rather than a mock.
+ *
+ * SQLite in memory is used because the assertions here are about what PDO *actually does* — an
+ * attribute a driver silently refuses, a fetch mode that changes the shape of a row, an error
+ * mode that decides between an exception and a `false`. A doubled `PDO` would return whatever the
+ * double was told to, which is the belief under test rather than a test of it.
+ *
+ * The MySQL-only behaviour (`SET NAMES utf8mb4`) cannot be reached this way and is covered by the
+ * driver-dispatch assertion below plus, eventually, T-02 (roadmap 4.4).
+ */
+#[Group('T-02')]
+#[RequiresPhpExtension('pdo_sqlite')]
+final class DatabaseConnectionTest extends TestCase
+{
+    private function connect(): DatabaseConnection
+    {
+        $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
+        $connection->execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)');
+
+        return $connection;
+    }
+
+    public function testErrorModeIsPinnedToExceptions(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+
+        new DatabaseConnection($pdo);
+
+        self::assertSame(PDO::ERRMODE_EXCEPTION, $pdo->getAttribute(PDO::ATTR_ERRMODE));
+    }
+
+    public function testDefaultFetchModeIsPinnedToAssoc(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_BOTH);
+
+        new DatabaseConnection($pdo);
+
+        self::assertSame(PDO::FETCH_ASSOC, $pdo->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE));
+    }
+
+    /**
+     * Note what this does and does not cover: `select()` passes `FETCH_ASSOC` to `fetchAll()`
+     * explicitly, so this passes even if the *pinned default* were removed. It is a regression
+     * test for `select()`'s own contract. The pin itself is covered by
+     * {@see self::testThePinnedFetchModeAppliesToStatementsRunOnTheRawPdo()}, which was added
+     * after deliberately removing the pin and finding this test still green.
+     */
+    public function testSelectReturnsAssociativeArraysOnly(): void
+    {
+        $connection = $this->connect();
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]);
+
+        $rows = $connection->select('SELECT name, age FROM users');
+
+        // FETCH_BOTH would additionally carry 0 and 1; asserting the exact key set is the point.
+        self::assertSame([['name' => 'Grace', 'age' => 45]], $rows);
+    }
+
+    /**
+     * The pinned fetch mode has to reach statements the *consumer* runs, not just this class's own
+     * helpers — that is the whole value of pinning a default on a connection someone else owns.
+     */
+    public function testThePinnedFetchModeAppliesToStatementsRunOnTheRawPdo(): void
+    {
+        $connection = $this->connect();
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]);
+
+        // No fetch mode passed anywhere here: whatever comes back is the pinned default's doing.
+        $statement = $connection->pdo()->query('SELECT name, age FROM users');
+        self::assertNotFalse($statement);
+
+        self::assertSame([['name' => 'Grace', 'age' => 45]], $statement->fetchAll());
+    }
+
+    public function testConstructorIsAcceptedOnADriverWithNoEmulationConcept(): void
+    {
+        // SQLite returns false from setAttribute(ATTR_EMULATE_PREPARES) and throws when the
+        // attribute is read back. That combination means "no such concept", not "refused", and
+        // must not be treated as a failure to pin.
+        $this->expectNotToPerformAssertions();
+
+        new DatabaseConnection(new PDO('sqlite::memory:'));
+    }
+
+    /**
+     * The security branch no reachable real driver exercises.
+     *
+     * SQLite cannot emulate prepares and MySQL honours the attribute, so without a stand-in the
+     * refusal path in `requireRealPrepares()` would never run — the most security-relevant
+     * behaviour in FR-06 would be present, plausible, and completely unexecuted by the suite.
+     */
+    public function testAConnectionStillEmulatingPreparesIsRefused(): void
+    {
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessageMatches('/still emulating prepared statements/');
+
+        new DatabaseConnection(new StubbornlyEmulatingPdo());
+    }
+
+    public function testDriverNameIsReported(): void
+    {
+        self::assertSame('sqlite', $this->connect()->driver());
+    }
+
+    public function testPdoAccessorReturnsTheSameConnection(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+
+        self::assertSame($pdo, (new DatabaseConnection($pdo))->pdo());
+    }
+
+    public function testSelectOneReturnsNullRatherThanFalseWhenThereIsNoRow(): void
+    {
+        self::assertNull($this->connect()->selectOne('SELECT * FROM users WHERE id = ?', [404]));
+    }
+
+    public function testSelectOneReturnsTheFirstRow(): void
+    {
+        $connection = $this->connect();
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]);
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]);
+
+        self::assertSame(['id' => 1, 'name' => 'Ada', 'age' => 36], $connection->selectOne('SELECT * FROM users ORDER BY id'));
+    }
+
+    public function testExecuteReportsAffectedRows(): void
+    {
+        $connection = $this->connect();
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]);
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]);
+
+        self::assertSame(2, $connection->execute('UPDATE users SET age = age + 1'));
+    }
+
+    public function testNamedParametersBind(): void
+    {
+        $connection = $this->connect();
+        $connection->execute('INSERT INTO users (name, age) VALUES (:name, :age)', ['name' => 'Ada', 'age' => 36]);
+
+        self::assertSame([['name' => 'Ada']], $connection->select('SELECT name FROM users WHERE age = :age', ['age' => 36]));
+    }
+
+    /**
+     * The point of pinning real prepares: a value that looks like SQL is data, not syntax.
+     *
+     * With emulation on, this string would be interpolated into the statement text client-side
+     * before the driver ever saw it. Bound, it can only ever be a value — so the row is stored
+     * and read back verbatim, and the table it names is still there.
+     */
+    public function testAValueThatLooksLikeSqlIsStoredAsData(): void
+    {
+        $connection = $this->connect();
+        $payload = "Robert'); DROP TABLE users;--";
+
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]);
+
+        self::assertSame($payload, $connection->selectOne('SELECT name FROM users')['name'] ?? null);
+        self::assertSame([['n' => 1]], $connection->select('SELECT COUNT(*) AS n FROM users'));
+    }
+
+    public function testAFailingStatementRaisesTheLibraryException(): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $this->connect()->select('SELECT * FROM a_table_that_does_not_exist');
+    }
+
+    public function testTheFailureCarriesThePdoExceptionAsItsCause(): void
+    {
+        try {
+            $this->connect()->select('THIS IS NOT SQL');
+            self::fail('expected a DatabaseException');
+        } catch (DatabaseException $e) {
+            self::assertInstanceOf(\PDOException::class, $e->getPrevious());
+        }
+    }
+
+    /**
+     * A failing statement's text is the most likely place for data that should not reach a log.
+     */
+    public function testTheFailureMessageDoesNotEchoTheStatement(): void
+    {
+        try {
+            $this->connect()->select('SELECT * FROM missing_table WHERE secret = 1');
+            self::fail('expected a DatabaseException');
+        } catch (DatabaseException $e) {
+            self::assertStringNotContainsString('secret', $e->getMessage());
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Database/Fixture/StubbornlyEmulatingPdo.php
+++ b/src/test/php/d4np/utils/Database/Fixture/StubbornlyEmulatingPdo.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database\Fixture;
+
+use PDO;
+
+/**
+ * A driver that claims to support emulated prepares and refuses to turn them off.
+ *
+ * No real driver reachable from this test suite behaves this way — MySQL honours the attribute,
+ * and SQLite has no emulation mode at all — which is exactly why this exists. The branch in
+ * {@see \D4np\Utils\Database\DatabaseConnection} that *refuses a connection* rather than proceed
+ * with client-side interpolation is the single most security-relevant line in spec FR-06's
+ * implementation, and without this fixture nothing would ever execute it.
+ *
+ * It is deliberately a subclass of a real `PDO` on a real SQLite connection rather than a mock:
+ * everything except the two overridden attribute calls behaves like the genuine article.
+ */
+final class StubbornlyEmulatingPdo extends PDO
+{
+    public function __construct()
+    {
+        parent::__construct('sqlite::memory:');
+    }
+
+    public function setAttribute(int $attribute, mixed $value): bool
+    {
+        if ($attribute === PDO::ATTR_EMULATE_PREPARES) {
+            return false;
+        }
+
+        return parent::setAttribute($attribute, $value);
+    }
+
+    public function getAttribute(int $attribute): mixed
+    {
+        // The distinguishing signal: this driver *does* answer for the attribute (so it has the
+        // concept) and reports that it is still emulating.
+        if ($attribute === PDO::ATTR_EMULATE_PREPARES) {
+            return true;
+        }
+
+        return parent::getAttribute($attribute);
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item 4.1, opening Milestone 4. Wraps a **consumer-owned** `PDO` (RFC-0001: the library owns no persistent state and opens no connections) and pins spec FR-06's four defaults on it — `ERRMODE_EXCEPTION`, real prepares, `FETCH_ASSOC`, `SET NAMES utf8mb4` on MySQL — **refusing** the connection when one cannot be applied.

### The reason refusal matters

Probed before designing: **`PDO::setAttribute()` signals refusal by returning `false`, not by throwing.** The natural implementation — four `setAttribute()` calls in a row — would let a security-relevant default fail *silently*, which is exactly what FR-06 exists to prevent.

And that `false` is ambiguous:

| driver | `setAttribute(ATTR_EMULATE_PREPARES, false)` | meaning |
|---|---|---|
| SQLite | `false` | no emulation concept at all — **fine** |
| a driver that declined | `false` | client-side interpolation still on — **security failure** |

Reading the attribute back separates them: `getAttribute()` **throws** `SQLSTATE[IM001]` for the first, returns `true` for the second.

### Order is a security property, not tidiness

`SET NAMES` is the classic *wrong* answer to charset configuration — but only when the client is also escaping, because the client library's notion of the charset doesn't change with it and a multibyte charset can smuggle a quote past client-side escaping. With emulation already off there's no client-side escaping left to fool. **Real prepares is what licenses `SET NAMES`**; reordering them reintroduces a real vulnerability.

ADR-0014 also records that the *better* mechanism (`charset=utf8mb4` in the DSN) is genuinely unreachable here — the connection already exists by the time this class sees it — so a reader who knows that doesn't assume carelessness.

## Test plan

- [x] **Tested the branch no reachable driver executes.** SQLite has no emulation mode, MySQL honours the attribute — so the refusal path would have been present, plausible and never run. `StubbornlyEmulatingPdo` (a real `PDO` overriding exactly two attribute calls) exists solely to run it.
- [x] **Four planted probes**, all caught: no `FETCH_ASSOC` pin; no `ERRMODE` pin; treating every `false` as fatal (breaks all 6 SQLite tests); leaking SQL into the message.
- [x] **One probe found a real hole in my own test** — removing the `FETCH_ASSOC` pin did *not* fail the row-shape test, because `select()` passes `FETCH_ASSOC` to `fetchAll()` explicitly. That test covered `select()`'s contract, not the pin, while its name claimed otherwise. Renamed, and `testThePinnedFetchModeAppliesToStatementsRunOnTheRawPdo` added (runs through `pdo()` with no fetch mode passed anywhere). Re-ran the probe: two failures now instead of one.
- [x] `vendor/bin/phpunit` — 274 tests, 509 assertions, 7 skipped
- [x] PHPStan max clean · deptrac 0 violations / 0 uncovered (the 3.6 gate now constrains a second real group) · consistency + action-pin lints OK
- [ ] CI

## Known gap, stated rather than papered over

`SET NAMES utf8mb4` is MySQL-only and there's no MySQL server in CI, so **that line is unexecuted by the suite** — only the driver dispatch around it is tested. Recorded in ADR-0014, the roadmap note and the journal; a real driver matrix belongs to **T-02 (item 4.4)**.

Also deliberate: the failing SQL is **not** in the exception message, since a failing statement's text is the likeliest place for data that shouldn't reach a log. Driver message and SQLSTATE survive as `getPrevious()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)