### PR TITLE
feat(database): closure-scoped Transaction with savepoint nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,16 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   recorded honestly rather than adjusted to pass, shipped non-blocking by explicit maintainer
   decision, with closing the gap filed as roadmap item 3.7. The `benchmark` CI job (self-skipped
   since item 1.9) is now active, since `phpbench.json.dist` exists.
+- `D4np\Utils\Database\Transaction` (**ADR-0016**) — closure-scoped transactions: commit on return,
+  roll back and rethrow on any **`Throwable`** (a `TypeError` leaves the same half-written state as
+  an exception). Nested calls use savepoints, which is not an optimisation but the only mechanism
+  available: a second `beginTransaction()` on an open connection **throws** rather than nesting or
+  no-opping. A handled inner failure therefore undoes only the inner work, leaving the enclosing
+  transaction intact. If the rollback *itself* fails its error is swallowed so the closure's
+  exception — the actionable one — still reaches the caller; PHP has no suppressed-exception
+  mechanism, so the choice is strictly between losing the cause and losing the cleanup failure.
+  Savepoint names come from a process-wide monotonic counter and are never caller-influenced.
+  Documented caveat no wrapper can fix: on MySQL, DDL causes an implicit commit mid-closure.
 - `D4np\Utils\Database\QueryBuilder`, `Sort` and `Operator` (**ADR-0015**) — RFC-0001's second
   security mechanism: prepared statements bind *values*, never table or column names, so an
   identifier has nothing to hide behind and the allowlist is the whole defence. Identifiers are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — The spec's own regex was the vulnerability](docs/journal/2026/08/2026-08-04-querybuilder-allowlist.md).
+  [2026-08-04 — Transactions: three PDO probes that each decided a design](docs/journal/2026/08/2026-08-04-transaction-savepoints.md).
 
 ## Model & effort routing (advisory)
 
@@ -217,8 +217,15 @@ Safe-by-default PDO access (RFC-0001).
       hostile payloads × 4 identifier surfaces; suite proved non-vacuous with 4 planted defects.
       Closes half of item 4.1's declared gap: `SET NAMES utf8mb4` is now asserted issued for MySQL
       and not for others.*
-- [ ] 4.3 `Transaction`: closure scope, rollback+rethrow, savepoints (RFC-0001)
-      (severity:medium) — route: standard / medium
+- [x] 4.3 `Transaction`: closure scope, rollback+rethrow, savepoints (RFC-0001)
+      (severity:medium) — route: standard / medium · **ADR-0016**. *Savepoints are not an
+      optimisation but the only mechanism: a nested `beginTransaction()` **throws** (probed), it
+      does not nest or no-op. Catches `Throwable`, not `Exception` — a `TypeError` leaves the same
+      half-written state. A failing rollback is swallowed so the closure's exception survives:
+      PHP has no suppressed-exception mechanism, so the choice is strictly between losing the
+      cause and losing the cleanup failure. Savepoint names are generated from a monotonic
+      counter, never caller-influenced. Documented caveat no wrapper can fix: MySQL DDL causes an
+      implicit commit mid-closure.*
 - [ ] 4.4 T-02 injection suite (values / identifiers / LIKE wildcards) + T-04 transaction
       semantics (RFC-0001) (security — the protected floor holds in the test step) —
       route: frontier-reasoning / extra

