### PR TITLE
test(database): T-02 injection suite with a real query-log assertion

### DIFF
--- a/.eados-core/learning/runs/2026-08-04-utils-2.yaml
+++ b/.eados-core/learning/runs/2026-08-04-utils-2.yaml
@@ -1,0 +1,36 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-04"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}
+route_mismatch:
+  routed: "frontier-reasoning/extra"
+  session: "standard"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,19 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   recorded honestly rather than adjusted to pass, shipped non-blocking by explicit maintainer
   decision, with closing the gap filed as roadmap item 3.7. The `benchmark` CI job (self-skipped
   since item 1.9) is now active, since `phpbench.json.dist` exists.
+- Spec §7's **T-02 injection suite** (**ADR-0017**) — 29 fuzzed payloads × 6 value-accepting paths,
+  asserting via a real **query log** (`PDO::ATTR_STATEMENT_CLASS`) that a payload appears in the
+  bound-parameter array and **never** in the statement text. This is stronger than the round-trip
+  assertions items 4.1–4.3 carried, and measurably so: against a planted *correctly-escaping*
+  interpolation, the round-trip assertions passed 28 of 29 times while the query-log assertions
+  failed 28 of 29. The PDO boundary is a sufficient proof point *because* ADR-0014 pins real
+  prepares — with no client-side interpolation, placeholder-only text there is placeholder-only
+  text on the wire. `--group T-02` now runs 321 tests and `--group T-04` 17, making spec §7's named
+  suites runnable units.
+  **T-02 is not complete:** its LIKE-wildcard leg needs `Sanitizer::sqlLikePattern()` (FR-10,
+  roadmap item 5.2, not yet built). A test asserts the current behaviour and names the gap rather
+  than leaving silence — a `LIKE` value binds and cannot inject SQL, but a user-supplied `%` still
+  behaves as a wildcard.
 - `D4np\Utils\Database\Transaction` (**ADR-0016**) — closure-scoped transactions: commit on return,
   roll back and rethrow on any **`Throwable`** (a `TypeError` leaves the same half-written state as
   an exception). Nested calls use savepoints, which is not an optimisation but the only mechanism

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Transactions: three PDO probes that each decided a design](docs/journal/2026/08/2026-08-04-transaction-savepoints.md).
+  [2026-08-04 — Measuring what the old tests would have missed](docs/journal/2026/08/2026-08-04-t02-injection-suite.md).
 
 ## Model & effort routing (advisory)
 
@@ -226,9 +226,18 @@ Safe-by-default PDO access (RFC-0001).
       cause and losing the cleanup failure. Savepoint names are generated from a monotonic
       counter, never caller-influenced. Documented caveat no wrapper can fix: MySQL DDL causes an
       implicit commit mid-closure.*
-- [ ] 4.4 T-02 injection suite (values / identifiers / LIKE wildcards) + T-04 transaction
+- [x] 4.4 T-02 injection suite (values / identifiers / LIKE wildcards) + T-04 transaction
       semantics (RFC-0001) (security — the protected floor holds in the test step) —
-      route: frontier-reasoning / extra
+      route: frontier-reasoning / extra · **ADR-0017**. *Route mismatch accepted and recorded.
+      T-02's **query-log** clause was the missing piece and is not ceremony: measured, the
+      round-trip assertions items 4.1-4.3 had **miss a correctly-escaping interpolation in 28 of
+      29 cases**, while the query-log assertion catches it in 28 of 29. Proof point is the PDO
+      boundary via `ATTR_STATEMENT_CLASS`, which is sufficient *because* ADR-0014 pins real
+      prepares — with no client-side interpolation, placeholder-only text at that boundary is
+      placeholder-only text on the wire. 29 payloads × 6 value paths. **T-02 is NOT complete:**
+      its LIKE-wildcard leg needs `Sanitizer::sqlLikePattern()` (FR-10, item 5.2) and a test
+      asserts that gap explicitly rather than leaving silence. T-04 needed no new tests — item 4.3
+      delivered it; verified against the spec text rather than padded.*
 - [ ] 4.5 phpbench: NFR-03 build-time benchmark (RFC-0001) (step:optimize) — route: fast / medium
 
 ---

