### PR TITLE
feat(database): QueryBuilder with a refusing identifier allowlist and closed keywords

### DIFF
--- a/.eados-core/learning/runs/2026-08-04-utils.yaml
+++ b/.eados-core/learning/runs/2026-08-04-utils.yaml
@@ -1,0 +1,36 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-04"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}
+route_mismatch:
+  routed: "frontier-reasoning/extra"
+  session: "standard"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,20 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   recorded honestly rather than adjusted to pass, shipped non-blocking by explicit maintainer
   decision, with closing the gap filed as roadmap item 3.7. The `benchmark` CI job (self-skipped
   since item 1.9) is now active, since `phpbench.json.dist` exists.
+- `D4np\Utils\Database\QueryBuilder`, `Sort` and `Operator` (**ADR-0015**) — RFC-0001's second
+  security mechanism: prepared statements bind *values*, never table or column names, so an
+  identifier has nothing to hide behind and the allowlist is the whole defence. Identifiers are
+  **refused** (`DatabaseException`), never sanitised, then driver-quoted (backticks on MySQL,
+  brackets on SQL Server, double quotes elsewhere). Values always bind. `LIMIT`/`OFFSET` are `int`
+  by signature and refused when negative rather than clamped.
+  **Security fix found while building it:** spec FR-07 writes the allowlist as
+  `^[A-Za-z_][A-Za-z0-9_]*$`, and transcribed literally into PHP that is a **bypass** — PCRE's `$`
+  also matches before a trailing newline, so `"id\n"` passed and rendered as
+  `SELECT "id\n" FROM "users"`. The pattern is anchored with `\z` instead, implementing FR-07's
+  intent rather than copying its notation; ADR-0015 records it so nobody restores `$` for spec
+  fidelity. `Operator` is likewise an extension of FR-07 rather than a silent addition: FR-07 makes
+  the `ORDER BY` direction an enum because it is concatenated into the SQL text and cannot be
+  bound, and a comparison operator is concatenated for exactly the same reason.
 - `D4np\Utils\Database\DatabaseConnection` (**ADR-0014**) — opens Milestone 4. Wraps a
   **consumer-owned** `PDO` (RFC-0001: the library opens no connections) and pins spec FR-06's four
   safe defaults: `ERRMODE_EXCEPTION`, real prepares (`EMULATE_PREPARES=false`), `FETCH_ASSOC`, and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Milestone 4 opens: the security default that fails by returning false](docs/journal/2026/08/2026-08-04-pinned-pdo-defaults.md).