--- a/docs/adr/0016-closure-scoped-transactions-with-savepoint-nesting.md
+++ b/docs/adr/0016-closure-scoped-transactions-with-savepoint-nesting.md
@@ -1,0 +1,129 @@
+# ADR-0016: Closure-scoped transactions, savepoint nesting, and keeping the original exception
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 4.3 · spec FR-08, §7 T-04 · item 4.4 (T-04 suite) ·
+  [ADR-0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) ·
+  [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) ·
+  [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md)
+
+## Context
+
+Spec FR-08 asks for *"closure-scoped transactions — automatic rollback on any exception and
+rethrow; nested calls use savepoints."*
+
+Three facts about PDO were probed before designing, and each one determined part of the shape:
+
+| probe | result |
+|---|---|
+| `beginTransaction()` while one is already open | **throws** `PDOException: There is already an active transaction` |
+| `ROLLBACK TO SAVEPOINT sp` — is `sp` still defined afterwards? | **yes** — a subsequent `RELEASE` succeeds |
+| `rollBack()` with no active transaction | **throws** `PDOException: There is no active transaction` |
+
+The first is why savepoints are not an optimisation but the only mechanism available: PDO does not
+nest, and does not quietly no-op either. The second determines cleanup: rolling back to a savepoint
+leaves it on the stack, so a nested scope that fails must also release it or the stack grows once
+per failed call.
+
+## Decision
+
+**One closure, one scope. Commit on return; roll back and rethrow on any `Throwable`. Nest with
+savepoints.**
+
+### The closure is the point, not a convenience
+
+Hand-written `beginTransaction()` … `commit()` leaks an open transaction down every path that
+returns or throws in between, and the leak surfaces later, elsewhere, as a lock nobody can
+explain. A closure has exactly one exit, so there is one place to put the cleanup and no way for a
+caller to forget it.
+
+### `Throwable`, not `Exception`
+
+A `TypeError` inside the closure leaves exactly the same half-written state as a
+`RuntimeException`. Committing it because it descends from `Error` rather than `Exception` would be
+indefensible, so the catch is `Throwable`.
+
+### Nesting uses savepoints, and releases them on both paths
+
+A nested `run()` opens `SAVEPOINT egl_sp_N`; failure means `ROLLBACK TO SAVEPOINT` — which undoes
+the inner work and leaves the outer transaction open and intact — followed by `RELEASE`, because
+the probe showed the savepoint survives the rollback.
+
+**Savepoint names are generated, never accepted.** A savepoint name is an identifier spliced into
+SQL, and this group has already decided how identifiers are handled (ADR-0015). The honest way to
+make this one safe is not to allowlist it but to ensure no caller can influence it at all: a
+process-wide monotonic counter, not a caller-supplied label and not a depth index — monotonic so
+two savepoints cannot collide even if nesting unwinds in an order this class did not anticipate.
+
+### A failing rollback must not replace the original exception
+
+If cleanup fails — a dropped connection being the usual cause — letting that failure propagate
+would hand the caller a `PDOException` about a lost connection *in place of* the `TypeError` that
+actually caused the problem. That is the wrong end of the causal chain, and the end they cannot act
+on.
+
+So the rollback's own failure is swallowed and the closure's exception is rethrown. **The cost is
+real and is named rather than hidden:** a failed rollback leaves the connection in a state this
+class did not intend and does not report. PHP has no equivalent of Java's suppressed exceptions, so
+the choice is strictly between losing the original cause and losing the cleanup failure. Losing the
+cleanup failure keeps the actionable one.
+
+### A caveat this class cannot fix
+
+On MySQL, DDL (`CREATE TABLE`, `ALTER`, `DROP`, …) causes an **implicit commit**, ending the
+transaction underneath the closure. Work issued after that point is not covered, and a later
+rollback will not undo what the DDL already committed. No wrapper can intercept this — it is a
+MySQL behaviour, not a PDO or library one. It is documented in the class because the failure is
+silent and the natural assumption is that the closure is atomic throughout.
+
+## Alternatives Considered
+
+- **A depth counter instead of `inTransaction()`** — rejected: the connection is consumer-owned
+  (ADR-0014), so a transaction may have been opened outside this class entirely. Asking PDO is the
+  only answer that is true in that case; a private counter would confidently open a second
+  transaction and hit the error the first probe found.
+- **Emulating nested transactions by counting and committing once at depth zero** — rejected. It
+  gives the *appearance* of nesting while a failed inner scope silently commits with the outer one,
+  which is worse than not nesting: the caller believes work was rolled back when it was not.
+- **Naming savepoints by nesting depth (`sp_1`, `sp_2`)** — rejected in favour of a monotonic
+  counter. Depth names collide if scopes unwind out of order, and the failure mode is releasing or
+  rolling back to the wrong scope's savepoint.
+- **Letting a failing rollback propagate** — rejected above; it destroys the causal chain.
+- **Wrapping the closure's exception in a `DatabaseException`** — rejected: FR-08 says *rethrow*,
+  and a caller catching their own domain exception around a transaction is the normal case. The
+  test asserts object **identity**, not just class, so a wrapper would fail it.
+- **`try`/`finally` with a committed flag** instead of explicit catch/rethrow — equivalent for the
+  happy path, but it makes "roll back only on failure" implicit and would have obscured the
+  rollback-must-not-mask decision above.
+
+## Consequences
+
+- An open transaction cannot outlive a `run()` call on either path, which is asserted directly
+  (`inTransaction()` is false after both a successful and a failed run).
+- A handled inner failure undoes only the inner work — the case FR-08's savepoint clause exists
+  for, and the one a plain `rollBack()` would get wrong by discarding the outer scope too.
+- Repeated failed nested calls do not grow the savepoint stack, because the failure path releases
+  as well as rolls back.
+- **The suite is verified non-vacuous.** Four planted defects, each caught and reverted: nesting via
+  `beginTransaction()` instead of savepoints (3 errors), catching `Exception` instead of `Throwable`
+  (1), a nested rollback discarding the outer transaction (3 errors), and a failing rollback
+  masking the original exception (1). A fifth probe — making `run()` swallow the exception — was
+  used after PHPStan forced a test restructure (below), and fails 2.
+- **PHPStan max rejected the defensive `self::fail()` after each throwing closure** as provably
+  unreachable, which is correct: the closures throw unconditionally. Removing them, however,
+  silently weakened the two tests whose only assertion lived inside the `catch` — they would have
+  passed vacuously had `run()` ever swallowed. Those now capture the exception and assert
+  *outside* the try/catch, so the assertion always runs. Worth recording because the safe-looking
+  fix for a static-analysis complaint was a real reduction in coverage.
+- No support for isolation levels, read-only transactions, or deferred constraints. FR-08 asks for
+  none of them, and each is driver-specific enough to deserve its own decision.
+
+## References
+
+- Spec FR-08 (closure scope, rollback + rethrow, savepoint nesting), §7 T-04 (the suite)
+- ADR-0014 — the consumer-owned connection this operates on, and why `inTransaction()` rather than
+  private state is the right question to ask
+- ADR-0015 — the identifier rule savepoint naming follows by construction rather than by check
+- Probed directly (PHP 8.3.1, `pdo_sqlite`): nested `beginTransaction()`, savepoint survival after
+  `ROLLBACK TO`, and `rollBack()` outside a transaction

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,3 +31,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0013](0013-compile-a-hydration-closure-for-the-scalar-shape.md) | Compile a hydration closure for the scalar shape, keep the interpreter for everything else | Accepted |
 | [0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) | Pin PDO's safe defaults on a consumer-owned connection, and refuse one that will not take them | Accepted |
 | [0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) | Refuse identifiers rather than escape them, close every keyword, and anchor the allowlist with `\z` | Accepted |