--- a/docs/adr/0017-prove-binding-at-the-pdo-boundary-and-defer-t02s-like-leg.md
+++ b/docs/adr/0017-prove-binding-at-the-pdo-boundary-and-defer-t02s-like-leg.md
@@ -1,0 +1,134 @@
+# ADR-0017: Prove binding at the PDO boundary, and ship T-02 with its LIKE leg openly deferred
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 4.4 · spec §7 T-02 and T-04, FR-10 · item **5.2**
+  (`Sanitizer::sqlLikePattern()` — the blocker named below) ·
+  [ADR-0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) ·
+  [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) ·
+  [ADR-0016](0016-closure-scoped-transactions-with-savepoint-nesting.md)
+
+## Context
+
+Spec §7 defines T-02 as three things:
+
+> fuzzed value payloads reach the driver only as bound parameters **via query-log assertion**;
+> identifier injection throws `DatabaseException`; **LIKE-wildcard escapes**
+
+Items 4.1–4.3 already asserted something in the neighbourhood of the first clause: a hostile value
+round-trips intact and the table survives. **That is weaker than it looks.** It is *consistent
+with* binding, but it is equally consistent with correct client-side escaping — an escaped value
+also round-trips intact and also leaves the schema alone. The test passes either way, so it cannot
+distinguish the mechanism the security model actually depends on from a mechanism that merely
+resembles it.
+
+That gap was measured rather than argued. With a *correctly quote-escaping* interpolation planted
+in `DatabaseConnection::run()`:
+
+| assertion | outcome under the planted vulnerability |
+|---|---|
+| round-trip + schema survives (items 4.1–4.3) | **28 of 29 passed** — the vulnerability is missed |
+| query-log assertion (this item) | **28 of 29 failed** — the vulnerability is caught |
+
+The spec's insistence on a *query-log* assertion is therefore not ceremony. It is the difference
+between testing an outcome and testing the mechanism.
+
+## Decision
+
+### 1. The PDO boundary is the proof point, and the pinned real-prepares is what makes it sufficient
+
+A `QueryLog` is installed through `PDO::ATTR_STATEMENT_CLASS`, so every statement the library
+prepares — via `DatabaseConnection`, `QueryBuilder` or `Transaction` — records the exact SQL text
+and the exact bound-parameter array, while still executing for real against the driver. For each
+payload the suite asserts the payload appears **in the parameter array and never in the statement
+text**.
+
+The obvious objection is that this observes PDO's *input*, not the bytes on the wire. Two things
+answer it, and the second is the load-bearing one:
+
+- PDO exposes no way to see what it sends, and no database server is available in CI to read a
+  real `general_log` from. This is the last point inside the process where SQL text and values are
+  still separable.
+- **ADR-0014 pins `ATTR_EMULATE_PREPARES=false`.** With real prepares, PDO performs no
+  interpolation: the statement and the parameters travel to the server separately, by construction.
+  So "the statement text at this boundary contains only placeholders" *is* "the statement text on
+  the wire contains only placeholders". If emulation were ever silently re-enabled,
+  `DatabaseConnectionTest`'s own assertions fail first — which is what makes this chain of
+  reasoning checkable rather than merely plausible.
+
+Every value-accepting path is covered, because a binding guarantee is worth exactly what its
+leakiest entry point is worth: `select()`, `selectOne()`, `execute()`, `QueryBuilder::where()`,
+`QueryBuilder::whereIn()`, and the same inside a `Transaction`.
+
+### 2. Round-trip assertions are kept *alongside* the query-log ones, not replaced
+
+Binding is not only a syntactic property. The value must also survive intact and the schema must
+be untouched, and the query log alone would not notice a value that was bound but mangled. The two
+assertions fail for different reasons, which is the point of having both.
+
+### 3. T-02's LIKE-wildcard leg is **not** delivered, and says so in a test
+
+`Sanitizer::sqlLikePattern()` is spec FR-10 and **roadmap item 5.2** — a Milestone 5 deliverable
+that does not exist yet. Implementing it inside item 4.4 would jump a milestone and duplicate an
+item the roadmap already owns.
+
+The alternative to silence is a test that states the true state of affairs, which is what ships:
+`testLikePatternsStillBindButWildcardsAreNotYetEscaped()` asserts what *is* true today — a `LIKE`
+value binds like any other and cannot inject SQL — and then asserts the gap explicitly: a
+user-supplied `%` still behaves as a wildcard and matches everything. Its message names item 5.2 as
+the owner and says which assertion should change when it lands.
+
+This is deliberate: an untested gap and a gap with a test that documents it look identical in a
+coverage report and completely different to whoever reads the suite next. **T-02 is not complete at
+the end of item 4.4**, and the roadmap entry says so rather than ticking a box the spec has not
+earned.
+
+### 4. T-04 needed no new tests, and none were invented
+
+Spec §7's T-04 is *"exception → rollback → rethrow; savepoint nesting"*. Item 4.3 delivered exactly
+that, `#[Group('T-04')]`, 17 tests. Adding redundant tests to make item 4.4 look busier would add
+maintenance cost and no coverage. Verified as complete against the spec text and left alone.
+
+## Alternatives Considered
+
+- **Assert on a real server's query log** (MySQL `general_log`, PostgreSQL `log_statement`) —
+  the strongest possible evidence, and rejected as out of scope here: it needs a service container
+  in CI, which is a build-infrastructure decision affecting every job, not a test-suite one. It
+  would strengthen this and the MySQL gaps ADR-0014 named; worth its own item if wanted.
+- **`PDOStatement::debugDumpParams()`** — rejected: it writes to stdout in a format documented as
+  unstable, and it reports what PDO *recorded*, not what a statement was asked to execute.
+- **Keeping only the round-trip assertions** — rejected on the measurement above: they miss a
+  correctly-escaping interpolation in 28 of 29 cases.
+- **Implementing `sqlLikePattern()` here to complete T-02** — rejected: it is item 5.2's
+  deliverable, and pulling a Milestone 5 security helper forward into a test item would mean
+  designing it under the wrong item's review.
+- **Marking the LIKE case `skipped` or `incomplete`** — rejected in favour of a passing test that
+  asserts the *current* behaviour. A skipped test tells a reader nothing about what is true today;
+  this one pins present behaviour so that item 5.2 changing it is a visible, deliberate edit.
+
+## Consequences
+
+- 205 new tests (29 payloads × 6 value paths, plus the standalone cases). `--group T-02` now runs
+  **321** tests and `--group T-04` 17, so spec §7's named suites are runnable units rather than
+  docblock claims.
+- **The suite is verified non-vacuous against the real vulnerability**, not a synthetic one:
+  planting a correctly-quote-escaping interpolation fails 142 tests and errors 6 more.
+- The corpus targets mechanisms rather than scary strings — quote break-out, comment truncation,
+  stacked statements, UNION exfiltration, backslash tricks, the **GBK multibyte quote** that
+  defeats a charset-unaware escaper (the exact attack ADR-0014's ordering removes), null bytes,
+  CRLF, Unicode lookalikes, and a 5.5 KB payload.
+- The empty-string payload skips the containment half of the assertion, because every string
+  contains the empty string and the check can never hold. It stays in the corpus for the binding
+  half, and the skip is explained at the point it happens rather than silently dropped from the
+  provider.
+- **T-02 remains incomplete until item 5.2**, in one named respect, with a test asserting the
+  current behaviour and the roadmap entry saying so.
+
+## References
+
+- Spec §7 T-02 (three legs), T-04; FR-10 (`Sanitizer::sqlLikePattern()`)
+- ADR-0014 — the pinned real prepares that make the PDO boundary a sufficient proof point
+- ADR-0015 — the identifier leg of T-02, already delivered
+- ADR-0016 — the T-04 semantics, already delivered
+- `PDO::ATTR_STATEMENT_CLASS` with constructor arguments, verified on PHP 8.3.1 / `pdo_sqlite`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) | Pin PDO's safe defaults on a consumer-owned connection, and refuse one that will not take them | Accepted |
 | [0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) | Refuse identifiers rather than escape them, close every keyword, and anchor the allowlist with `\z` | Accepted |
 | [0016](0016-closure-scoped-transactions-with-savepoint-nesting.md) | Closure-scoped transactions, savepoint nesting, and keeping the original exception | Accepted |