+  [2026-08-04 — The spec's own regex was the vulnerability](docs/journal/2026/08/2026-08-04-querybuilder-allowlist.md).
 
 ## Model & effort routing (advisory)
 
@@ -205,9 +205,18 @@ Safe-by-default PDO access (RFC-0001).
       load-bearing: real prepares must be off before `SET NAMES utf8mb4`, because `SET NAMES` is
       only safe once there is no client-side escaping left to fool. Honest gap: the MySQL-only
       `SET NAMES` path is unexecuted by the suite (no MySQL in CI) — T-02 (item 4.4) owns that.*
-- [ ] 4.2 `QueryBuilder`: bound values, identifier allowlist + driver quoting, `Sort` enum,
+- [x] 4.2 `QueryBuilder`: bound values, identifier allowlist + driver quoting, `Sort` enum,
       int-cast LIMIT/OFFSET (RFC-0001) (security — protected floor) —
-      route: frontier-reasoning / extra
+      route: frontier-reasoning / extra · **ADR-0015**. *Route mismatch accepted by the maintainer
+      and recorded (`record_run.py --route-mismatch "frontier-reasoning/extra=standard"`).
+      **Finding: FR-07's allowlist `^[A-Za-z_][A-Za-z0-9_]*$` transcribed literally is a bypass** —
+      PCRE's `$` matches before a trailing newline, so `"id\n"` rendered as
+      `SELECT "id\n" FROM "users"`. Anchored with `\z`; the spec's intent implemented rather than
+      its notation copied. Also adds `Operator` as an enum — FR-07 closes the ORDER BY keyword for
+      a reason that applies identically to comparison operators, which it does not mention. 17
+      hostile payloads × 4 identifier surfaces; suite proved non-vacuous with 4 planted defects.
+      Closes half of item 4.1's declared gap: `SET NAMES utf8mb4` is now asserted issued for MySQL
+      and not for others.*
 - [ ] 4.3 `Transaction`: closure scope, rollback+rethrow, savepoints (RFC-0001)
       (severity:medium) — route: standard / medium
 - [ ] 4.4 T-02 injection suite (values / identifiers / LIKE wildcards) + T-04 transaction

--- a/docs/adr/0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md
+++ b/docs/adr/0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md
@@ -1,0 +1,161 @@
+# ADR-0015: Refuse identifiers rather than escape them, close every keyword, and anchor the allowlist with `\z`
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 4.2 · spec FR-07, FR-10 · item 4.4 (T-02) ·
+  [RFC-0001](../rfc/0001-egl-utils-library.md) §Context (security mechanism 2) ·
+  [ADR-0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) (mechanism 1) ·
+  [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md)
+
+## Context
+
+RFC-0001's security model has four mechanisms. ADR-0014 implemented the first (parameterised
+values, via pinned PDO defaults). This is the second, and it exists because of a fact the first
+cannot cover:
+
+> **Persistence (identifiers): allowlist + strict driver quoting (prepared statements do not cover
+> table/column names).**
+
+A placeholder is not legal SQL where an identifier goes. There is no `?` for a column name. So an
+identifier arriving from user input has nothing to hide behind, and the allowlist is not one
+defence among several — it is the whole of it.
+
+Spec FR-07 specifies the allowlist as `^[A-Za-z_][A-Za-z0-9_]*$`.
+
+## Decision
+
+**Refuse anything that is not a bare identifier; close every keyword that reaches the SQL text;
+anchor the allowlist with `\z`.**
+
+### The allowlist is anchored with `\z`, not `$` — and that is not a transcription liberty
+
+Transcribed into PHP literally, FR-07's pattern **has a hole**. PCRE's `$` also matches
+immediately before a trailing newline, so `"id\n"` satisfies `^[A-Za-z_][A-Za-z0-9_]*$`.
+
+This was not reasoned about in the abstract — it was verified against the built class, which
+happily produced:
+
+```
+SELECT "id\n" FROM "users"
+```
+
+past an allowlist that is supposed to be the only thing between an identifier and the statement.
+The suite did not catch it either: the hostile-identifier matrix had a newline payload, but with
+content *after* the newline, which fails the pattern for an unrelated reason.
+
+`\z` admits nothing after the final character. **The decision is to implement FR-07's intent
+rather than copy its notation**, and to record that here loudly enough that nobody later
+"corrects" the pattern back to `$` for fidelity to the spec's wording. The pattern constant in
+`QueryBuilder` carries the same warning at the point of temptation.
+
+Practical severity of the original hole was low — the smuggled newline landed *inside* a quoted
+identifier, so it produced an unresolvable column rather than an injection — but that is an
+argument for the second layer having done its job, not for the first layer's hole being
+acceptable.
+
+### Identifiers are refused, not sanitised
+
+A failing identifier raises `DatabaseException`. It is not stripped, truncated, or escaped-and-
+accepted. Sanitising here would mean silently querying a *different* column than asked for, and an
+identifier that came from user input is a vulnerability report, not an input to clean up — the
+message says so, and points at mapping input to a known column at the call site.
+
+### Every keyword that reaches the SQL text is a closed type
+
+FR-07 asks for the `ORDER BY` direction to be an enum, for one reason: it is concatenated into
+the SQL text and cannot be bound. **A comparison operator is concatenated into the SQL text for
+exactly the same reason**, and FR-07 does not mention it. So `Operator` exists alongside `Sort`.
+
+A `where(string $column, string $operator, mixed $value)` signature would bind the value safely,
+allowlist the column safely, and leave an unchecked string spliced between them — the more
+dangerous for looking harmless next to two carefully-handled parameters. Applying the spec's own
+stated pattern to the case it missed is a smaller decision than inventing an operator allowlist,
+which is why it is this and not that. Recorded as an **extension of FR-07**, not a silent addition.
+
+`IN`, `IS NULL` and `IS NOT NULL` are separate builder methods rather than enum arms, because each
+needs a different number of placeholders (many, and none) and an enum arm would silently bind the
+wrong count.
+
+### Quoting is kept, and is not merely decorative
+
+Identifiers are wrapped in the driver's quoting characters — backticks (MySQL), brackets (SQL
+Server family), double quotes (everyone else) — with the quote character doubled inside.
+
+This class's first draft documented that escaping as *unreachable by construction*, since an
+allowlisted identifier holds no quote character. The `\z` incident above is the counter-example:
+for as long as the allowlist had a hole, the quoting is what kept the smuggled character contained.
+The claim was corrected in place rather than deleted, because "the allowlist makes this
+unreachable" is a claim about a regex being perfect, and the second layer costs nothing.
+
+Quoting is also what makes a legal-but-reserved word (`order`, `select`) usable as a column name.
+
+`PDO::quote()` is **not** used and cannot be: it produces a string *literal* (`'id'`), so quoting
+an identifier with it yields a constant rather than a column reference — a silent wrong answer
+rather than an error. Verified rather than assumed.
+
+### `LIMIT`/`OFFSET` are refused when negative, not clamped
+
+FR-07 says *"cast to non-negative int"*. `DatabaseException`'s own docblock, written back at item
+2.1, already said the stricter thing: *"a `LIMIT`/`OFFSET` that is not a non-negative integer"* is
+a refusal. That is followed. A negative value here means the caller computed it wrongly, and
+silently returning a different page than the one asked for would hide the bug rather than surface
+it. `int` by signature already excludes the string path.
+
+They are rendered as literals rather than bound, which is safe *because* of that refusal, and is
+in any case forced: several drivers reject a bound parameter in `LIMIT` once prepares are real —
+which ADR-0014 pins.
+
+### Qualified names are refused for now
+
+`users.id` does not match, deliberately. FR-07's allowlist has no `.`, this builder has no `JOIN`,
+and a single-table query never needs the qualification. Accepting it later — by validating each
+dot-separated part — widens the allowlist and stays backward compatible; the reverse would not.
+
+## Alternatives Considered
+
+- **Escape identifiers instead of refusing them** — rejected. Quoting is not a substitute for the
+  allowlist: it makes a hostile name *inert*, not *correct*, and the caller still gets a query
+  against a column nobody meant. RFC-0001 says allowlist **and** quoting, in that order.
+- **Copy FR-07's `$` verbatim for spec fidelity** — rejected on the evidence: it is a real bypass
+  in PCRE. Fidelity to a specification's intent beats fidelity to its notation when the two
+  disagree and the notation is the one that is wrong.
+- **`where()` taking a string operator with a runtime allowlist** — rejected in favour of the enum:
+  same protection, but checked by the type system instead of at run time, and consistent with the
+  `Sort` decision FR-07 already made.
+- **Mutable builder** — rejected: an immutable builder can be held, shared and reused as a base
+  query without a later call mutating it under its holder.
+- **Rendering `IN ()` or silently dropping an empty `whereIn()`** — rejected, and the reasoning is
+  in the exception message: matching nothing would be an accident rather than a decision, and
+  dropping the condition would silently **widen** the result set. A filter that quietly stops
+  filtering is the worse failure.
+- **Binding `LIMIT`/`OFFSET`** — not available; real prepares reject it on several drivers.
+
+## Consequences
+
+- Identifier injection is a refusal with a message that names the actual problem. 17 hostile
+  payloads × 4 identifier surfaces (table, `select`, `where`, `orderBy`) are asserted, including
+  the trailing-newline case that this ADR exists partly to record.
+- **The suite is verified non-vacuous.** Four planted defects, each caught and reverted: weakening
+  the allowlist to `/.*/ ` (76 failures), interpolating the value instead of binding it (3),
+  allowing a negative `LIMIT` (2), and dropping MySQL's backtick arm (1).
+- Driver-specific quoting is asserted on rendered SQL rather than by execution, because SQLite —
+  the only driver available in CI — accepts double quotes, backticks *and* brackets, so a query
+  built with entirely the wrong style still runs. `PretendDriverPdo` reports a chosen driver name
+  over a real SQLite connection to make the choice observable.
+- That same fixture closes half of the gap item 4.1 declared: `SET NAMES utf8mb4` is now asserted
+  to be issued for MySQL and *not* issued for other drivers. It still does not prove a real MySQL
+  server accepts it — the driver matrix remains T-02's (item 4.4).
+- PHPStan at max level surfaced that a variadic is not a `list`: PHP 8.1 permits named arguments
+  into one (`select(first: 'id')`), producing string keys. Fixed with `array_values()`.
+- No `JOIN`, `GROUP BY`, `HAVING` or aggregate support. FR-07 does not ask for them, and each adds
+  identifier surfaces that would need the same treatment.
+
+## References
+
+- Spec FR-07 (the allowlist, the enum, `LIMIT`/`OFFSET`), FR-10 (`LIKE` wildcards — `Operator::Like`
+  binds the value but wildcard-injection is `Sanitizer::sqlLikePattern()`'s problem, milestone 5)
+- RFC-0001 §Context, security mechanism 2 — allowlist + strict driver quoting
+- ADR-0014 — mechanism 1, and the pinned real prepares that make `LIMIT` un-bindable
+- Verified directly: PCRE `$` vs `\z` on `"id\n"`; `PDO::quote()` producing a string literal
+  (PHP 8.3.1)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0012](0012-enforce-the-layering-rule-by-directory-over-src-main.md) | Enforce RFC-0001's layering rule by directory, over `src/main` only | Accepted |
 | [0013](0013-compile-a-hydration-closure-for-the-scalar-shape.md) | Compile a hydration closure for the scalar shape, keep the interpreter for everything else | Accepted |
 | [0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) | Pin PDO's safe defaults on a consumer-owned connection, and refuse one that will not take them | Accepted |