+| [0016](0016-closure-scoped-transactions-with-savepoint-nesting.md) | Closure-scoped transactions, savepoint nesting, and keeping the original exception | Accepted |

--- a/docs/journal/2026/08/2026-08-04-transaction-savepoints.md
+++ b/docs/journal/2026/08/2026-08-04-transaction-savepoints.md
@@ -1,0 +1,90 @@
+# 2026-08-04 — Transactions: three PDO probes that each decided a design
+
+Roadmap item **4.3**. Route `standard / medium`; session is Opus 5, the standard tier — match, for
+the first time in three items.
+
+## Probing before designing
+
+Three questions, each of which turned out to determine part of the shape:
+
+| probe | result | what it decided |
+|---|---|---|
+| `beginTransaction()` while one is open | **throws** `There is already an active transaction` | savepoints aren't an optimisation, they're the only mechanism |
+| is a savepoint still defined after `ROLLBACK TO`? | **yes** — a later `RELEASE` succeeds | the failure path must release too, or the stack grows per failed call |
+| `rollBack()` with no active transaction | **throws** `There is no active transaction` | cleanup can't be fired blindly |
+
+The first is the important one. I'd assumed PDO would either nest or quietly no-op; it does
+neither. So "nested calls use savepoints" in FR-08 isn't a performance note — without it, nesting
+is an immediate fatal.
+
+## Decisions worth their own line
+
+**`Throwable`, not `Exception`.** A `TypeError` leaves exactly the same half-written state as a
+`RuntimeException`. Committing it because it descends from `Error` would be indefensible.
+
+**A failing rollback must not replace the original exception.** If cleanup fails — dropped
+connection, usually — letting that propagate hands the caller a `PDOException` about a lost
+connection *instead of* the `TypeError` that actually caused the problem. Wrong end of the causal
+chain, and the end they can't act on. So the rollback's failure is swallowed and the original is
+rethrown.
+
+That cost is real and I named it rather than hid it: a failed rollback leaves the connection in a
+state this class didn't intend and doesn't report. PHP has no suppressed-exception mechanism, so
+the choice is strictly between losing the cause and losing the cleanup failure. Losing the cleanup
+failure keeps the actionable one.
+
+**Savepoint names are generated, never accepted.** A savepoint name is an identifier spliced into
+SQL — the exact thing ADR-0015 spent an item on. But the right answer here isn't an allowlist; it's
+that no caller can influence it at all. Monotonic counter, not a depth index, so two savepoints
+can't collide even if scopes unwind in an order I didn't anticipate.
+
+**A caveat no wrapper can fix:** on MySQL, DDL causes an *implicit commit*, ending the transaction
+underneath the closure. Later work isn't covered and a rollback won't undo what the DDL committed.
+Documented in the class because the failure is silent and the natural assumption is that a closure
+is atomic throughout.
+
+## Where PHPStan's advice would have quietly cost coverage
+
+PHPStan max flagged six issues, all in the test file. Five were `self::fail('expected the exception
+to propagate')` after a closure that throws unconditionally — provably unreachable, and PHPStan was
+right.
+
+I removed them. That's the obvious fix, and it silently **weakened two tests**: the ones whose only
+assertion lived inside the `catch`. With `self::fail()` gone, if `run()` ever swallowed the
+exception the catch would never run, the assertion would never execute, and the test would pass.
+
+Caught it by asking what each test would do under the regression it exists to catch, then confirmed
+it — planting a swallowing `run()` and watching those tests stay green. Restructured both to
+capture the exception and assert *outside* the try/catch, so the assertion always runs. Re-planted
+the same defect: 2 failures now.
+
+Worth recording as a pattern: **the safe-looking fix for a static-analysis complaint was a real
+reduction in coverage.** "PHPStan is happy" and "the test still tests something" are different
+properties.
+
+## Non-vacuity
+
+| planted | result |
+|---|---|
+| nesting via `beginTransaction()` instead of savepoints | 3 errors |
+| catches `Exception` instead of `Throwable` | 1 failure |
+| nested rollback discards the outer transaction | 3 errors |
+| failing rollback masks the original exception | 1 failure |
+| `run()` swallows the exception (post-restructure) | 2 failures |
+
+The identity assertion is deliberately `assertSame`, not `assertInstanceOf`: the caller must get
+back the very object the closure threw, not a wrapper that lost its type or context.
+
+## Bar
+
+391 tests / 644 assertions green; `--group T-04` runs 17 as a unit, which is spec §7's named suite
+made runnable. PHPStan max clean, deptrac 0/0 with 73 allowed edges, consistency lint OK.
+
+## State of Milestone 4
+
+4.1–4.3 done. Remaining: **4.4** (T-02 injection + T-04 transaction suites — routed
+`frontier-reasoning / extra`, above this session's tier) and **4.5** (NFR-03 build-time benchmark).
+
+Much of 4.4 already exists: `--group T-02` runs 116 tests and `--group T-04` 17. What 4.4 still
+owes is the part neither item could do — the fuzzed-payload query-log assertion, and a real driver
+matrix instead of SQLite standing in for MySQL.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Transactions: three PDO probes that each decided a design](2026/08/2026-08-04-transaction-savepoints.md)
 - [2026-08-04 — The spec's own regex was the vulnerability](2026/08/2026-08-04-querybuilder-allowlist.md)
 - [2026-08-04 — Milestone 4 opens: the security default that fails by returning false](2026/08/2026-08-04-pinned-pdo-defaults.md)
 - [2026-08-04 — Measuring what was reachable before deciding what to build](2026/08/2026-08-04-nfr01-compiled-hydration.md)

--- a/src/main/php/d4np/utils/Database/Transaction.php
+++ b/src/main/php/d4np/utils/Database/Transaction.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Database;
+
+use D4np\Utils\Support\DatabaseException;
+use PDOException;
+use Throwable;
+
+/**
+ * Closure-scoped transactions: commit on return, roll back and rethrow on anything else
+ * (spec FR-08, ADR-0016).
+ *
+ * The shape exists because the manual one is easy to get wrong in a way that is invisible until
+ * it matters. `beginTransaction()` … `commit()` written by hand leaks an open transaction down
+ * every path that returns or throws in between, and the leak surfaces later, somewhere else, as a
+ * lock nobody can explain. A closure has exactly one exit, so there is one place to put the
+ * `finally`.
+ *
+ * ```php
+ * $total = (new Transaction($connection))->run(function (DatabaseConnection $db): int {
+ *     $db->execute('UPDATE accounts SET balance = balance - ? WHERE id = ?', [100, 1]);
+ *     $db->execute('UPDATE accounts SET balance = balance + ? WHERE id = ?', [100, 2]);
+ *
+ *     return 2;
+ * });
+ * ```
+ *
+ * **Nesting uses savepoints because PDO gives no choice.** A second `beginTransaction()` on a
+ * connection that already has one open does not nest and does not no-op — it throws
+ * `PDOException: There is already an active transaction` (verified). So a nested `run()` opens a
+ * `SAVEPOINT` instead, and "rollback" for that scope means `ROLLBACK TO SAVEPOINT`, which undoes
+ * the inner work while leaving the outer transaction intact and still open.
+ *
+ * **What counts as a failure is `Throwable`, not `Exception`.** A `TypeError` or an assertion
+ * inside the closure leaves the same half-written state as a `RuntimeException`, and committing it
+ * because it descends from `Error` rather than `Exception` would be indefensible.
+ *
+ * **The original failure is what propagates.** If the rollback *itself* also fails, the exception
+ * that comes out of `run()` is still the one from the closure — see {@see self::rollBackQuietly()}
+ * for why replacing it would hide the thing the caller actually needs to see.
+ *
+ * **A caveat this class cannot fix:** on MySQL, DDL (`CREATE TABLE`, `ALTER`, `DROP`, …) causes an
+ * *implicit commit*, ending the transaction underneath you. Work issued after that point is no
+ * longer covered, and a later rollback will not undo what the DDL already committed. That is a
+ * MySQL behaviour, not a PDO or library one, and no wrapper can intercept it — named here because
+ * the failure is silent and the natural assumption is that the closure is atomic throughout.
+ */
+final class Transaction
+{
+    /**
+     * Monotonic, process-wide, and never derived from caller input.
+     *
+     * A savepoint name is an identifier spliced into SQL, so it gets the same treatment as any
+     * other identifier in this group: it is generated here rather than accepted from anywhere.
+     * `QueryBuilder`'s allowlist exists for names that come from outside; the honest way to make
+     * this one safe is for there to be no path by which a caller can influence it at all.
+     *
+     * Monotonic rather than depth-keyed so that two savepoints can never share a name even if
+     * nesting unwinds in an unexpected order.
+     */
+    private static int $savepointSequence = 0;
+
+    public function __construct(
+        private readonly DatabaseConnection $connection,
+    ) {
+    }
+
+    /**
+     * Run `$work` inside a transaction, or inside a savepoint when one is already open.
+     *
+     * @template T
+     *
+     * @param callable(DatabaseConnection): T $work
+     *
+     * @return T whatever the closure returned
+     *
+     * @throws Throwable whatever the closure threw, after the work has been rolled back
+     * @throws DatabaseException if the transaction could not be started, committed or released
+     */
+    public function run(callable $work): mixed
+    {
+        return $this->connection->pdo()->inTransaction()
+            ? $this->runInSavepoint($work)
+            : $this->runInTransaction($work);
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(DatabaseConnection): T $work
+     *
+     * @return T
+     *
+     * @throws Throwable
+     */
+    private function runInTransaction(callable $work): mixed
+    {
+        $pdo = $this->connection->pdo();
+
+        try {
+            $pdo->beginTransaction();
+        } catch (PDOException $e) {
+            throw new DatabaseException('Could not begin a transaction: ' . $e->getMessage(), 0, $e);
+        }
+
+        try {
+            $result = $work($this->connection);
+        } catch (Throwable $e) {
+            $this->rollBackQuietly(static fn (): bool => $pdo->rollBack());
+
+            throw $e;
+        }
+
+        try {
+            $pdo->commit();
+        } catch (PDOException $e) {
+            throw new DatabaseException('Could not commit the transaction: ' . $e->getMessage(), 0, $e);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(DatabaseConnection): T $work
+     *
+     * @return T
+     *
+     * @throws Throwable
+     */
+    private function runInSavepoint(callable $work): mixed
+    {
+        $name = 'egl_sp_' . ++self::$savepointSequence;
+
+        try {
+            $this->connection->pdo()->exec('SAVEPOINT ' . $name);
+        } catch (PDOException $e) {
+            throw new DatabaseException(
+                sprintf('Could not open savepoint %s for a nested transaction: %s', $name, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        try {
+            $result = $work($this->connection);
+        } catch (Throwable $e) {
+            $this->rollBackQuietly(function () use ($name): void {
+                $pdo = $this->connection->pdo();
+                $pdo->exec('ROLLBACK TO SAVEPOINT ' . $name);
+                // ROLLBACK TO does not discard the savepoint — verified: it is still defined
+                // afterwards and can be released. Releasing keeps the enclosing transaction's
+                // savepoint stack from growing once per failed nested call.
+                $pdo->exec('RELEASE SAVEPOINT ' . $name);
+            });
+
+            throw $e;
+        }
+
+        try {
+            $this->connection->pdo()->exec('RELEASE SAVEPOINT ' . $name);
+        } catch (PDOException $e) {
+            throw new DatabaseException(
+                sprintf('Could not release savepoint %s: %s', $name, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Undo the scope's work, and never let doing so replace the reason we are undoing it.
+     *
+     * A rollback can fail — a dropped connection is the usual way — and if that failure were
+     * allowed to propagate it would *replace* the closure's exception with a message about
+     * cleanup. The caller would then be handed a `PDOException` about a lost connection in place
+     * of the `TypeError` that actually caused the problem, which is the wrong end of the causal
+     * chain and the one they cannot act on.
+     *
+     * So the rollback's own failure is swallowed here and the original is rethrown by the caller.
+     * The cost is real and worth naming: a failed rollback leaves the connection in a state this
+     * class did not intend and does not report. PHP has no equivalent of Java's suppressed
+     * exceptions, so the alternatives are to lose the original cause or to lose the cleanup
+     * failure; losing the cleanup failure keeps the actionable one.
+     *
+     * @param callable(): mixed $rollBack
+     */
+    private function rollBackQuietly(callable $rollBack): void
+    {
+        try {
+            $rollBack();
+        } catch (Throwable) {
+            // Deliberately empty. See the docblock: the closure's exception is the one that
+            // matters, and this method exists so that it survives.
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Database/TransactionTest.php
+++ b/src/test/php/d4np/utils/Database/TransactionTest.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database;
+
+use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\Transaction;
+use D4np\Utils\Support\DatabaseException;
+use LogicException;
+use PDO;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Throwable;
+use TypeError;
+
+/**
+ * Spec §7's T-04 suite: *"exception → rollback → rethrow; savepoint nesting"*.
+ *
+ * Run against real SQLite rather than a doubled PDO, because every assertion here is about what
+ * the driver actually did with the data — whether a row survived a rollback is not something a
+ * mock can be asked.
+ */
+#[Group('T-04')]
+#[RequiresPhpExtension('pdo_sqlite')]
+final class TransactionTest extends TestCase
+{
+    private DatabaseConnection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = new DatabaseConnection(new PDO('sqlite::memory:'));
+        $this->connection->execute('CREATE TABLE t (v TEXT)');
+    }
+
+    private function transaction(): Transaction
+    {
+        return new Transaction($this->connection);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function rows(): array
+    {
+        return array_map(
+            static function (array $row): string {
+                self::assertIsString($row['v']);
+
+                return $row['v'];
+            },
+            $this->connection->select('SELECT v FROM t ORDER BY rowid'),
+        );
+    }
+
+    private function insert(string $value): void
+    {
+        $this->connection->execute('INSERT INTO t (v) VALUES (?)', [$value]);
+    }
+
+    public function testWorkIsCommittedWhenTheClosureReturns(): void
+    {
+        $this->transaction()->run(function (): void {
+            $this->insert('kept');
+        });
+
+        self::assertSame(['kept'], $this->rows());
+    }
+
+    public function testTheClosureReturnValueIsReturned(): void
+    {
+        self::assertSame(42, $this->transaction()->run(static fn (): int => 42));
+    }
+
+    public function testTheClosureReceivesTheConnection(): void
+    {
+        $received = $this->transaction()->run(static fn (DatabaseConnection $db): DatabaseConnection => $db);
+
+        self::assertSame($this->connection, $received);
+    }
+
+    public function testAnExceptionRollsBackEveryStatementInTheScope(): void
+    {
+        try {
+            $this->transaction()->run(function (): void {
+                $this->insert('a');
+                $this->insert('b');
+
+                throw new RuntimeException('boom');
+            });
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        self::assertSame([], $this->rows());
+    }
+
+    public function testTheOriginalExceptionIsRethrownUnchanged(): void
+    {
+        $thrown = new RuntimeException('the original reason');
+
+        // Captured rather than asserted inside the catch: an assertion that only runs when the
+        // exception arrives would pass silently if `run()` ever swallowed it, which is precisely
+        // the regression this test exists to catch.
+        $caught = null;
+
+        try {
+            $this->transaction()->run(static function () use ($thrown): void {
+                throw $thrown;
+            });
+        } catch (Throwable $e) {
+            $caught = $e;
+        }
+
+        // Identity, not just class: the caller must get the very object the closure threw, not a
+        // wrapper that has lost its type or its context.
+        self::assertSame($thrown, $caught);
+    }
+
+    /**
+     * A `TypeError` leaves exactly the same half-written state as a `RuntimeException`; committing
+     * it because it descends from `Error` rather than `Exception` would be indefensible.
+     */
+    public function testAnErrorRollsBackJustLikeAnException(): void
+    {
+        try {
+            $this->transaction()->run(function (): void {
+                $this->insert('a');
+
+                throw new TypeError('not an exception');
+            });
+        } catch (TypeError) {
+            // expected
+        }
+
+        self::assertSame([], $this->rows());
+    }
+
+    public function testTheTransactionIsClosedAfterASuccessfulRun(): void
+    {
+        $this->transaction()->run(static fn (): null => null);
+
+        self::assertFalse($this->connection->pdo()->inTransaction());
+    }
+
+    public function testTheTransactionIsClosedAfterAFailedRun(): void
+    {
+        try {
+            $this->transaction()->run(static function (): void {
+                throw new RuntimeException('boom');
+            });
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        // The failure this class exists to prevent: an open transaction left behind, which
+        // surfaces later and elsewhere as a lock nobody can explain.
+        self::assertFalse($this->connection->pdo()->inTransaction());
+    }
+
+    // ---- nesting -----------------------------------------------------------------------------
+
+    public function testANestedRunCommitsWithTheOuterOne(): void
+    {
+        $this->transaction()->run(function (): void {
+            $this->insert('outer');
+            $this->transaction()->run(function (): void {
+                $this->insert('inner');
+            });
+        });
+
+        self::assertSame(['outer', 'inner'], $this->rows());
+    }
+
+    /**
+     * The heart of FR-08's savepoint clause: an inner failure that the outer scope *handles* must
+     * undo only the inner work. A plain `rollBack()` would have discarded 'outer' as well.
+     */
+    public function testAFailedNestedRunRollsBackOnlyItsOwnWork(): void
+    {
+        $this->transaction()->run(function (): void {
+            $this->insert('outer');
+
+            try {
+                $this->transaction()->run(function (): void {
+                    $this->insert('inner');
+
+                    throw new RuntimeException('inner failed');
+                });
+            } catch (RuntimeException) {
+                // handled by the outer scope, which carries on
+            }
+
+            $this->insert('after');
+        });
+
+        self::assertSame(['outer', 'after'], $this->rows());
+    }
+
+    public function testAnUnhandledNestedFailureRollsBackEverything(): void
+    {
+        try {
+            $this->transaction()->run(function (): void {
+                $this->insert('outer');
+                $this->transaction()->run(function (): void {
+                    $this->insert('inner');
+
+                    throw new RuntimeException('inner failed');
+                });
+            });
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        self::assertSame([], $this->rows());
+    }
+
+    public function testNestingSurvivesThreeLevels(): void
+    {
+        $this->transaction()->run(function (): void {
+            $this->insert('L1');
+            $this->transaction()->run(function (): void {
+                $this->insert('L2');
+                $this->transaction()->run(function (): void {
+                    $this->insert('L3');
+                });
+            });
+        });
+
+        self::assertSame(['L1', 'L2', 'L3'], $this->rows());
+    }
+
+    public function testRepeatedFailedNestedRunsDoNotLeakSavepoints(): void
+    {
+        $this->transaction()->run(function (): void {
+            $this->insert('outer');
+
+            for ($i = 0; $i < 5; $i++) {
+                try {
+                    $this->transaction()->run(function () use ($i): void {
+                        $this->insert('inner' . $i);
+
+                        throw new RuntimeException('nope');
+                    });
+                } catch (RuntimeException) {
+                    // each one is rolled back and released
+                }
+            }
+        });
+
+        self::assertSame(['outer'], $this->rows());
+    }
+
+    public function testANestedRunUsesASavepointRatherThanASecondBeginTransaction(): void
+    {
+        // PDO throws "There is already an active transaction" on a nested beginTransaction(), so
+        // if nesting were implemented that way this would fail rather than return.
+        $depth = $this->transaction()->run(fn (): bool => $this->transaction()->run(
+            fn (): bool => $this->connection->pdo()->inTransaction(),
+        ));
+
+        self::assertTrue($depth);
+    }
+
+    public function testTheOuterTransactionRemainsOpenWhileANestedScopeIsRolledBack(): void
+    {
+        $stillOpen = $this->transaction()->run(function (): bool {
+            try {
+                $this->transaction()->run(static function (): void {
+                    throw new RuntimeException('boom');
+                });
+            } catch (RuntimeException) {
+                // expected
+            }
+
+            return $this->connection->pdo()->inTransaction();
+        });
+
+        self::assertTrue($stillOpen);
+    }
+
+    // ---- failure handling --------------------------------------------------------------------
+
+    /**
+     * If the rollback itself fails, the caller must still receive the closure's exception — the
+     * actionable one — rather than a message about cleanup.
+     */
+    public function testAFailingRollbackDoesNotReplaceTheOriginalException(): void
+    {
+        $pdo = new class ('sqlite::memory:') extends PDO {
+            public function rollBack(): bool
+            {
+                throw new \PDOException('the connection went away during rollback');
+            }
+        };
+        $connection = new DatabaseConnection($pdo);
+        $connection->execute('CREATE TABLE t (v TEXT)');
+
+        $original = new LogicException('the reason the caller needs');
+        $caught = null;
+
+        try {
+            (new Transaction($connection))->run(static function () use ($original): void {
+                throw $original;
+            });
+        } catch (Throwable $e) {
+            $caught = $e;
+        }
+
+        self::assertSame($original, $caught);
+    }
+
+    public function testAFailureToBeginIsReportedAsADatabaseException(): void
+    {
+        $pdo = new class ('sqlite::memory:') extends PDO {
+            public function beginTransaction(): bool
+            {
+                throw new \PDOException('cannot begin');
+            }
+        };
+
+        $this->expectException(DatabaseException::class);
+
+        (new Transaction(new DatabaseConnection($pdo)))->run(static fn (): null => null);
+    }
+}

--- a/src/test/php/d4np/utils/Database/TransactionTest.php
+++ b/src/test/php/d4np/utils/Database/TransactionTest.php
@@ -140,7 +140,8 @@ final class TransactionTest extends TestCase
 
     public function testTheTransactionIsClosedAfterASuccessfulRun(): void
     {
-        $this->transaction()->run(static fn (): null => null);
+        $this->transaction()->run(static function (): void {
+        });
 
         self::assertFalse($this->connection->pdo()->inTransaction());
     }
@@ -323,6 +324,7 @@ final class TransactionTest extends TestCase
 
         $this->expectException(DatabaseException::class);
 
-        (new Transaction(new DatabaseConnection($pdo)))->run(static fn (): null => null);
+        (new Transaction(new DatabaseConnection($pdo)))->run(static function (): void {
+        });
     }
 }


### PR DESCRIPTION
## Summary

Roadmap item 4.3 (spec FR-08, suite T-04). Commit on return, roll back and rethrow on any `Throwable`, nest with savepoints.

### Three PDO probes ran before any design, and each decided part of the shape

| probe | result | what it decided |
|---|---|---|
| `beginTransaction()` while one is open | **throws** `There is already an active transaction` | savepoints aren't an optimisation — they're the only mechanism |
| is a savepoint still defined after `ROLLBACK TO`? | **yes** — a later `RELEASE` succeeds | the failure path must release too, or the stack grows per failed call |
| `rollBack()` with no active transaction | **throws** | cleanup can't be fired blindly |

The first is the one that mattered: I'd assumed PDO would either nest or quietly no-op. It does neither, so FR-08's "nested calls use savepoints" isn't a performance note — without it, nesting is an immediate fatal.

### Decisions

- **`Throwable`, not `Exception`** — a `TypeError` leaves exactly the same half-written state; committing it because it descends from `Error` would be indefensible.
- **A failing rollback must not replace the original exception.** Letting it propagate hands the caller a `PDOException` about a lost connection *instead of* the `TypeError` that caused the problem — wrong end of the causal chain, and the end they can't act on. The cost is named rather than hidden: a failed rollback leaves the connection in a state this class didn't intend and doesn't report. PHP has no suppressed-exception mechanism, so the choice is strictly between losing the cause and losing the cleanup failure.
- **Savepoint names are generated, never accepted** — a savepoint name is an identifier spliced into SQL (the ADR-0015 hazard), but the right answer here isn't an allowlist, it's that no caller can influence it at all. Monotonic counter, not a depth index, so names can't collide if scopes unwind unexpectedly.
- **Documented caveat no wrapper can fix:** on MySQL, DDL causes an implicit commit mid-closure.

## ⚠️ A note on the test restructure — worth a reviewer's eye

PHPStan max flagged five `self::fail()` calls after unconditionally-throwing closures as provably unreachable. It was right. **Removing them — the obvious fix — silently weakened two tests**: the ones whose only assertion lived inside the `catch`. Had `run()` ever swallowed the exception, the catch would never run, the assertion would never execute, and the test would pass.

Confirmed by planting a swallowing `run()` and watching them stay green. Both now capture the exception and assert *outside* the try/catch; the same planted defect fails 2 tests.

Recording it because "PHPStan is happy" and "the test still tests something" are different properties.

## Test plan

- [x] **Non-vacuity — five planted defects, each caught and reverted:** nesting via `beginTransaction()` (3 errors), catching `Exception` not `Throwable` (1), nested rollback discarding the outer transaction (3 errors), failing rollback masking the original (1), `run()` swallowing the exception (2)
- [x] Identity asserted with `assertSame`, not `assertInstanceOf` — the caller must get back the very object thrown, not a wrapper
- [x] `vendor/bin/phpunit` — 391 tests, 644 assertions, 7 skipped
- [x] `--group T-04` runs 17 as a unit (spec §7's named suite, made runnable)
- [x] PHPStan max clean · deptrac 0 violations / 0 uncovered · consistency + action-pin lints OK
- [ ] CI

## Milestone 4 status

4.1–4.3 done. **4.4** (T-02 + T-04 suites) is routed `frontier-reasoning / extra`, above this session's tier. Much of it already exists — `--group T-02` runs 116 tests, `--group T-04` runs 17. What 4.4 still owes is the part neither item could do: the fuzzed-payload query-log assertion, and a real driver matrix instead of SQLite standing in for MySQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)