+| [0017](0017-prove-binding-at-the-pdo-boundary-and-defer-t02s-like-leg.md) | Prove binding at the PDO boundary, and ship T-02 with its LIKE leg openly deferred | Accepted |

--- a/docs/journal/2026/08/2026-08-04-t02-injection-suite.md
+++ b/docs/journal/2026/08/2026-08-04-t02-injection-suite.md
@@ -1,0 +1,98 @@
+# 2026-08-04 — Measuring what the old tests would have missed
+
+Roadmap item **4.4**. Route `frontier-reasoning / extra`; session is standard tier. Flagged when
+closing 4.3, maintainer said proceed — accepted and recorded via `record_run.py`.
+
+## The clause I nearly treated as already-done
+
+Spec §7's T-02 has three legs:
+
+> fuzzed value payloads reach the driver only as bound parameters **via query-log assertion**;
+> identifier injection throws `DatabaseException`; **LIKE-wildcard escapes**
+
+Items 4.1–4.3 already had tests that *looked* like leg 1: a hostile value round-trips intact, the
+table survives. It would have been easy to call that done and tick the box.
+
+It isn't done, and the reason is precise: **round-tripping intact is equally consistent with
+correct client-side escaping.** An escaped value also survives and also leaves the schema alone.
+The test passes either way, so it cannot tell the mechanism the security model depends on from a
+different mechanism that merely resembles it.
+
+So rather than argue that, I measured it. Planted a *correctly quote-escaping* interpolation in
+`DatabaseConnection::run()` — a real vulnerability that behaves well on every visible axis — and
+ran the two kinds of assertion against it:
+
+| assertion | under the planted vulnerability |
+|---|---|
+| round-trip + schema survives (4.1–4.3) | **28 of 29 passed** — misses it |
+| query-log assertion (this item) | **28 of 29 failed** — catches it |
+
+That's why the spec says *query-log* and not "assert the value came back". It's the difference
+between testing an outcome and testing the mechanism.
+
+## Why the PDO boundary is enough
+
+`PDO::ATTR_STATEMENT_CLASS` lets a custom `PDOStatement` record the exact SQL text and the exact
+bound array while still executing for real. Every statement the library prepares passes through it
+without `DatabaseConnection`, `QueryBuilder` or `Transaction` knowing.
+
+The obvious objection: that's PDO's *input*, not the bytes on the wire. The answer that actually
+carries weight isn't "it's the best available" — it's **ADR-0014's pinned
+`ATTR_EMULATE_PREPARES=false`**. With real prepares PDO performs no interpolation at all; statement
+and parameters travel separately by construction. So placeholder-only text at that boundary *is*
+placeholder-only text on the wire. And if emulation were ever silently re-enabled,
+`DatabaseConnectionTest` fails first — which makes the chain checkable rather than merely
+plausible.
+
+Covered every value-accepting path, because a binding guarantee is worth exactly what its leakiest
+entry point is worth: three `DatabaseConnection` methods, `where`, `whereIn`, and the same inside a
+transaction.
+
+## The leg I could not deliver, and did not paper over
+
+T-02's third leg is LIKE-wildcard escaping. The mechanism is `Sanitizer::sqlLikePattern()` — spec
+FR-10, **roadmap item 5.2**, Milestone 5. It does not exist. Building it here would jump a
+milestone and design a security helper under the wrong item's review.
+
+What ships instead is a test that states the truth:
+`testLikePatternsStillBindButWildcardsAreNotYetEscaped()`. It asserts what *is* true — a `LIKE`
+value binds and cannot inject SQL — and then asserts the gap: a user-supplied `%` still matches
+everything. The message names 5.2 as owner and says which assertion should flip when it lands.
+
+An untested gap and a gap with a test documenting it look identical in a coverage report and
+completely different to whoever reads the suite next. **T-02 is not complete at the end of 4.4**,
+and the roadmap entry says so instead of ticking a box the spec hasn't earned.
+
+## T-04 needed nothing, so I added nothing
+
+Spec T-04 is "exception → rollback → rethrow; savepoint nesting". Item 4.3 delivered exactly that,
+grouped, 17 tests. I checked it against the spec text and left it alone. Padding the item with
+redundant tests would have made it look busier and covered nothing new — the same judgement item
+2.6 and 3.4 made when their named suites turned out to be mostly already-satisfied.
+
+## Corpus notes
+
+Aimed at mechanisms, not scary strings: quote break-out, comment truncation, stacked statements,
+UNION exfiltration, backslash tricks, null bytes, CRLF, Unicode lookalikes, a 5.5 KB payload — and
+the **GBK multibyte quote** (`0xBF 0x27`), a valid GBK character whose second byte is a quote,
+which defeats a charset-unaware escaper. That's the exact attack ADR-0014's ordering removes, so it
+belongs in the corpus that proves the removal.
+
+One honest wrinkle: the empty-string payload skips the containment half of the assertion, because
+every string contains the empty string and the check can never hold. It stays for the binding half,
+and the skip is explained where it happens rather than the payload being quietly dropped from the
+provider.
+
+## Bar
+
+596 tests / 1253 assertions (up from 391). `--group T-02` runs 321, `--group T-04` 17. PHPStan max
+clean, deptrac 0/0, consistency lint OK.
+
+## State of Milestone 4
+
+4.1–4.4 done. Remaining: **4.5** (phpbench NFR-03 build-time benchmark, `fast / medium`).
+
+Carried forward, both named in ADRs rather than lost: T-02's LIKE leg awaits item **5.2**, and the
+MySQL-only behaviours (`SET NAMES utf8mb4` against a real server, real-prepares honoured by a real
+driver) still have no real driver behind them — a CI service container would close both, and that
+is a build-infrastructure decision rather than a test one.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Measuring what the old tests would have missed](2026/08/2026-08-04-t02-injection-suite.md)
 - [2026-08-04 — Transactions: three PDO probes that each decided a design](2026/08/2026-08-04-transaction-savepoints.md)
 - [2026-08-04 — The spec's own regex was the vulnerability](2026/08/2026-08-04-querybuilder-allowlist.md)
 - [2026-08-04 — Milestone 4 opens: the security default that fails by returning false](2026/08/2026-08-04-pinned-pdo-defaults.md)

--- a/src/test/php/d4np/utils/Database/Fixture/LoggedStatement.php
+++ b/src/test/php/d4np/utils/Database/Fixture/LoggedStatement.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database\Fixture;
+
+use PDOStatement;
+
+/**
+ * A `PDOStatement` that records what it was asked to run into a {@see QueryLog}.
+ *
+ * Installed via `PDO::ATTR_STATEMENT_CLASS`, so every statement the library prepares — through
+ * `DatabaseConnection`, `QueryBuilder` or `Transaction` — passes through here without any of them
+ * knowing. Nothing is stubbed: `parent::execute()` still runs against the real driver, so a test
+ * can assert on the log *and* on what the database actually did.
+ *
+ * The constructor is `protected` because PDO constructs this itself; the `QueryLog` arrives via
+ * the second element of the `ATTR_STATEMENT_CLASS` array.
+ */
+final class LoggedStatement extends PDOStatement
+{
+    protected function __construct(
+        private readonly QueryLog $log,
+    ) {
+    }
+
+    /**
+     * @param array<array-key, mixed>|null $params
+     */
+    public function execute(?array $params = null): bool
+    {
+        $this->log->entries[] = ['sql' => $this->queryString, 'params' => $params];
+
+        return parent::execute($params);
+    }
+}

--- a/src/test/php/d4np/utils/Database/Fixture/QueryLog.php
+++ b/src/test/php/d4np/utils/Database/Fixture/QueryLog.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database\Fixture;
+
+/**
+ * Everything the driver was asked to prepare, and everything it was asked to bind.
+ *
+ * Spec §7's T-02 requires that *"fuzzed value payloads reach the driver only as bound parameters
+ * via query-log assertion"*. This is that log. It sits at the PDO boundary — the last place inside
+ * this process where the SQL text and the values are still separable — and lets a test assert the
+ * property directly rather than infer it: **the payload appears in the parameter array and never
+ * in the statement text.**
+ *
+ * That boundary is the strongest one available here without a server. PDO offers no way to see the
+ * bytes it puts on the wire, and no database is available in CI to read a real `general_log` from.
+ * What makes the boundary sufficient is ADR-0014's pinned `ATTR_EMULATE_PREPARES=false`: with real
+ * prepares, PDO does not interpolate values into the SQL text at all — statement and parameters
+ * travel to the server separately. So SQL text that contains only placeholders *at this boundary*
+ * is SQL text that contains only placeholders on the wire. Were emulation ever silently re-enabled,
+ * `DatabaseConnectionTest` fails first.
+ */
+final class QueryLog
+{
+    /** @var list<array{sql: string, params: array<array-key, mixed>|null}> */
+    public array $entries = [];
+
+    /**
+     * Every distinct statement text the driver was asked to prepare.
+     *
+     * @return list<string>
+     */
+    public function statements(): array
+    {
+        return array_values(array_unique(array_map(
+            static fn (array $entry): string => $entry['sql'],
+            $this->entries,
+        )));
+    }
+
+    /**
+     * Every value bound, across every statement, flattened.
+     *
+     * @return list<mixed>
+     */
+    public function boundValues(): array
+    {
+        $values = [];
+        foreach ($this->entries as $entry) {
+            foreach ($entry['params'] ?? [] as $value) {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
+    }
+}

--- a/src/test/php/d4np/utils/Database/InjectionTest.php
+++ b/src/test/php/d4np/utils/Database/InjectionTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database;
+
+use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\Operator;
+use D4np\Utils\Database\QueryBuilder;
+use D4np\Utils\Database\Sort;
+use D4np\Utils\Database\Transaction;
+use D4np\Utils\Tests\Database\Fixture\LoggedStatement;
+use D4np\Utils\Tests\Database\Fixture\QueryLog;
+use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec §7's **T-02 injection suite**, first leg: *"fuzzed value payloads reach the driver only as
+ * bound parameters via query-log assertion"*.
+ *
+ * Items 4.1–4.3 asserted this indirectly — a hostile value round-tripped intact and the table
+ * survived, which is *consistent with* binding but does not prove it. A value can round-trip
+ * intact through correct escaping too. This suite proves the stronger property directly, by
+ * watching the boundary: for every payload, the statement text handed to the driver contains
+ * **only placeholders**, and the payload appears **only** in the bound parameter array.
+ *
+ * Every path that accepts a value is covered, because the guarantee is worth exactly as much as
+ * its leakiest entry point: `DatabaseConnection`'s three query methods, `QueryBuilder`'s `where`
+ * and `whereIn`, and the same through a `Transaction`.
+ *
+ * The other two legs of T-02: identifier injection is covered by `QueryBuilderTest` (17 hostile
+ * identifiers × 4 surfaces, same group), and **LIKE-wildcard escaping is not covered here** —
+ * `Sanitizer::sqlLikePattern()` is roadmap item 5.2 and does not exist yet. See the class-level
+ * note on {@see self::testLikePatternsStillBindButWildcardsAreNotYetEscaped()}.
+ */
+#[Group('T-02')]
+#[RequiresPhpExtension('pdo_sqlite')]
+final class InjectionTest extends TestCase
+{
+    private QueryLog $log;
+
+    private DatabaseConnection $connection;
+
+    protected function setUp(): void
+    {
+        $this->log = new QueryLog();
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_STATEMENT_CLASS, [LoggedStatement::class, [$this->log]]);
+
+        $this->connection = new DatabaseConnection($pdo);
+        $this->connection->execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
+        $this->connection->execute('CREATE TABLE secrets (token TEXT)');
+        $this->connection->execute("INSERT INTO secrets (token) VALUES ('do-not-leak')");
+
+        // Only the payload traffic matters; drop the fixture's own setup from the log.
+        $this->log->entries = [];
+    }
+
+    /**
+     * A corpus aimed at the ways SQL injection actually works, rather than a list of scary
+     * strings: quote break-out, comment truncation, stacked statements, UNION exfiltration,
+     * backslash and multibyte escaping tricks, and the encoding edge cases that defeat naive
+     * escapers.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function payloads(): iterable
+    {
+        yield 'classic tautology' => ["' OR '1'='1"];
+        yield 'tautology, double quotes' => ['" OR ""="'];
+        yield 'stacked drop' => ["Robert'); DROP TABLE users;--"];
+        yield 'stacked delete' => ['1; DELETE FROM users'];
+        yield 'comment truncation (dash)' => ["admin'--"];
+        yield 'comment truncation (hash)' => ['admin\'#'];
+        yield 'block comment' => ["admin'/*"];
+        yield 'union exfiltration' => ["' UNION SELECT token FROM secrets --"];
+        yield 'union with null padding' => ["' UNION SELECT NULL, token FROM secrets --"];
+        yield 'backslash escape' => ["\\' OR 1=1 --"];
+        yield 'double backslash' => ["\\\\' OR 1=1 --"];
+        // The classic charset attack: 0xBF 0x27 is a valid GBK character whose second byte is a
+        // quote. It defeats a client-side escaper that does not know the connection charset --
+        // which is exactly the scenario ADR-0014's real-prepares pin removes.
+        yield 'GBK multibyte quote' => ["\xbf\x27 OR 1=1 --"];
+        yield 'null byte' => ["admin\0' OR 1=1"];
+        yield 'newline injection' => ["admin'\nOR 1=1"];
+        yield 'CRLF injection' => ["admin'\r\nOR 1=1"];
+        yield 'tab injection' => ["admin'\tOR 1=1"];
+        yield 'nested quotes' => ["''''''"];
+        yield 'percent wildcard' => ['100%'];
+        yield 'underscore wildcard' => ['a_b'];
+        yield 'sqlite pragma' => ["'; PRAGMA writable_schema = 1;--"];
+        yield 'sqlite attach' => ["'; ATTACH DATABASE '/tmp/x' AS x;--"];
+        yield 'unicode quote lookalike' => ["admin\u{2019} OR 1=1"];
+        yield 'emoji' => ['🙂 OR 1=1'];
+        yield 'very long' => [str_repeat("' OR 1=1 --", 500)];
+        yield 'only whitespace' => ['   '];
+        yield 'empty string' => [''];
+        yield 'json-ish' => ['{"$ne": null}'];
+        yield 'template expression' => ['${1+1}'];
+        yield 'sprintf token' => ['%s %d %%'];
+    }
+
+    /**
+     * The core assertion, and the one the whole suite exists for.
+     *
+     */
+    private function assertNeverInStatementText(string $payload): void
+    {
+        $statements = $this->log->statements();
+
+        self::assertNotSame([], $statements, 'nothing was logged — the assertion would be vacuous');
+
+        // The empty string is a degenerate case for a substring check: every string contains it,
+        // so "the statement does not contain the payload" can never hold. It stays in the corpus
+        // because the *binding* half below is still meaningful for it — an empty value must still
+        // travel as a parameter — but the containment half is skipped rather than fudged.
+        if ($payload !== '') {
+            foreach ($statements as $sql) {
+                self::assertStringNotContainsString(
+                    $payload,
+                    $sql,
+                    "the payload reached the driver inside the statement text:\n" . $sql,
+                );
+            }
+        }
+
+        self::assertContains($payload, $this->log->boundValues(), 'the payload was not bound as a parameter');
+    }
+
+    #[DataProvider('payloads')]
+    public function testConnectionExecuteBindsRatherThanInterpolates(string $payload): void
+    {
+        $this->connection->execute('INSERT INTO users (name) VALUES (?)', [$payload]);
+
+        $this->assertNeverInStatementText($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testConnectionSelectBindsRatherThanInterpolates(string $payload): void
+    {
+        $this->connection->select('SELECT * FROM users WHERE name = ?', [$payload]);
+
+        $this->assertNeverInStatementText($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testConnectionSelectOneBindsRatherThanInterpolates(string $payload): void
+    {
+        $this->connection->selectOne('SELECT * FROM users WHERE name = :name', ['name' => $payload]);
+
+        $this->assertNeverInStatementText($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testQueryBuilderWhereBindsRatherThanInterpolates(string $payload): void
+    {
+        (new QueryBuilder($this->connection, 'users'))
+            ->where('name', Operator::Equals, $payload)
+            ->orderBy('id', Sort::Desc)
+            ->limit(10)
+            ->get();
+
+        $this->assertNeverInStatementText($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testQueryBuilderWhereInBindsRatherThanInterpolates(string $payload): void
+    {
+        (new QueryBuilder($this->connection, 'users'))
+            ->whereIn('name', [$payload, 'harmless'])
+            ->get();
+
+        $this->assertNeverInStatementText($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testBindingHoldsInsideATransaction(string $payload): void
+    {
+        (new Transaction($this->connection))->run(function () use ($payload): void {
+            $this->connection->execute('INSERT INTO users (name) VALUES (?)', [$payload]);
+        });
+
+        $this->assertNeverInStatementText($payload);
+    }
+
+    /**
+     * Binding is not only about syntax: the value must survive intact, and the schema must be
+     * untouched. A payload that were escaped rather than bound could still round-trip — which is
+     * why this runs *alongside* the query-log assertion rather than instead of it.
+     */
+    #[DataProvider('payloads')]
+    public function testThePayloadRoundTripsAndTheSchemaSurvives(string $payload): void
+    {
+        $this->connection->execute('INSERT INTO users (name) VALUES (?)', [$payload]);
+
+        $row = $this->connection->selectOne('SELECT name FROM users WHERE name = ?', [$payload]);
+
+        self::assertSame($payload, $row['name'] ?? null);
+        self::assertSame([['n' => 1]], $this->connection->select('SELECT COUNT(*) AS n FROM users'));
+        // Exfiltration and destruction both leave traces here.
+        self::assertSame([['n' => 1]], $this->connection->select('SELECT COUNT(*) AS n FROM secrets'));
+    }
+
+    /**
+     * A tautology payload must match nothing, because it is a *value*.
+     *
+     * This is the practical statement of the whole mechanism: `' OR '1'='1` is famous for
+     * returning every row, and bound it returns none.
+     */
+    public function testATautologyMatchesNothingBecauseItIsAValue(): void
+    {
+        $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['Ada']);
+        $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['Grace']);
+
+        $rows = (new QueryBuilder($this->connection, 'users'))
+            ->where('name', Operator::Equals, "' OR '1'='1")
+            ->get();
+
+        self::assertSame([], $rows);
+    }
+
+    /**
+     * **T-02's third leg is not covered, and this test says so rather than leaving a gap that
+     * looks like coverage.**
+     *
+     * Spec §7 asks T-02 for *"LIKE-wildcard escapes"*. The mechanism for that is FR-10's
+     * `Sanitizer::sqlLikePattern()`, which is **roadmap item 5.2** and does not exist yet — it is
+     * a Milestone 5 deliverable, and building it here would jump a milestone and duplicate that
+     * item.
+     *
+     * What is true today, and asserted below: a `LIKE` value **binds** like any other, so it
+     * cannot inject SQL. What is *not* true today is that its wildcards are neutralised — a
+     * user-supplied `%` still behaves as a wildcard, turning an intended exact-ish match into a
+     * scan. That is a real gap with a real consequence (unbounded scans; matching rows a user
+     * should not see), and it is FR-10's to close.
+     */
+    public function testLikePatternsStillBindButWildcardsAreNotYetEscaped(): void
+    {
+        $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['secret-document']);
+        $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['public-note']);
+
+        $rows = (new QueryBuilder($this->connection, 'users'))
+            ->where('name', Operator::Like, '%')
+            ->get();
+
+        // Binding held — no injection, no error.
+        $this->assertNeverInStatementText('%');
+
+        // But the wildcard still matched everything. When item 5.2 lands, a caller passing a
+        // literal '%' through Sanitizer::sqlLikePattern() will match nothing here, and this
+        // assertion is the one that should change.
+        self::assertCount(2, $rows, 'wildcard escaping is FR-10 / item 5.2, not yet implemented');
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item 4.4 (spec §7, T-02 + T-04).

T-02's first leg asks that fuzzed payloads reach the driver as bound parameters **"via query-log assertion"**. Items 4.1–4.3 already had tests that *looked* like this — hostile value round-trips intact, table survives — and it would have been easy to tick the box.

**It wasn't done.** Round-tripping intact is equally consistent with correct client-side escaping: an escaped value also survives and also leaves the schema alone. The test passes either way, so it can't distinguish the mechanism the security model depends on from one that merely resembles it.

### So I measured it rather than argued it

Planted a *correctly quote-escaping* interpolation in `DatabaseConnection::run()` — a real vulnerability that behaves well on every visible axis:

| assertion | under the planted vulnerability |
|---|---|
| round-trip + schema survives (4.1–4.3) | **28 of 29 passed** — misses it |
| query-log assertion (this item) | **28 of 29 failed** — catches it |

That's why the spec says *query-log*: it's the difference between testing an outcome and testing the mechanism.

### Why the PDO boundary is a sufficient proof point

`PDO::ATTR_STATEMENT_CLASS` records the exact SQL text and bound array while still executing for real. The obvious objection is that this is PDO's *input*, not the wire — and the answer that carries weight isn't "it's the best available". It's **ADR-0014's pinned `ATTR_EMULATE_PREPARES=false`**: with real prepares PDO performs no interpolation at all, so placeholder-only text there *is* placeholder-only text on the wire. If emulation were ever silently re-enabled, `DatabaseConnectionTest` fails first — which makes the chain checkable rather than plausible.

29 payloads × 6 value paths (`select`, `selectOne`, `execute`, `where`, `whereIn`, and the same inside a `Transaction`) — a binding guarantee is worth exactly what its leakiest entry point is worth. Corpus targets mechanisms, not scary strings: quote break-out, comment truncation, stacked statements, UNION exfiltration, backslash tricks, null bytes, CRLF, Unicode lookalikes, a 5.5 KB payload, and the **GBK multibyte quote** (`0xBF 0x27`) that defeats a charset-unaware escaper — the exact attack ADR-0014's ordering removes.

## ⚠️ T-02 is **not** complete, and this PR doesn't pretend otherwise

Its third leg — LIKE-wildcard escaping — needs `Sanitizer::sqlLikePattern()` (**FR-10, roadmap item 5.2**, a Milestone 5 deliverable that doesn't exist). Building it here would jump a milestone and design a security helper under the wrong item's review.

What ships instead is a test asserting the true state of affairs: a `LIKE` value binds and cannot inject SQL, but a user-supplied `%` still matches everything. Its message names 5.2 as owner and says which assertion should flip when it lands. An untested gap and a gap with a test documenting it look identical in a coverage report and completely different to whoever reads the suite next.

## T-04 needed no new tests

Spec T-04 is *"exception → rollback → rethrow; savepoint nesting"* — item 4.3 delivered exactly that, grouped, 17 tests. Verified against the spec text and left alone rather than padded to make this item look busier.

## Test plan

- [x] Non-vacuity against the **real** vulnerability (not a synthetic one): planted correctly-escaping interpolation → 142 failures + 6 errors
- [x] `vendor/bin/phpunit` — 596 tests, 1253 assertions, 7 skipped (up from 391)
- [x] `--group T-02` → 321 tests · `--group T-04` → 17
- [x] PHPStan max clean · deptrac 0/0 · consistency + action-pin lints OK
- [ ] CI

Honest wrinkle: the empty-string payload skips the *containment* half of the assertion (every string contains `''`, so the check can never hold). It stays for the binding half, and the skip is explained where it happens rather than the payload being quietly dropped.

## Process note

Routed `frontier-reasoning / extra`; session ran standard. Flagged when closing 4.3, you said proceed — recorded via `record_run.py --route-mismatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)