+| [0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) | Refuse identifiers rather than escape them, close every keyword, and anchor the allowlist with `\z` | Accepted |

--- a/docs/journal/2026/08/2026-08-04-querybuilder-allowlist.md
+++ b/docs/journal/2026/08/2026-08-04-querybuilder-allowlist.md
@@ -1,0 +1,112 @@
+# 2026-08-04 — The spec's own regex was the vulnerability
+
+Roadmap item **4.2**. Route: `frontier-reasoning / extra`; session is Opus 5 (standard). I flagged
+the mismatch when closing 4.1; the maintainer said proceed, so it is accepted and recorded —
+`record_run.py --route-mismatch "frontier-reasoning/extra=standard"` — rather than left as a silent
+divergence.
+
+## Why this class is the whole defence
+
+RFC-0001's security model has four mechanisms. ADR-0014 did the first. This is the second, and it
+exists because of one fact:
+
+> prepared statements bind **values**, never table or column names.
+
+There is no `?` for a column name. An identifier arriving from user input has nothing to hide
+behind, so the allowlist isn't one layer among several — it *is* the layer.
+
+## The finding
+
+Spec FR-07 specifies the allowlist as `^[A-Za-z_][A-Za-z0-9_]*$`. I transcribed it literally.
+Then, before trusting it, I checked what PCRE actually does with `$`:
+
+```
+"id"      => 1
+"id\n"    => 1     <-- PCRE's `$` matches before a trailing newline
+"id\r\n"  => 0
+```
+
+Against the built class:
+
+```
+SELECT "id\n" FROM "users"
+>>> ALLOWLIST BYPASSED
+```
+
+**The spec's own regex, implemented faithfully, is a bypass.** Anchored with `\z` — which admits
+nothing after the final character — it refuses. That's FR-07's *intent* implemented rather than its
+*notation* copied, and it's recorded in ADR-0015 and in a comment on the constant itself, because
+the obvious future "fix" is someone restoring `$` for fidelity to the spec text.
+
+Two things worth being honest about:
+
+**My own suite missed it.** The hostile-identifier matrix already had a newline payload —
+`"id\nDROP TABLE users"` — which fails the pattern, but for an unrelated reason (the content after
+the newline). A trailing newline is the case that slips through, and I only found it by checking
+the regex engine's semantics rather than by testing the payloads I'd thought of. Both cases are in
+the matrix now.
+
+**Practical severity was low, and that is the second layer's doing, not the first's.** The smuggled
+newline landed *inside* a quoted identifier, so it produced an unresolvable column rather than an
+injection. Which forced me to correct something I'd written an hour earlier.
+
+## Correcting my own docblock
+
+The first draft of `QueryBuilder` said the quote-escaping was *"by construction unreachable"* —
+an allowlisted identifier holds no quote character, so there is nothing to escape. That reads well
+and it was wrong in a specific way: it's a claim that a regex is perfect. For as long as the
+allowlist had a hole, the quoting is what contained it.
+
+Corrected in place rather than deleted, with the incident as the reason. The second layer costs
+nothing and it earned its keep within a single item.
+
+## An enum the spec doesn't ask for
+
+FR-07 makes the `ORDER BY` direction an enum for a stated reason: it's concatenated into the SQL
+text and can't be bound. A comparison operator is concatenated into the SQL text for *exactly the
+same reason*, and FR-07 says nothing about it.
+
+A `where(string $column, string $operator, mixed $value)` would bind the value safely, allowlist
+the column safely, and leave an unchecked string spliced between the two — more dangerous for
+looking harmless next to two carefully-handled parameters. So `Operator` exists. Applying the
+spec's own pattern to the case it missed is a smaller decision than inventing an operator
+allowlist, and it's recorded as an extension rather than slipped in.
+
+## Things checked instead of assumed
+
+- **`PDO::quote()` is useless for identifiers** — it returns `'id'`, a string *literal*. Quoting an
+  identifier with it yields a constant instead of a column reference: a silent wrong answer.
+- **SQLite is a bad witness for quoting.** It accepts double quotes, backticks *and* brackets, so a
+  query built in entirely the wrong style still runs. Executing one proves nothing about whether
+  the right style was chosen — so driver quoting is asserted on the rendered SQL, via
+  `PretendDriverPdo` (a real SQLite connection reporting a chosen driver name).
+- **A variadic is not a `list`.** PHPStan max caught it: PHP 8.1 allows named arguments into a
+  variadic (`select(first: 'id')`), producing string keys. `array_values()`.
+
+## Closing half of 4.1's declared gap
+
+Item 4.1 shipped `SET NAMES utf8mb4` unexecuted by any test and said so. `PretendDriverPdo` closes
+the closeable half: it's now asserted that the statement is issued for MySQL and *not* issued for
+other drivers. It still doesn't prove a real MySQL server accepts it — that stays with T-02's
+driver matrix (item 4.4).
+
+## Non-vacuity
+
+Four planted defects, each caught and reverted, blast radius in brackets:
+
+| planted | failures |
+|---|---|
+| allowlist weakened to `/.*/` | 76 |
+| value interpolated instead of bound | 3 |
+| negative `LIMIT`/`OFFSET` allowed | 2 |
+| MySQL's backtick arm removed | 1 |
+
+## Bar
+
+374 tests / 618 assertions green (up from 274). `--group T-02` runs 116 as a unit. PHPStan max
+clean, deptrac 0/0 with 68 allowed edges, consistency lint OK.
+
+## Next
+
+**4.3** `Transaction` — closure scope, rollback + rethrow, savepoint nesting. Routed
+`standard / medium`.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — The spec's own regex was the vulnerability](2026/08/2026-08-04-querybuilder-allowlist.md)
 - [2026-08-04 — Milestone 4 opens: the security default that fails by returning false](2026/08/2026-08-04-pinned-pdo-defaults.md)
 - [2026-08-04 — Measuring what was reachable before deciding what to build](2026/08/2026-08-04-nfr01-compiled-hydration.md)
 - [2026-08-04 — Enforcing a rule two ADRs had already been obeying by hand](2026/08/2026-08-04-deptrac-layering-gate.md)

--- a/src/main/php/d4np/utils/Database/Operator.php
+++ b/src/main/php/d4np/utils/Database/Operator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Database;
+
+/**
+ * A comparison operator in a `WHERE` clause.
+ *
+ * **Spec FR-07 does not ask for this enum. It asks for {@see Sort}, and this is the same
+ * requirement applied to the same threat.**
+ *
+ * FR-07 makes the `ORDER BY` direction an enum for one reason: the direction is concatenated into
+ * the SQL text and therefore cannot be a bound parameter. A comparison operator is concatenated
+ * into the SQL text for exactly the same reason. A `where(string $column, string $operator, mixed
+ * $value)` signature would bind the *value* safely, allowlist the *column* safely, and leave the
+ * operator as an unchecked string spliced between them — an injection point in the middle of a
+ * builder whose whole purpose is not to have one, and the more dangerous for looking harmless
+ * next to two parameters that are carefully handled.
+ *
+ * Following the spec's own stated pattern is the smaller decision here than inventing an operator
+ * allowlist, so this enum exists and `QueryBuilder::where()` takes it. Recorded in ADR-0015 as an
+ * extension of FR-07 rather than a silent addition.
+ *
+ * `IN`, `IS NULL` and `IS NOT NULL` are deliberately absent: each needs a different number of
+ * placeholders (many, and none), so they are separate methods on the builder rather than arms of
+ * this enum that would silently bind the wrong thing.
+ */
+enum Operator: string
+{
+    case Equals = '=';
+    case NotEquals = '<>';
+    case LessThan = '<';
+    case LessThanOrEqual = '<=';
+    case GreaterThan = '>';
+    case GreaterThanOrEqual = '>=';
+
+    /**
+     * Pattern matching.
+     *
+     * The value still binds as a parameter, so the *pattern* cannot inject SQL. What it can still
+     * do is inject **wildcards**: a user-supplied `%` turns an equality-like lookup into a prefix
+     * scan, which is a real problem (unbounded scans, and matching rows a user should not see).
+     * That is spec FR-10's job — `Sanitizer::sqlLikePattern()`, milestone 5 — and is not solved
+     * by binding alone. Named here so a caller reaching for `Like` is pointed at it.
+     */
+    case Like = 'LIKE';
+}

--- a/src/main/php/d4np/utils/Database/QueryBuilder.php
+++ b/src/main/php/d4np/utils/Database/QueryBuilder.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Database;
+
+use D4np\Utils\Support\DatabaseException;
+
+/**
+ * A fluent `SELECT` builder that binds every value and allowlists every identifier (spec FR-07,
+ * ADR-0015).
+ *
+ * RFC-0001's security model has four mechanisms; this class is the second one, and it exists
+ * because of a fact the first one cannot cover: **prepared statements bind values, never table or
+ * column names.** A parameter placeholder is not legal SQL where an identifier goes, so an
+ * identifier that reaches this builder from user input has no binding to hide behind. The
+ * allowlist is the whole defence, which is why it is a refusal rather than an escape:
+ *
+ * - **Values** — always bound (`?` placeholders, {@see self::bindings()}). No method on this class
+ *   concatenates a value into the SQL text.
+ * - **Identifiers** — must match `^[A-Za-z_][A-Za-z0-9_]*$` exactly, or a {@see DatabaseException}
+ *   is raised. Not sanitised, not truncated, not quoted-and-hoped: **refused**.
+ * - **Keywords** — the `ORDER BY` direction and the comparison operator are closed enums
+ *   ({@see Sort}, {@see Operator}), so no caller-supplied string reaches the SQL text at all.
+ * - **`LIMIT`/`OFFSET`** — `int` by signature, and negative values are refused.
+ *
+ * **On quoting.** Identifiers are additionally wrapped in the driver's own quoting characters
+ * (backticks on MySQL, brackets on SQL Server, double quotes elsewhere), with the quote character
+ * doubled inside. It is tempting to call that escaping unreachable — an identifier that passed the
+ * allowlist holds only letters, digits and underscores, so there is no quote character left to
+ * escape — and this class's first draft said exactly that.
+ *
+ * It was wrong, and the way it was wrong is worth keeping: FR-07's allowlist transcribed literally
+ * admitted `"id\n"`, because PCRE's `$` matches before a trailing newline (see
+ * {@see self::IDENTIFIER}). For as long as that hole was open, the quoting is what kept the
+ * smuggled character inside a quoted identifier instead of loose in the statement. The anchor is
+ * fixed now, but the lesson stands: "the allowlist makes this unreachable" is a claim about a
+ * regex being perfect, and the second layer costs nothing. Quoting is also what lets a
+ * legal-but-reserved word (`order`, `select`) be used as a column name at all.
+ *
+ * Note that `PDO::quote()` is **not** used, and could not be: it produces a string *literal*
+ * (`'id'`), so quoting an identifier with it yields a constant rather than a column reference —
+ * a silent wrong answer rather than an error. Verified rather than assumed.
+ *
+ * Instances are immutable; every method returns a new builder, so a partially-built query can be
+ * shared or reused without a later call mutating it under its holder.
+ */
+final class QueryBuilder
+{
+    /**
+     * Spec FR-07 writes this allowlist as `^[A-Za-z_][A-Za-z0-9_]*$`. Transcribed into PHP
+     * literally, **that pattern has a hole**: PCRE's `$` also matches immediately before a
+     * trailing newline, so `"id\n"` satisfies it. Verified directly — it rendered as
+     * `SELECT "id\n" FROM "users"`, past an allowlist that is supposed to be the only thing
+     * standing between an identifier and the SQL text.
+     *
+     * `\z` anchors at the true end of the subject and admits nothing after the last character.
+     * This is the spec's *intent* implemented rather than its notation copied; ADR-0015 records
+     * the difference so nobody later "corrects" it back to `$` for fidelity to FR-07's wording.
+     */
+    private const IDENTIFIER = '/^[A-Za-z_][A-Za-z0-9_]*\z/';
+
+    /** @var list<string> */
+    private array $columns = [];
+
+    /** @var list<string> */
+    private array $conditions = [];
+
+    /** @var list<mixed> */
+    private array $bindings = [];
+
+    /** @var list<string> */
+    private array $orderBy = [];
+
+    private ?int $limit = null;
+
+    private ?int $offset = null;
+
+    /**
+     * @throws DatabaseException if the table name fails the allowlist
+     */
+    public function __construct(
+        private readonly DatabaseConnection $connection,
+        private readonly string $table,
+    ) {
+        $this->identifier($table);
+    }
+
+    /**
+     * The columns to select. No arguments — or never calling this — selects `*`.
+     *
+     * @throws DatabaseException if any column fails the allowlist
+     */
+    public function select(string ...$columns): self
+    {
+        $clone = clone $this;
+        // array_values() because a variadic is not necessarily a list: PHP 8.1 lets a caller pass
+        // named arguments into one (`select(first: 'id')`), which produces string keys. PHPStan at
+        // max level is what surfaced that — the keys are discarded here either way, but the
+        // declared `list<string>` has to be true rather than nearly true.
+        $clone->columns = array_values(array_map(fn (string $c): string => $this->identifier($c), $columns));
+
+        return $clone;
+    }
+
+    /**
+     * `WHERE <column> <operator> ?`, with the value bound.
+     *
+     * @throws DatabaseException if the column fails the allowlist
+     */
+    public function where(string $column, Operator $operator, mixed $value): self
+    {
+        $clone = clone $this;
+        $clone->conditions[] = sprintf('%s %s ?', $this->identifier($column), $operator->value);
+        $clone->bindings[] = $value;
+
+        return $clone;
+    }
+
+    /**
+     * `WHERE <column> IN (?, ?, …)`, one placeholder per value.
+     *
+     * An empty list is refused rather than rendered. `IN ()` is a syntax error on most drivers,
+     * and the plausible silent alternatives are both wrong: rendering `IN (NULL)` matches nothing
+     * by accident rather than by intent, and dropping the condition entirely would *widen* the
+     * result set — a filter that silently stops filtering is the more dangerous failure.
+     *
+     * @param list<mixed> $values
+     *
+     * @throws DatabaseException if the column fails the allowlist, or the list is empty
+     */
+    public function whereIn(string $column, array $values): self
+    {
+        if ($values === []) {
+            throw new DatabaseException(sprintf(
+                'whereIn() on "%s" was given an empty list. `IN ()` is not valid SQL, and both '
+                . 'ways of hiding that are wrong: matching nothing would be an accident rather '
+                . 'than a decision, and dropping the condition would silently widen the result '
+                . 'set. Decide at the call site whether an empty list means "no rows".',
+                $column,
+            ));
+        }
+
+        $clone = clone $this;
+        $clone->conditions[] = sprintf(
+            '%s IN (%s)',
+            $this->identifier($column),
+            implode(', ', array_fill(0, count($values), '?')),
+        );
+        foreach ($values as $value) {
+            $clone->bindings[] = $value;
+        }
+
+        return $clone;
+    }
+
+    /**
+     * `WHERE <column> IS NULL`.
+     *
+     * A separate method because `= NULL` is never true in SQL — binding `null` through
+     * {@see self::where()} with {@see Operator::Equals} would produce a condition that silently
+     * matches nothing.
+     *
+     * @throws DatabaseException if the column fails the allowlist
+     */
+    public function whereNull(string $column): self
+    {
+        $clone = clone $this;
+        $clone->conditions[] = $this->identifier($column) . ' IS NULL';
+
+        return $clone;
+    }
+
+    /**
+     * `WHERE <column> IS NOT NULL`.
+     *
+     * @throws DatabaseException if the column fails the allowlist
+     */
+    public function whereNotNull(string $column): self
+    {
+        $clone = clone $this;
+        $clone->conditions[] = $this->identifier($column) . ' IS NOT NULL';
+
+        return $clone;
+    }
+
+    /**
+     * `ORDER BY <column> <ASC|DESC>`. Repeated calls append, left to right.
+     *
+     * @throws DatabaseException if the column fails the allowlist
+     */
+    public function orderBy(string $column, Sort $direction = Sort::Asc): self
+    {
+        $clone = clone $this;
+        $clone->orderBy[] = sprintf('%s %s', $this->identifier($column), $direction->value);
+
+        return $clone;
+    }
+
+    /**
+     * @throws DatabaseException if `$limit` is negative
+     */
+    public function limit(int $limit): self
+    {
+        $clone = clone $this;
+        $clone->limit = $this->nonNegative($limit, 'LIMIT');
+
+        return $clone;
+    }
+
+    /**
+     * @throws DatabaseException if `$offset` is negative
+     */
+    public function offset(int $offset): self
+    {
+        $clone = clone $this;
+        $clone->offset = $this->nonNegative($offset, 'OFFSET');
+
+        return $clone;
+    }
+
+    /**
+     * The SQL this builder represents, with `?` where every value goes.
+     *
+     * Paired with {@see self::bindings()}; the two are only meaningful together, and neither
+     * contains a caller-supplied value.
+     */
+    public function toSql(): string
+    {
+        $sql = sprintf(
+            'SELECT %s FROM %s',
+            $this->columns === [] ? '*' : implode(', ', $this->columns),
+            $this->quote($this->table),
+        );
+
+        if ($this->conditions !== []) {
+            $sql .= ' WHERE ' . implode(' AND ', $this->conditions);
+        }
+
+        if ($this->orderBy !== []) {
+            $sql .= ' ORDER BY ' . implode(', ', $this->orderBy);
+        }
+
+        // Rendered as literals, which is safe only because both are `int` by signature and
+        // already refused if negative — there is no string path to either. Several drivers reject
+        // a bound parameter in LIMIT when prepares are real (which DatabaseConnection pins), so
+        // binding them is not actually an option here.
+        if ($this->limit !== null) {
+            $sql .= ' LIMIT ' . $this->limit;
+        }
+
+        if ($this->offset !== null) {
+            $sql .= ' OFFSET ' . $this->offset;
+        }
+
+        return $sql;
+    }
+
+    /**
+     * The values to bind, in placeholder order.
+     *
+     * @return list<mixed>
+     */
+    public function bindings(): array
+    {
+        return $this->bindings;
+    }
+
+    /**
+     * Run the query and return every row.
+     *
+     * @return list<array<string, mixed>>
+     *
+     * @throws DatabaseException
+     */
+    public function get(): array
+    {
+        return $this->connection->select($this->toSql(), $this->bindings);
+    }
+
+    /**
+     * Run the query and return the first row, or `null`.
+     *
+     * @return array<string, mixed>|null
+     *
+     * @throws DatabaseException
+     */
+    public function first(): ?array
+    {
+        return $this->connection->selectOne($this->toSql(), $this->bindings);
+    }
+
+    /**
+     * Refuse anything that is not a bare identifier, then quote what survives.
+     *
+     * A qualified name (`users.id`) does **not** match, and that is deliberate rather than an
+     * oversight: FR-07's allowlist has no `.` in it, this builder has no `JOIN`, and a single-table
+     * query never needs the qualification. Accepting it later — by validating each dot-separated
+     * part — widens the allowlist and stays backward compatible; having accepted it and needing to
+     * take it back would not.
+     *
+     * @throws DatabaseException
+     */
+    private function identifier(string $name): string
+    {
+        if (preg_match(self::IDENTIFIER, $name) !== 1) {
+            throw new DatabaseException(sprintf(
+                'The identifier "%s" is not allowed. Table and column names cannot be bound as '
+                . 'parameters — a prepared statement has no placeholder for them — so this '
+                . 'builder allows only bare names matching %s and refuses everything else. If '
+                . 'this name came from user input, that is the vulnerability this refusal exists '
+                . 'to stop; map the input to a known column at the call site instead.',
+                $name,
+                self::IDENTIFIER,
+            ));
+        }
+
+        return $this->quote($name);
+    }
+
+    /**
+     * Wrap an already-allowlisted identifier in the driver's quoting characters.
+     *
+     * The doubling below is unreachable for anything that passed {@see self::identifier()} — such
+     * a name has no quote character in it. It is written correctly anyway rather than skipped,
+     * because a quoting function that is only safe when called in the right order is a trap for
+     * whoever calls it next.
+     */
+    private function quote(string $identifier): string
+    {
+        return match ($this->connection->driver()) {
+            'mysql' => '`' . str_replace('`', '``', $identifier) . '`',
+            'sqlsrv', 'dblib', 'mssql' => '[' . str_replace(']', ']]', $identifier) . ']',
+            // The SQL standard's own form, and what SQLite, PostgreSQL, Oracle and the rest use.
+            default => '"' . str_replace('"', '""', $identifier) . '"',
+        };
+    }
+
+    /**
+     * @throws DatabaseException
+     */
+    private function nonNegative(int $value, string $clause): int
+    {
+        if ($value < 0) {
+            throw new DatabaseException(sprintf(
+                '%s must be a non-negative integer, got %d. Refused rather than clamped to 0: a '
+                . 'negative value here means the caller computed it wrongly, and silently '
+                . 'returning a different page than the one asked for would hide that.',
+                $clause,
+                $value,
+            ));
+        }
+
+        return $value;
+    }
+}

--- a/src/main/php/d4np/utils/Database/Sort.php
+++ b/src/main/php/d4np/utils/Database/Sort.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Database;
+
+/**
+ * An `ORDER BY` direction (spec FR-07).
+ *
+ * An enum rather than a string because this value is **concatenated into the SQL text** — it
+ * cannot be a bound parameter, so a `string $direction` would be an injection point sitting in
+ * the middle of a builder whose entire purpose is to not have any. Making it a closed type moves
+ * the check from run time to the type system: there is no value of this type that is not one of
+ * two keywords.
+ *
+ * Spec FR-07 names this design directly (*"ORDER BY direction is an enum"*), and the same
+ * reasoning is why {@see Operator} exists.
+ */
+enum Sort: string
+{
+    case Asc = 'ASC';
+    case Desc = 'DESC';
+}

--- a/src/test/php/d4np/utils/Database/DatabaseConnectionTest.php
+++ b/src/test/php/d4np/utils/Database/DatabaseConnectionTest.php
@@ -6,6 +6,7 @@ namespace D4np\Utils\Tests\Database;
 
 use D4np\Utils\Database\DatabaseConnection;
 use D4np\Utils\Support\DatabaseException;
+use D4np\Utils\Tests\Database\Fixture\PretendDriverPdo;
 use D4np\Utils\Tests\Database\Fixture\StubbornlyEmulatingPdo;
 use PDO;
 use PHPUnit\Framework\Attributes\Group;
@@ -112,6 +113,23 @@ final class DatabaseConnectionTest extends TestCase
         $this->expectExceptionMessageMatches('/still emulating prepared statements/');
 
         new DatabaseConnection(new StubbornlyEmulatingPdo());
+    }
+
+    /**
+     * Item 4.1 shipped this line unexecuted by any test, and said so: `SET NAMES utf8mb4` is
+     * MySQL-only and there is no MySQL server in CI. {@see PretendDriverPdo} closes the half that
+     * is closeable — that the statement is issued, and issued *only* for MySQL. It does not prove
+     * a real MySQL server accepts it; that belongs to T-02's driver matrix (item 4.4).
+     */
+    public function testUtf8mb4IsSetOnMysqlOnly(): void
+    {
+        $mysql = new PretendDriverPdo('mysql');
+        new DatabaseConnection($mysql);
+        self::assertContains('SET NAMES utf8mb4', $mysql->executed);
+
+        $pgsql = new PretendDriverPdo('pgsql');
+        new DatabaseConnection($pgsql);
+        self::assertSame([], $pgsql->executed, 'SET NAMES is MySQL-specific and must not be issued elsewhere');
     }
 
     public function testDriverNameIsReported(): void

--- a/src/test/php/d4np/utils/Database/Fixture/PretendDriverPdo.php
+++ b/src/test/php/d4np/utils/Database/Fixture/PretendDriverPdo.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database\Fixture;
+
+use PDO;
+
+/**
+ * A real SQLite connection that reports itself as some other driver.
+ *
+ * Driver-specific behaviour is otherwise untestable here. Only `pdo_sqlite` is available in CI,
+ * and SQLite is a *particularly* poor witness for identifier quoting because it accepts double
+ * quotes, backticks and brackets alike — a query built with entirely the wrong style still runs,
+ * so executing one proves nothing about whether the right style was chosen.
+ *
+ * This reports a chosen driver name and otherwise behaves like the real SQLite connection
+ * underneath, which lets two things be checked that nothing else here can reach:
+ *
+ * 1. `QueryBuilder` picking the correct quoting characters per driver.
+ * 2. `DatabaseConnection` issuing `SET NAMES utf8mb4` when — and only when — the driver is MySQL.
+ *    Item 4.1 shipped that line unexecuted by any test and said so; this covers the dispatch and
+ *    the statement text.
+ *
+ * **What it does not prove:** that a real MySQL server accepts what we send. This is a stand-in
+ * for driver *dispatch*, not a substitute for the driver matrix T-02 (item 4.4) is meant to bring.
+ */
+final class PretendDriverPdo extends PDO
+{
+    /** @var list<string> every statement passed to exec(), in order */
+    public array $executed = [];
+
+    public function __construct(
+        private readonly string $driverName,
+    ) {
+        parent::__construct('sqlite::memory:');
+    }
+
+    public function getAttribute(int $attribute): mixed
+    {
+        if ($attribute === PDO::ATTR_DRIVER_NAME) {
+            return $this->driverName;
+        }
+
+        return parent::getAttribute($attribute);
+    }
+
+    public function setAttribute(int $attribute, mixed $value): bool
+    {
+        // A real MySQL driver honours this; SQLite underneath would return false and make the
+        // connection look like one that refuses a pinned default, which is a different fixture's
+        // job (see StubbornlyEmulatingPdo).
+        if ($attribute === PDO::ATTR_EMULATE_PREPARES) {
+            return true;
+        }
+
+        return parent::setAttribute($attribute, $value);
+    }
+
+    public function exec(string $statement): int|false
+    {
+        $this->executed[] = $statement;
+
+        // SQLite does not understand MySQL's session-charset statement; swallow it so the rest of
+        // the connection behaves normally, and record it so a test can assert it was issued.
+        if (str_starts_with($statement, 'SET NAMES')) {
+            return 0;
+        }
+
+        return parent::exec($statement);
+    }
+}

--- a/src/test/php/d4np/utils/Database/QueryBuilderTest.php
+++ b/src/test/php/d4np/utils/Database/QueryBuilderTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database;
+
+use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\Operator;
+use D4np\Utils\Database\QueryBuilder;
+use D4np\Utils\Database\Sort;
+use D4np\Utils\Support\DatabaseException;
+use D4np\Utils\Tests\Database\Fixture\PretendDriverPdo;
+use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-07: values bound, identifiers allowlisted and driver-quoted, keywords closed, and
+ * `LIMIT`/`OFFSET` non-negative.
+ *
+ * The identifier cases are the point of the class — prepared statements cannot bind a table or
+ * column name, so the allowlist is the only defence there is — and they are `#[Group('T-02')]`
+ * because spec §7's T-02 suite names *"identifier injection throws DatabaseException"* explicitly.
+ */
+#[Group('T-02')]
+#[RequiresPhpExtension('pdo_sqlite')]
+final class QueryBuilderTest extends TestCase
+{
+    private function connection(): DatabaseConnection
+    {
+        $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
+        $connection->execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)');
+
+        return $connection;
+    }
+
+    private function builder(): QueryBuilder
+    {
+        return new QueryBuilder($this->connection(), 'users');
+    }
+
+    public function testSelectsEverythingByDefault(): void
+    {
+        self::assertSame('SELECT * FROM "users"', $this->builder()->toSql());
+    }
+
+    public function testNamedColumnsAreQuoted(): void
+    {
+        self::assertSame('SELECT "id", "name" FROM "users"', $this->builder()->select('id', 'name')->toSql());
+    }
+
+    public function testWhereBindsTheValueRatherThanInliningIt(): void
+    {
+        $query = $this->builder()->where('name', Operator::Equals, 'Ada');
+
+        self::assertSame('SELECT * FROM "users" WHERE "name" = ?', $query->toSql());
+        self::assertSame(['Ada'], $query->bindings());
+        // The value must not appear in the SQL text at all.
+        self::assertStringNotContainsString('Ada', $query->toSql());
+    }
+
+    public function testConditionsCombineWithAnd(): void
+    {
+        $query = $this->builder()
+            ->where('name', Operator::Equals, 'Ada')
+            ->where('age', Operator::GreaterThan, 30);
+
+        self::assertSame('SELECT * FROM "users" WHERE "name" = ? AND "age" > ?', $query->toSql());
+        self::assertSame(['Ada', 30], $query->bindings());
+    }
+
+    public function testWhereInBindsOnePlaceholderPerValue(): void
+    {
+        $query = $this->builder()->whereIn('id', [1, 2, 3]);
+
+        self::assertSame('SELECT * FROM "users" WHERE "id" IN (?, ?, ?)', $query->toSql());
+        self::assertSame([1, 2, 3], $query->bindings());
+    }
+
+    public function testWhereInRefusesAnEmptyList(): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $this->builder()->whereIn('id', []);
+    }
+
+    public function testNullChecksRenderAsIsNull(): void
+    {
+        self::assertSame('SELECT * FROM "users" WHERE "name" IS NULL', $this->builder()->whereNull('name')->toSql());
+        self::assertSame('SELECT * FROM "users" WHERE "name" IS NOT NULL', $this->builder()->whereNotNull('name')->toSql());
+    }
+
+    public function testOrderByUsesTheEnumKeyword(): void
+    {
+        $query = $this->builder()->orderBy('name')->orderBy('age', Sort::Desc);
+
+        self::assertSame('SELECT * FROM "users" ORDER BY "name" ASC, "age" DESC', $query->toSql());
+    }
+
+    public function testLimitAndOffsetRender(): void
+    {
+        self::assertSame('SELECT * FROM "users" LIMIT 10 OFFSET 20', $this->builder()->limit(10)->offset(20)->toSql());
+    }
+
+    public function testZeroIsAcceptableForLimitAndOffset(): void
+    {
+        self::assertSame('SELECT * FROM "users" LIMIT 0 OFFSET 0', $this->builder()->limit(0)->offset(0)->toSql());
+    }
+
+    public function testNegativeLimitIsRefused(): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $this->builder()->limit(-1);
+    }
+
+    public function testNegativeOffsetIsRefused(): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $this->builder()->offset(-5);
+    }
+
+    /**
+     * The heart of FR-07. Each of these is a real way an identifier has been used to inject SQL;
+     * none of them can be bound as a parameter, so each must be refused outright.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function hostileIdentifiers(): iterable
+    {
+        yield 'statement terminator' => ['id; DROP TABLE users'];
+        yield 'comment' => ['id -- '];
+        yield 'block comment' => ['id /* x */'];
+        yield 'union' => ['id UNION SELECT password FROM admins'];
+        yield 'quote break-out (double)' => ['id" FROM users; --'];
+        yield 'quote break-out (backtick)' => ['id` FROM users; --'];
+        yield 'quote break-out (bracket)' => ['id] FROM users; --'];
+        yield 'subquery' => ['(SELECT 1)'];
+        yield 'wildcard' => ['*'];
+        yield 'qualified name' => ['users.id'];
+        yield 'space' => ['user name'];
+        yield 'leading digit' => ['1id'];
+        yield 'empty' => [''];
+        yield 'whitespace only' => ['   '];
+        yield 'newline smuggling' => ["id\nDROP TABLE users"];
+        // PCRE's `$` matches before a trailing newline, so FR-07's allowlist transcribed
+        // literally admits this one. It did, until the pattern was anchored with `\z`.
+        yield 'trailing newline (the `$` anchor hole)' => ["id\n"];
+        yield 'trailing CRLF' => ["id\r\n"];
+        yield 'null byte' => ["id\0"];
+        yield 'unicode lookalike' => ['ｉd'];
+    }
+
+    #[DataProvider('hostileIdentifiers')]
+    public function testHostileColumnNamesAreRefused(string $identifier): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $this->builder()->select($identifier);
+    }
+
+    #[DataProvider('hostileIdentifiers')]
+    public function testHostileTableNamesAreRefused(string $identifier): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        new QueryBuilder($this->connection(), $identifier);
+    }
+
+    #[DataProvider('hostileIdentifiers')]
+    public function testHostileWhereColumnsAreRefused(string $identifier): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $this->builder()->where($identifier, Operator::Equals, 1);
+    }
+
+    #[DataProvider('hostileIdentifiers')]
+    public function testHostileOrderByColumnsAreRefused(string $identifier): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $this->builder()->orderBy($identifier);
+    }
+
+    /**
+     * A reserved word is a legal column name; quoting is what makes it usable.
+     */
+    public function testAReservedWordIsAcceptableBecauseIdentifiersAreQuoted(): void
+    {
+        self::assertSame('SELECT "order", "select" FROM "users"', $this->builder()->select('order', 'select')->toSql());
+    }
+
+    public function testTheBuilderIsImmutable(): void
+    {
+        $base = $this->builder();
+        $filtered = $base->where('name', Operator::Equals, 'Ada');
+
+        self::assertSame('SELECT * FROM "users"', $base->toSql());
+        self::assertSame([], $base->bindings());
+        self::assertNotSame($base, $filtered);
+    }
+
+    /**
+     * The quoting has to follow the driver, and SQLite is a poor witness for that on its own —
+     * it accepts double quotes, backticks *and* brackets, so a query built with the wrong style
+     * would still run. Asserting the rendered text is what actually pins the per-driver choice.
+     */
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function driverQuoting(): iterable
+    {
+        yield 'mysql uses backticks' => ['mysql', 'SELECT `id` FROM `users`'];
+        yield 'sqlsrv uses brackets' => ['sqlsrv', 'SELECT [id] FROM [users]'];
+        yield 'dblib uses brackets' => ['dblib', 'SELECT [id] FROM [users]'];
+        yield 'pgsql uses double quotes' => ['pgsql', 'SELECT "id" FROM "users"'];
+        yield 'oci uses double quotes' => ['oci', 'SELECT "id" FROM "users"'];
+        yield 'sqlite uses double quotes' => ['sqlite', 'SELECT "id" FROM "users"'];
+    }
+
+    #[DataProvider('driverQuoting')]
+    public function testQuotingFollowsTheDriver(string $driver, string $expected): void
+    {
+        $connection = new DatabaseConnection(new PretendDriverPdo($driver));
+
+        self::assertSame($expected, (new QueryBuilder($connection, 'users'))->select('id')->toSql());
+    }
+
+    public function testEndToEndAgainstARealDriver(): void
+    {
+        $connection = $this->connection();
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]);
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]);
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]);
+
+        $rows = (new QueryBuilder($connection, 'users'))
+            ->select('name')
+            ->where('age', Operator::GreaterThanOrEqual, 41)
+            ->orderBy('age', Sort::Desc)
+            ->limit(2)
+            ->get();
+
+        self::assertSame([['name' => 'Grace'], ['name' => 'Alan']], $rows);
+    }
+
+    public function testFirstReturnsNullWhenNothingMatches(): void
+    {
+        self::assertNull($this->builder()->where('name', Operator::Equals, 'nobody')->first());
+    }
+
+    /**
+     * A value that looks like SQL stays a value, end to end through a real driver.
+     */
+    public function testAHostileValueIsStoredAndMatchedAsData(): void
+    {
+        $connection = $this->connection();
+        $payload = "'; DROP TABLE users; --";
+        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]);
+
+        $row = (new QueryBuilder($connection, 'users'))->where('name', Operator::Equals, $payload)->first();
+
+        self::assertSame($payload, $row['name'] ?? null);
+        self::assertSame([['n' => 1]], $connection->select('SELECT COUNT(*) AS n FROM users'));
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item 4.2 — RFC-0001's **second security mechanism**, which exists because of one fact the first cannot cover: prepared statements bind *values*, never table or column names. There is no placeholder for an identifier, so one arriving from user input has nothing to hide behind and the allowlist isn't a layer among several — it *is* the layer.

## ⚠️ Security finding: FR-07's own regex, implemented faithfully, is a bypass

Spec FR-07 specifies the allowlist as `^[A-Za-z_][A-Za-z0-9_]*$`. Transcribed literally into PHP, **PCRE's `$` also matches immediately before a trailing newline**, so `"id\n"` satisfies it. Verified against the built class:

```
SELECT "id\n" FROM "users"
>>> ALLOWLIST BYPASSED
```

Anchored with `\z` instead, which admits nothing after the final character. This implements FR-07's **intent** rather than copying its **notation** — ADR-0015 and a comment on the constant both say so, because the obvious future "fix" is restoring `$` for fidelity to the spec text.

Two things I'd rather state than bury:

- **My own suite missed it.** The hostile-identifier matrix already had a newline payload — but with content *after* the newline, which fails the pattern for an unrelated reason. Found by checking the regex engine's semantics, not by testing payloads I'd thought of. Both cases are in the matrix now.
- **Severity was low, and that's the *second* layer's doing.** The smuggled newline landed inside a quoted identifier, producing an unresolvable column rather than an injection — which falsified this class's own first draft, where I'd written that the quote-escaping was *"by construction unreachable"*. That reads well and is a claim that a regex is perfect. Corrected in place, with the incident as the reason.

## `Operator`: an enum the spec doesn't ask for

FR-07 makes the `ORDER BY` direction an enum for a stated reason — it's concatenated into the SQL text and can't be bound. **A comparison operator is concatenated for exactly the same reason**, and FR-07 doesn't mention it. A `where(string, string, mixed)` would bind the value safely, allowlist the column safely, and leave an unchecked string spliced between them. Recorded as an extension of FR-07, not slipped in.

## Checked rather than assumed

- **`PDO::quote()` is useless for identifiers** — returns `'id'`, a string *literal*; quoting an identifier with it yields a constant instead of a column reference (silent wrong answer, not an error).
- **SQLite is a bad witness for quoting** — it accepts double quotes, backticks *and* brackets, so a query in entirely the wrong style still runs. Driver quoting is asserted on **rendered SQL** via `PretendDriverPdo`, not by execution.
- **A variadic is not a `list`** — PHPStan max caught it: PHP 8.1 allows named args into a variadic (`select(first: 'id')`), producing string keys.

## Test plan

- [x] 17 hostile payloads × 4 identifier surfaces (table, `select`, `where`, `orderBy`)
- [x] **Non-vacuity — four planted defects, each caught and reverted:** allowlist weakened to `/.*/` (76 failures), value interpolated instead of bound (3), negative `LIMIT` allowed (2), MySQL backtick arm removed (1)
- [x] `vendor/bin/phpunit` — 374 tests, 618 assertions, 7 skipped
- [x] `--group T-02` runs 116 tests as a unit
- [x] PHPStan max clean · deptrac 0 violations / 0 uncovered · consistency + action-pin lints OK
- [ ] CI

## Also closes half of item 4.1's declared gap

`PretendDriverPdo` makes `SET NAMES utf8mb4` assertable: it's now verified issued for MySQL and **not** issued for other drivers. It still doesn't prove a real MySQL server accepts it — the driver matrix stays with **T-02 (item 4.4)**.

## Process note

Item routed `frontier-reasoning / extra`; this session ran at standard tier. Flagged when closing 4.1, you said proceed — accepted and recorded via `record_run.py --route-mismatch` rather than left as a silent divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)