### PR TITLE
feat(security): context-aware Escaper for html/attr/js/url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,25 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   recorded honestly rather than adjusted to pass, shipped non-blocking by explicit maintainer
   decision, with closing the gap filed as roadmap item 3.7. The `benchmark` CI job (self-skipped
   since item 1.9) is now active, since `phpbench.json.dist` exists.
+- `D4np\Utils\Security\Escaper` (**ADR-0019**) — opens Milestone 5. RFC-0001's third security
+  mechanism: context-aware output escaping. Four methods — `html()`, `attr()`, `js()`, `url()` —
+  and deliberately **no general-purpose `escape()`**, because a method that did not name its
+  context is the one that would get used in the wrong one. Each documents what it is *not* safe
+  for, and a test asserts that separation rather than leaving it as advice.
+  **`attr()` assumes the attribute is unquoted**, escaping every non-alphanumeric ASCII character
+  as `&#xHH;`: an escaper cannot see its own call site, and the two possible assumptions are
+  asymmetric — assuming quoted is wrong toward an XSS hole, assuming unquoted is wrong toward
+  verbose output. Valid multibyte passes through, since no non-ASCII byte can terminate an
+  attribute and escaping bytes individually would only produce mojibake.
+  `js()` escapes on an allowlist, including `/` (inside `<script>` the HTML parser ends the element
+  at `</script>` regardless of JavaScript string state) and U+2028/U+2029 (JavaScript line
+  terminators before ES2019); output is pure ASCII with surrogate pairs above U+FFFF.
+  **Invalid UTF-8 becomes U+FFFD in all four.** Without `ENT_SUBSTITUTE`, `htmlspecialchars()`
+  returns an **empty string** for input containing one malformed byte — total silent data loss —
+  so `attr()` and `js()` reproduce the same substitution via PCRE rather than `mbstring`, which is
+  not a declared extension (NFR-08) and substitutes `?` rather than U+FFFD.
+  `url()` covers one URL *component*; it is **not** the defence for a whole-URL sink such as
+  `href="…"`, which needs scheme allowlisting — named as a gap rather than half-built.
 - phpbench benchmark for NFR-03 (**ADR-0018**) — closes Milestone 4. `QueryBuilderBench` measures
   a 5-condition `SELECT`'s build time; `QueryBuilderTest::testBuildingNeverRunsAQuery()` asserts
   the "0 queries executed" half directly via the same `QueryLog` fixture item 4.4 built (timing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — The same shape as NFR-01, found in a different class](docs/journal/2026/08/2026-08-04-nfr03-querybuilder-bench.md).
+  [2026-08-04 — Four grammars, and the assumption an escaper cannot check](docs/journal/2026/08/2026-08-04-escaper-contexts.md).
 
 ## Model & effort routing (advisory)
 
@@ -259,8 +259,18 @@ Safe-by-default PDO access (RFC-0001).
 
 Explicit-mechanism security helpers (RFC-0001; every item carries the protected `security` floor).
 
-- [ ] 5.1 `Escaper`: html/attr/js/url context escaping (RFC-0001) (security) —
-      route: frontier-reasoning / extra
+- [x] 5.1 `Escaper`: html/attr/js/url context escaping (RFC-0001) (security) —
+      route: frontier-reasoning / extra · **ADR-0019**. *Four methods, deliberately no general
+      `escape()` — a wrapper that guessed the context is the one that gets used in a `<script>`
+      block. **`attr()` assumes the attribute is UNQUOTED** (`&#xHH;` for every non-alphanumeric
+      ASCII): an escaper cannot see its call site, and the two assumptions are asymmetric —
+      assuming quoted is wrong toward an XSS hole, assuming unquoted is wrong toward verbosity.
+      `js()` escapes `/` (`</script>` ends the element regardless of JS string state) and
+      U+2028/U+2029 (JS line terminators pre-ES2019). Probed: without `ENT_SUBSTITUTE`,
+      `htmlspecialchars()` returns **`''`** for invalid UTF-8 — total silent data loss — so all
+      four substitute U+FFFD identically, via PCRE rather than `mbstring` (undeclared dependency,
+      and it substitutes `?` not U+FFFD). Suite proved non-vacuous with 7 planted defects. OWASP
+      corpus snapshot stays item 5.4.*
 - [ ] 5.2 `Sanitizer::richText()` over symfony/html-sanitizer (optional dep) +
       `sqlLikePattern()` (RFC-0001) (security) — route: frontier-reasoning / extra
 - [ ] 5.3 `Hash`: Argon2id default, `bcryptFallback` policy, `needsRehash()` (RFC-0001)

--- a/docs/adr/0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md
+++ b/docs/adr/0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md
@@ -1,0 +1,152 @@
+# ADR-0019: Four escaping contexts, no general `escape()`, and assume the attribute is unquoted
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 5.1 (opens Milestone 5) · spec FR-09 · item 5.4 (OWASP corpus snapshot
+  suite) · [RFC-0001](../rfc/0001-egl-utils-library.md) §Context (security mechanism 3) ·
+  [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) (mechanism 2's
+  allowlist-over-escape reasoning, applied again here)
+
+## Context
+
+RFC-0001's third security mechanism: *"Output: context-aware escaping at render time, never input
+mutilation."* Spec FR-09 names four operations — `html()` with `ENT_QUOTES|ENT_SUBSTITUTE` and
+UTF-8, `attr()`, `js()` in hex, and `url()` via `rawurlencode()`.
+
+The word doing the work is **context-aware**. HTML is not one grammar but several nested ones, and
+a value escaped for the wrong one is not partially safe, it is unsafe. Three facts were probed
+before writing anything, and each changed the design:
+
+| probe | result |
+|---|---|
+| `htmlspecialchars()` on invalid UTF-8 **without** `ENT_SUBSTITUTE` | returns **`''`** — the entire value silently vanishes |
+| `htmlspecialchars()` on `/` and `` ` `` | neither is escaped, in any flag combination |
+| `mb_convert_encoding($s, 'UTF-8', 'UTF-8')` on invalid input | substitutes **`?`**, not U+FFFD — disagreeing with `ENT_SUBSTITUTE` |
+
+## Decision
+
+### 1. Four methods, and deliberately no general-purpose `escape()`
+
+There is no method that does not name its context. A convenience wrapper that guessed, or that
+defaulted to "HTML", would be the one that got reached for in a `<script>` block — and the failure
+would be invisible in review, because the call would look escaped. The four methods are documented
+with what each is **not** safe for, and a test asserts the separation rather than leaving it as
+docblock advice: `html()` output still contains the `/` that closes a `<script>` element, and still
+contains the space that ends an unquoted attribute.
+
+### 2. `attr()` assumes the attribute is **unquoted**
+
+`html()` is sufficient for `x="…"` and `x='…'`. It is not sufficient for `x=…`, where a space,
+tab, newline, `/`, `>` or backtick ends the attribute and starts a new one — `onmouseover=alert(1)`
+needs no quote character at all.
+
+**An escaper cannot see its own call site.** It cannot know whether the caller quoted the
+attribute, and the two possible assumptions are not symmetric: assuming *quoted* is wrong in the
+direction of an XSS hole, assuming *unquoted* is wrong in the direction of verbose output. So
+`attr()` escapes **every non-alphanumeric ASCII character** as `&#xHH;` — OWASP's unquoted-context
+rule, and inert in the quoted context.
+
+This is the same shape of reasoning ADR-0015 used for SQL identifiers: prefer the strict, total
+rule over the one that is correct only if the caller did something the callee cannot verify.
+
+**Non-ASCII passes through unchanged**, and that is a decision rather than an omission. Every
+character that can terminate an attribute is ASCII, so a multibyte sequence cannot be a delimiter.
+Escaping the individual *bytes* — the literal reading of OWASP's "ASCII values less than 256",
+written when single-byte encodings were the default — would emit one entity per byte and turn the
+text into mojibake. Asserted, so nobody "fixes" it toward the literal reading later.
+
+### 3. `js()` escapes everything non-alphanumeric, including two non-ASCII characters
+
+An allowlist, not a denylist: a denylist in an escaper is a list of the attacks its author had
+heard of. Three specifics that a naive "escape quotes and backslashes" misses, each a documented
+break-out:
+
+- **`/` is escaped.** Inside a `<script>` element the HTML parser runs *before* the JavaScript
+  parser and knows nothing about string literals: the byte sequence `</script>` ends the element
+  wherever it appears, quoted or not.
+- **U+2028 and U+2029 are escaped**, despite being non-ASCII. They are JavaScript *line
+  terminators* before ES2019 — an unescaped one ends the statement, and what follows is code
+  rather than string data. They are the reason `js()` cannot pass non-ASCII through the way
+  `attr()` safely can.
+- **Output is pure ASCII** (`\xHH`, and `\uXXXX` with surrogate pairs above U+FFFF), so it survives
+  whatever charset the surrounding document is actually served with.
+
+`js()` makes a value safe **as a string in JavaScript**, not safe *as* JavaScript. Interpolating
+attacker-controlled data where a string literal is not already the grammar — an event-handler
+attribute, a `src`, `eval()` — is a different problem and is documented as out of scope rather
+than silently implied.
+
+### 4. `url()` escapes a component, and its likely misuse fails safe
+
+`rawurlencode()` per FR-09 — not `urlencode()`, which renders a space as `+` (correct only in an
+`x-www-form-urlencoded` body, wrong in a path segment where `+` is a literal plus).
+
+It escapes **one component**, not a URL. Passing a whole URL encodes its `:` and `/`, yielding an
+inert relative path. That misuse is stated prominently *because* the failure mode is favourable
+and worth relying on: a broken link is visible, and `javascript:alert(1)` encodes to
+`javascript%3Aalert%281%29`, which no browser treats as a scheme. Asserted as a test.
+
+It follows that `url()` is **not** the defence for a whole-URL sink like `href="…"`; that needs
+scheme allowlisting, which is a different mechanism, outside FR-09, and deliberately not invented
+here.
+
+### 5. Invalid UTF-8 becomes U+FFFD in all four, via PCRE rather than `mbstring`
+
+`ENT_SUBSTITUTE` is the single most load-bearing flag in the class: without it a value containing
+one bad byte renders as **nothing at all**, which is a bug that hides. `attr()` and `js()` do their
+own escaping and so must reproduce that behaviour, or the library would answer differently for the
+same input depending on which context a template used.
+
+Implemented with a PCRE UTF-8-sequence pattern, **not `mbstring`**, for two reasons: `mbstring` is
+not among this library's declared extensions (`ext-pdo`, `ext-fileinfo` — spec NFR-08), and a
+security helper is the wrong place to quietly acquire a hard dependency; and
+`mb_convert_encoding()` substitutes `?` rather than U+FFFD, which would have *disagreed* with
+`html()`. Overlong encodings, surrogate halves and codepoints above U+10FFFF were each verified
+rejected directly, because "the regex looks right" is not a property a security boundary should
+rest on.
+
+## Alternatives Considered
+
+- **One `escape($value, $context)` with an enum** — rejected. It reads well, and it makes the
+  context a *runtime argument* that can be wrong, defaulted, or passed a variable. Four named
+  methods make the context a fact of the call site, visible in review and in a grep.
+- **`attr()` delegating to `html()`** (sufficient if attributes are always quoted) — rejected on
+  the reasoning in §2; probed, and it fails 16 tests including the unquoted break-out.
+- **A denylist for `js()`** (quotes, backslash, angle brackets) — rejected; probed, and it fails
+  6 tests including `</script>` break-out and the U+2028 line terminator.
+- **Escaping every byte ≥ 0x80 in `attr()`** — the literal OWASP wording, rejected: it corrupts
+  valid UTF-8 into mojibake and defends against nothing, since no multibyte byte is a delimiter.
+- **Adding `ext-mbstring`** — rejected on NFR-08 and on the `?`-vs-U+FFFD disagreement above.
+- **Adding scheme allowlisting to `url()`** — rejected as out of FR-09's scope, and because
+  bundling two unrelated defences into one method makes it unclear which one a caller is getting.
+  Named as a gap instead.
+- **A CSS-context escaper** — not in FR-09; noted in the class docblock as an uncovered context
+  rather than half-implemented.
+
+## Consequences
+
+- Four contexts, each with a documented safe-in and not-safe-in list, and a test that asserts the
+  separation is real rather than advisory.
+- **The suite is verified non-vacuous** against six planted defects, each caught and reverted:
+  dropping `ENT_SUBSTITUTE` (2 failures), `ENT_COMPAT` instead of `ENT_QUOTES` (6), `attr()`
+  delegating to `html()` (16), `urlencode()` instead of `rawurlencode()` (2), a `js()` denylist
+  (6), `js()` passing non-ASCII through (6), and `toValidUtf8()` as a no-op (3).
+- `Escaper` joins `StaticUtilityContractTest`, so its private constructor is asserted present and
+  inert like every other static helper's.
+- **The OWASP cheat-sheet snapshot corpus is item 5.4, not this item.** What ships here is the
+  behavioural contract plus break-out payloads that distinguish the contexts; the corpus suite is
+  a separate roadmap deliverable and is not pre-empted.
+- `attr()` output is verbose — every space becomes `&#x20;`. That cost is paid on the path where
+  the caller quoted the attribute and did not need it, in exchange for correctness on the path
+  where they did not and it was exploitable.
+- No CSS context, and no whole-URL/scheme validation. Both named, neither half-built.
+
+## References
+
+- Spec FR-09 (the four operations and `html()`'s exact flags), §7 (item 5.4's OWASP corpus)
+- RFC-0001 §Context, security mechanism 3 — context-aware output escaping, never input mutilation
+- ADR-0015 — the same "prefer the total rule over one that depends on the caller" reasoning
+- Verified directly on PHP 8.3.1: `htmlspecialchars()` returning `''` without `ENT_SUBSTITUTE`;
+  `/` and `` ` `` never escaped; `mb_convert_encoding()` substituting `?`; UTF-16 surrogate-pair
+  arithmetic; `rawurlencode()` on a whole URL

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0016](0016-closure-scoped-transactions-with-savepoint-nesting.md) | Closure-scoped transactions, savepoint nesting, and keeping the original exception | Accepted |
 | [0017](0017-prove-binding-at-the-pdo-boundary-and-defer-t02s-like-leg.md) | Prove binding at the PDO boundary, and ship T-02 with its LIKE leg openly deferred | Accepted |
 | [0018](0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md) | QueryBuilder's benchmark measures NFR-03 now; the ~23µs build-time gap is deliberately deferred | Accepted |
+| [0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md) | Four escaping contexts, no general `escape()`, and assume the attribute is unquoted | Accepted |

--- a/docs/journal/2026/08/2026-08-04-escaper-contexts.md
+++ b/docs/journal/2026/08/2026-08-04-escaper-contexts.md
@@ -1,0 +1,119 @@
+# 2026-08-04 — Four grammars, and the assumption an escaper cannot check
+
+Roadmap item **5.1**, opening Milestone 5. Route `frontier-reasoning / extra`; session switched to
+Fable 5 — the frontier tier. First time in three items the route and the session actually agree.
+
+## Three probes, three design changes
+
+Before writing anything:
+
+| probe | result | what it changed |
+|---|---|---|
+| `htmlspecialchars()` on invalid UTF-8 **without** `ENT_SUBSTITUTE` | returns **`''`** | made UTF-8 handling the class's central concern, not a footnote |
+| `htmlspecialchars()` on `/` and `` ` `` | never escaped, any flags | `attr()` and `js()` cannot be built on it |
+| `mb_convert_encoding($s,'UTF-8','UTF-8')` on bad input | substitutes **`?`**, not U+FFFD | ruled out mbstring on correctness, not just dependency grounds |
+
+The first one is the one I'd have gotten wrong by reading the spec alone. FR-09 pins
+`ENT_SUBSTITUTE` and it would be easy to treat that as a tidiness flag. It isn't: without it a
+value containing one malformed byte renders as **nothing at all**. A template that silently emits
+an empty string where a username should be is a bug that hides indefinitely.
+
+That finding then propagated. `attr()` and `js()` do their own escaping, so they had to reproduce
+the same U+FFFD substitution or the library would answer differently for the same input depending
+on which context a template happened to use. Hence a UTF-8 sanitizer — built on PCRE, because
+mbstring is not a declared extension (NFR-08) *and* because it substitutes `?`, which would have
+disagreed with `html()`. Verified the pattern rejects overlong encodings, surrogate halves, and
+codepoints above U+10FFFF, because "the regex looks right" isn't a property a security boundary
+should rest on.
+
+## The decision I want on record
+
+**`attr()` assumes the attribute is unquoted.**
+
+`html()` is sufficient for `x="…"` and `x='…'`. It is useless for `x=…`, where a space ends the
+attribute and the next token starts a new one — `onmouseover=alert(1)` needs no quote character at
+all.
+
+An escaper **cannot see its own call site.** It cannot know whether the caller quoted. And the two
+possible assumptions are not symmetric:
+
+- assume quoted → wrong in the direction of an XSS hole
+- assume unquoted → wrong in the direction of verbose output
+
+So: every non-alphanumeric ASCII becomes `&#xHH;`. Every space in every attribute becomes
+`&#x20;`, forever, on every page — paid on the path where the caller *did* quote and didn't need
+it, in exchange for correctness on the path where they didn't and it was exploitable.
+
+This is the same shape as ADR-0015's identifier reasoning: prefer the total rule over one that's
+correct only if the caller did something the callee can't verify. Nice to notice the project has
+developed a consistent instinct here rather than deciding it fresh each time.
+
+## Where the literal spec reading would have been wrong
+
+OWASP's rule for attributes says "escape all characters with ASCII values less than 256". Read
+literally in 2026 that means escaping bytes `0x80`–`0xFF` — which in UTF-8 are *continuation
+bytes*, not characters. Doing it would emit one `&#xHH;` per byte and turn `héllo漢🙂` into
+mojibake, while defending against nothing: no multibyte byte can terminate an attribute.
+
+The rule was written when single-byte encodings were the default. I implemented its intent
+(neutralise every ASCII delimiter) rather than its letter, and pinned that with a test so nobody
+"corrects" it toward the literal wording later — the same move item 4.2 made when FR-07's own
+regex turned out to be a bypass.
+
+## `js()` is not "escape quotes and backslashes"
+
+Three break-outs a denylist misses:
+
+- **`/`** — inside `<script>`, the HTML parser runs first and knows nothing about JS string
+  literals. `</script>` ends the element wherever it appears, quoted or not.
+- **U+2028 / U+2029** — JavaScript line terminators before ES2019. Unescaped, one ends the
+  statement and everything after it is code. These are why `js()` can't pass non-ASCII through the
+  way `attr()` safely can.
+- **everything else non-alphanumeric** — a denylist in an escaper is a list of the attacks its
+  author had heard of.
+
+Output is pure ASCII (`\xHH`, `\uXXXX` with surrogate pairs above U+FFFF) so it survives whatever
+charset the document is actually served with.
+
+Documented plainly: `js()` makes a value safe **as a string in** JavaScript, not safe **as**
+JavaScript. Event-handler attributes, `src`, `eval()` are a different problem.
+
+## A misuse that fails safe, so I pinned it
+
+`url()` escapes a *component*. The likely misuse is passing a whole URL, which encodes its `:` and
+`/` into an inert relative path. That's a **visible** failure — a broken link, not a silent hole —
+and `javascript:alert(1)` encodes to `javascript%3Aalert%281%29`, which no browser reads as a
+scheme. Worth a test precisely because the failure mode is favourable and it's reasonable to rely
+on it.
+
+What `url()` is *not* is the defence for `href="…"`. That needs scheme allowlisting — a different
+mechanism, outside FR-09, deliberately not invented here. Named as a gap rather than half-built.
+
+## Non-vacuity
+
+Seven planted defects, each caught and reverted:
+
+| planted | failures |
+|---|---|
+| `attr()` delegates to `html()` | 16 |
+| `ENT_COMPAT` instead of `ENT_QUOTES` | 6 |
+| `js()` uses a denylist | 6 |
+| `js()` passes non-ASCII through | 6 |
+| `toValidUtf8()` is a no-op | 3 |
+| `html()` drops `ENT_SUBSTITUTE` | 2 |
+| `urlencode()` instead of `rawurlencode()` | 2 |
+
+One of these needed redoing: my first denylist probe produced a broken regex and 61 *errors*,
+which is not a meaningful signal — an error means the code didn't run, not that the test caught
+something. Redid it cleanly to get a real 6 failures.
+
+## Bar
+
+661 tests / 1433 assertions green (up from 597). PHPStan max clean, deptrac 0/0 — `Security` is now
+a third real group depending on nothing, which the layering gate confirms.
+
+## Next
+
+**5.2** — `Sanitizer::richText()` over `symfony/html-sanitizer` (an *optional* dependency, a first
+for this library) plus `sqlLikePattern()`, which also closes T-02's third leg left open at item
+4.4. Routed `frontier-reasoning / extra`, matching this session.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Four grammars, and the assumption an escaper cannot check](2026/08/2026-08-04-escaper-contexts.md)
 - [2026-08-04 — The same shape as NFR-01, found in a different class](2026/08/2026-08-04-nfr03-querybuilder-bench.md)
 - [2026-08-04 — Measuring what the old tests would have missed](2026/08/2026-08-04-t02-injection-suite.md)
 - [2026-08-04 — Transactions: three PDO probes that each decided a design](2026/08/2026-08-04-transaction-savepoints.md)

--- a/src/main/php/d4np/utils/Security/Escaper.php
+++ b/src/main/php/d4np/utils/Security/Escaper.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Security;
+
+/**
+ * Context-aware output escaping (spec FR-09, ADR-0019).
+ *
+ * RFC-0001's third security mechanism: *"Output: context-aware escaping at render time, never
+ * input mutilation."* The four methods here are not four spellings of one idea — they are four
+ * different grammars, and a value escaped for one is **not** safe in another. `html()` output
+ * inside a `<script>` block is still executable; `js()` output inside an unquoted attribute can
+ * still break out. There is deliberately no general-purpose `escape()`, because the method that
+ * did not need a context is the one that would get used in the wrong one.
+ *
+ * | method | safe in | mechanism |
+ * |---|---|---|
+ * | {@see html()} | element text, **quoted** attributes | `htmlspecialchars` with the pinned flags |
+ * | {@see attr()} | any attribute, **including unquoted** | `&#xHH;` for every non-alphanumeric ASCII |
+ * | {@see js()} | inside a JavaScript **string literal** | `\xHH` / `\uXXXX` |
+ * | {@see url()} | one URL **component** | `rawurlencode` |
+ *
+ * **Invalid UTF-8 becomes U+FFFD, in all four, by design.** This is not incidental tidiness: it
+ * is the single most load-bearing detail in the class. Called *without* `ENT_SUBSTITUTE`,
+ * `htmlspecialchars()` returns an **empty string** for input containing an invalid byte sequence
+ * — verified, not assumed. A template that silently renders nothing where a value should be is a
+ * bug that hides; historically, malformed sequences were also an XSS vector in their own right,
+ * because a browser resynchronising on a broken sequence could reinterpret the bytes around it.
+ * `html()` gets that behaviour from the pinned flag; {@see attr()} and {@see js()} get it from
+ * {@see toValidUtf8()}, which reproduces exactly the same U+FFFD substitution so that all four
+ * methods answer identically for the same bad input.
+ *
+ * That substitution is implemented with PCRE rather than `mbstring`, deliberately: `mbstring` is
+ * not among this library's declared extensions (`ext-pdo`, `ext-fileinfo` — spec NFR-08), and a
+ * security helper is the wrong place to acquire a new hard dependency. `mb_convert_encoding()`
+ * would also have substituted `?` rather than U+FFFD, disagreeing with `htmlspecialchars()`.
+ */
+final class Escaper
+{
+    /**
+     * Matches one well-formed UTF-8 sequence, or — as a last alternative — any single byte.
+     *
+     * The final `.` is what makes the pattern total: anything that is not a valid sequence is
+     * captured one byte at a time, and {@see toValidUtf8()} replaces exactly those. Overlong
+     * encodings (`\xE0\x80\xAF`), surrogate halves (`\xED\xA0\x80`) and codepoints above
+     * U+10FFFF (`\xF4\x90\x80\x80`) all fail the valid alternatives and are caught by it — each
+     * verified directly, because "the regex looks right" is not a property a security boundary
+     * should rest on.
+     */
+    private const UTF8_SEQUENCE = '/[\x00-\x7F]'
+        . '|[\xC2-\xDF][\x80-\xBF]'
+        . '|\xE0[\xA0-\xBF][\x80-\xBF]'
+        . '|[\xE1-\xEC][\x80-\xBF]{2}'
+        . '|\xED[\x80-\x9F][\x80-\xBF]'
+        . '|[\xEE-\xEF][\x80-\xBF]{2}'
+        . '|\xF0[\x90-\xBF][\x80-\xBF]{2}'
+        . '|[\xF1-\xF3][\x80-\xBF]{3}'
+        . '|\xF4[\x80-\x8F][\x80-\xBF]{2}'
+        . '|./s';
+
+    private function __construct()
+    {
+        // Static-only: no instances.
+    }
+
+    /**
+     * Escape for HTML element text, or for an attribute **you have quoted**.
+     *
+     * The flags are spec FR-09's, verbatim, and each earns its place:
+     *
+     * - `ENT_QUOTES` escapes both `"` and `'`. `ENT_COMPAT` (PHP's default before 8.1) leaves `'`
+     *   alone, which is safe in `attr="…"` and an XSS hole in `attr='…'`.
+     * - `ENT_SUBSTITUTE` replaces invalid UTF-8 with U+FFFD instead of returning `''`. See the
+     *   class docblock — this is the flag that turns silent, total data loss into a visible
+     *   replacement character.
+     * - `'UTF-8'` is passed explicitly rather than relying on `default_charset`, which a consumer's
+     *   `php.ini` can change underneath this library.
+     *
+     * The flags are also *not* left to PHP's defaults even where they currently agree: PHP 8.1
+     * changed the default from `ENT_COMPAT` to `ENT_QUOTES | ENT_SUBSTITUTE`, and a security
+     * guarantee that holds only on some supported versions is not a guarantee.
+     *
+     * **Not safe** inside `<script>`, inside a `style` attribute, in an unquoted attribute, or as
+     * a URL. Those are {@see js()}, a CSS context this library does not yet cover, {@see attr()}
+     * and {@see url()} respectively.
+     */
+    public static function html(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+
+    /**
+     * Escape for an HTML attribute value, including one the caller did not quote.
+     *
+     * `html()` is sufficient for `attr="…"` and `attr='…'`. It is **not** sufficient for
+     * `attr=…`, where a space, tab, newline, `/`, `>` or backtick ends the attribute and begins a
+     * new one — `onmouseover=alert(1)` needs no quote character at all to get in.
+     *
+     * An escaper cannot see its own call site and therefore cannot know whether the caller quoted
+     * the attribute. Assuming they did means being wrong in the direction of an XSS hole, so this
+     * assumes they did not: **every non-alphanumeric ASCII character becomes `&#xHH;`**, which is
+     * OWASP's rule for the unquoted-attribute context and is inert in the quoted one too. The
+     * cost is verbosity in the rendered HTML, paid on the rare path where it is not needed rather
+     * than on the common path where its absence is exploitable.
+     *
+     * Characters outside ASCII pass through unchanged, and that is deliberate rather than an
+     * omission: every character that can terminate an attribute is ASCII, so a multibyte sequence
+     * cannot be a delimiter. Escaping the individual **bytes** of one — the naive reading of
+     * OWASP's "ASCII values less than 256", which predates UTF-8 being the default — would emit
+     * one entity per byte and corrupt the text into mojibake.
+     */
+    public static function attr(string $value): string
+    {
+        $escaped = preg_replace_callback(
+            '/[^a-zA-Z0-9]/',
+            static function (array $match): string {
+                $byte = $match[0];
+
+                // Leave the bytes of a valid multibyte sequence alone; only ASCII can delimit.
+                if ($byte >= "\x80") {
+                    return $byte;
+                }
+
+                return sprintf('&#x%02X;', ord($byte));
+            },
+            self::toValidUtf8($value),
+        );
+
+        return $escaped ?? '';
+    }
+
+    /**
+     * Escape for use **inside a JavaScript string literal** — `var x = '<here>';`
+     *
+     * Three things this handles that a naive "escape quotes and backslashes" does not, each of
+     * which is a real, documented break-out:
+     *
+     * - **`/` is escaped.** Inside a `<script>` element the HTML parser runs first and knows
+     *   nothing about JavaScript string literals: the byte sequence `</script>` ends the element
+     *   wherever it appears, quoted or not. Escaping `/` as `\x2F` is what stops a payload
+     *   closing the block it is sitting in.
+     * - **U+2028 and U+2029 are escaped**, despite being non-ASCII. `LINE SEPARATOR` and
+     *   `PARAGRAPH SEPARATOR` are *line terminators* in JavaScript before ES2019, so an unescaped
+     *   one ends the statement and everything after it is code. They are the reason this method
+     *   cannot simply pass non-ASCII through the way {@see attr()} safely can.
+     * - **Everything non-alphanumeric is escaped**, rather than a denylist of characters thought
+     *   to be dangerous. A denylist in an escaper is a list of the attacks its author had heard
+     *   of.
+     *
+     * Non-ASCII is emitted as `\uXXXX`, with a surrogate pair above U+FFFF, so the output is pure
+     * ASCII and survives any charset the surrounding document is served with.
+     *
+     * **This does not make a value safe as JavaScript.** It makes it safe as a *string* in
+     * JavaScript. Interpolating attacker-controlled data anywhere a value is not already a string
+     * literal — an event-handler attribute, a `src`, `eval()`, a JSON-in-HTML block — is a
+     * different problem this method does not solve.
+     */
+    public static function js(string $value): string
+    {
+        $escaped = preg_replace_callback(
+            '/[^a-zA-Z0-9]/u',
+            static function (array $match): string {
+                $character = $match[0];
+
+                if (strlen($character) === 1) {
+                    return sprintf('\\x%02X', ord($character));
+                }
+
+                $codepoint = self::codepointOf($character);
+
+                if ($codepoint > 0xFFFF) {
+                    // JavaScript's \u escape addresses UTF-16 code units, so anything outside the
+                    // BMP is written as the surrogate pair it is stored as.
+                    $offset = $codepoint - 0x10000;
+
+                    return sprintf('\\u%04X\\u%04X', 0xD800 + ($offset >> 10), 0xDC00 + ($offset & 0x3FF));
+                }
+
+                return sprintf('\\u%04X', $codepoint);
+            },
+            self::toValidUtf8($value),
+        );
+
+        return $escaped ?? '';
+    }
+
+    /**
+     * Escape one **component** of a URL — a single path segment, or one query-string value.
+     *
+     * `rawurlencode()` per spec FR-09, which is RFC 3986 percent-encoding. Note it is not
+     * `urlencode()`: that encodes a space as `+`, which is correct only in
+     * `application/x-www-form-urlencoded` bodies and wrong in a path segment, where `+` is a
+     * literal plus.
+     *
+     * **A component, not a URL.** Passing a whole URL through this encodes its `:` and `/`, so
+     * `https://example.com/a` becomes `https%3A%2F%2Fexample.com%2Fa` — a relative path that
+     * resolves to nothing. That is a visible, harmless failure, and it is worth stating plainly
+     * *because* it is the likely misuse: the failure mode is a broken link, not a silent hole.
+     *
+     * It follows that this method is **not** the defence for a whole-URL sink such as
+     * `href="…"`. There, the risk is a `javascript:` or `data:` scheme, and the defence is
+     * validating the scheme against an allowlist — a different mechanism, not in FR-09's scope,
+     * and deliberately not invented here. (Should such a value be run through this method anyway,
+     * the result is inert: `javascript:alert(1)` encodes to `javascript%3Aalert%281%29`, which no
+     * browser treats as a scheme.)
+     */
+    public static function url(string $value): string
+    {
+        return rawurlencode($value);
+    }
+
+    /**
+     * Replace every byte that is not part of a well-formed UTF-8 sequence with U+FFFD.
+     *
+     * Reproduces `ENT_SUBSTITUTE`'s behaviour for the two methods that do their own escaping, so
+     * that all four answer identically for the same malformed input — asserted, not assumed.
+     */
+    private static function toValidUtf8(string $value): string
+    {
+        $valid = preg_replace_callback(
+            self::UTF8_SEQUENCE,
+            static function (array $match): string {
+                // A single byte above ASCII reached the `.` alternative, meaning it did not form a
+                // valid sequence with its neighbours.
+                if (strlen($match[0]) === 1 && $match[0] >= "\x80") {
+                    return "\u{FFFD}";
+                }
+
+                return $match[0];
+            },
+            $value,
+        );
+
+        return $valid ?? '';
+    }
+
+    /**
+     * The Unicode codepoint of one well-formed UTF-8 character.
+     *
+     * Decoded by hand rather than via `mb_ord()` — see the class docblock on why `mbstring` is
+     * not a dependency of this library. The input is always a single character produced by a
+     * `/u` match over a string {@see toValidUtf8()} has already made well-formed.
+     */
+    private static function codepointOf(string $character): int
+    {
+        return match (strlen($character)) {
+            2 => ((ord($character[0]) & 0x1F) << 6)
+                | (ord($character[1]) & 0x3F),
+            3 => ((ord($character[0]) & 0x0F) << 12)
+                | ((ord($character[1]) & 0x3F) << 6)
+                | (ord($character[2]) & 0x3F),
+            default => ((ord($character[0]) & 0x07) << 18)
+                | ((ord($character[1]) & 0x3F) << 12)
+                | ((ord($character[2]) & 0x3F) << 6)
+                | (ord($character[3]) & 0x3F),
+        };
+    }
+}

--- a/src/test/php/d4np/utils/Security/EscaperTest.php
+++ b/src/test/php/d4np/utils/Security/EscaperTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Security;
+
+use D4np\Utils\Security\Escaper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-09's four escaping contexts.
+ *
+ * The OWASP cheat-sheet **snapshot** suite is roadmap item 5.4 and is not this file; what is here
+ * is the behavioural contract each method owes its own context, plus the break-out payloads that
+ * distinguish the contexts from one another. The cases that matter most are the ones proving a
+ * value escaped for one context is *not* safe in another — that separation is the entire reason
+ * FR-09 asks for four methods rather than one.
+ */
+#[Group('T-06')]
+final class EscaperTest extends TestCase
+{
+    // ---- html() -------------------------------------------------------------------------------
+
+    public function testHtmlEscapesTheFiveSignificantCharacters(): void
+    {
+        self::assertSame('&lt;a&gt; &amp; &quot;q&quot; &#039;s&#039;', Escaper::html('<a> & "q" \'s\''));
+    }
+
+    /**
+     * `ENT_COMPAT` — PHP's default before 8.1 — leaves `'` alone, which is safe in `x="…"` and an
+     * XSS hole in `x='…'`. Pinning `ENT_QUOTES` is what closes that.
+     */
+    public function testHtmlEscapesSingleQuotesNotJustDouble(): void
+    {
+        self::assertSame('&#039;', Escaper::html("'"));
+    }
+
+    public function testHtmlLeavesOrdinaryTextAlone(): void
+    {
+        self::assertSame('Grace Hopper — héllo 漢 🙂', Escaper::html('Grace Hopper — héllo 漢 🙂'));
+    }
+
+    /**
+     * The single most load-bearing detail in the class. Without `ENT_SUBSTITUTE`,
+     * `htmlspecialchars()` returns an **empty string** for input containing an invalid byte
+     * sequence — silent, total data loss. Verified against PHP directly, then pinned here.
+     */
+    public function testHtmlSubstitutesInvalidUtf8RatherThanReturningEmpty(): void
+    {
+        $escaped = Escaper::html("before \xC3\x28 after");
+
+        self::assertNotSame('', $escaped);
+        self::assertStringContainsString('before', $escaped);
+        self::assertStringContainsString('after', $escaped);
+        self::assertStringContainsString("\u{FFFD}", $escaped);
+        // And what comes out is itself well-formed, so it cannot corrupt the document.
+        self::assertSame(1, preg_match('//u', $escaped));
+    }
+
+    // ---- attr() -------------------------------------------------------------------------------
+
+    public function testAttrEscapesEveryNonAlphanumericAsciiCharacter(): void
+    {
+        self::assertSame('&#x20;', Escaper::attr(' '));
+        self::assertSame('&#x2F;', Escaper::attr('/'));
+        self::assertSame('&#x3D;', Escaper::attr('='));
+        self::assertSame('&#x60;', Escaper::attr('`'));
+        self::assertSame('&#x09;', Escaper::attr("\t"));
+        self::assertSame('&#x0A;', Escaper::attr("\n"));
+    }
+
+    public function testAttrLeavesAlphanumericsAlone(): void
+    {
+        self::assertSame('abcXYZ0189', Escaper::attr('abcXYZ0189'));
+    }
+
+    /**
+     * The case `html()` cannot cover. In `<div class=USER_VALUE>` a bare space ends the attribute
+     * and the next token becomes a *new* attribute — no quote character is needed to inject an
+     * event handler, so `html()` output is not safe here and `attr()` output is.
+     */
+    public function testAttrDefeatsUnquotedAttributeBreakOut(): void
+    {
+        $payload = 'x onmouseover=alert(1)';
+
+        // html() lets this through intact: every character in it is one htmlspecialchars ignores.
+        self::assertSame($payload, Escaper::html($payload));
+
+        // attr() neutralises the delimiters that make it work.
+        $escaped = Escaper::attr($payload);
+        self::assertStringNotContainsString(' ', $escaped);
+        self::assertStringNotContainsString('=', $escaped);
+        self::assertStringNotContainsString('(', $escaped);
+    }
+
+    /**
+     * Escaping the individual *bytes* of a multibyte character — the naive reading of OWASP's
+     * "ASCII values less than 256", which predates UTF-8 — would emit one entity per byte and
+     * corrupt the text. Every character that can terminate an attribute is ASCII, so passing
+     * valid multibyte through is both safe and correct.
+     */
+    public function testAttrPassesValidMultibyteThroughWithoutMojibake(): void
+    {
+        self::assertSame('héllo漢🙂', Escaper::attr('héllo漢🙂'));
+    }
+
+    public function testAttrSubstitutesInvalidUtf8LikeHtmlDoes(): void
+    {
+        $escaped = Escaper::attr("ok\xC3\x28bad");
+
+        self::assertSame(1, preg_match('//u', $escaped));
+        self::assertStringContainsString("\u{FFFD}", $escaped);
+    }
+
+    // ---- js() ---------------------------------------------------------------------------------
+
+    public function testJsEscapesQuotesAndBackslash(): void
+    {
+        self::assertSame('\\x27', Escaper::js("'"));
+        self::assertSame('\\x22', Escaper::js('"'));
+        self::assertSame('\\x5C', Escaper::js('\\'));
+    }
+
+    /**
+     * The break-out this method exists for. Inside a `<script>` element the HTML parser runs
+     * first and knows nothing about JavaScript string literals: `</script>` ends the element
+     * wherever it appears, quoted or not. Escaping `/` is what stops it.
+     */
+    public function testJsEscapesTheSlashThatWouldCloseAScriptElement(): void
+    {
+        $escaped = Escaper::js('</script><img src=x onerror=alert(1)>');
+
+        self::assertStringNotContainsString('/', $escaped);
+        self::assertStringNotContainsString('<', $escaped);
+        self::assertStringNotContainsString('>', $escaped);
+        self::assertSame('\\x2F', Escaper::js('/'));
+    }
+
+    /**
+     * `LINE SEPARATOR` and `PARAGRAPH SEPARATOR` are *line terminators* in JavaScript before
+     * ES2019 — an unescaped one ends the statement, and everything after it is code rather than
+     * string. They are the reason `js()` cannot pass non-ASCII through the way `attr()` safely
+     * can.
+     */
+    public function testJsEscapesTheUnicodeLineTerminators(): void
+    {
+        self::assertSame('\\u2028', Escaper::js("\u{2028}"));
+        self::assertSame('\\u2029', Escaper::js("\u{2029}"));
+    }
+
+    public function testJsEmitsSurrogatePairsAboveTheBasicMultilingualPlane(): void
+    {
+        // U+1F642 is stored in UTF-16 as D83D DE42, and JavaScript's \u addresses code units.
+        self::assertSame('\\uD83D\\uDE42', Escaper::js('🙂'));
+    }
+
+    public function testJsOutputIsPureAscii(): void
+    {
+        $escaped = Escaper::js('héllo 漢 🙂 <>&"\'');
+
+        self::assertSame(1, preg_match('/^[\x20-\x7E]*$/', $escaped), 'output must survive any document charset');
+    }
+
+    public function testJsLeavesAlphanumericsAlone(): void
+    {
+        self::assertSame('abcXYZ0189', Escaper::js('abcXYZ0189'));
+    }
+
+    public function testJsSubstitutesInvalidUtf8(): void
+    {
+        $escaped = Escaper::js("ok\xC3\x28bad");
+
+        self::assertStringStartsWith('ok', $escaped);
+        self::assertStringContainsString('\\uFFFD', $escaped);
+    }
+
+    // ---- url() --------------------------------------------------------------------------------
+
+    public function testUrlPercentEncodesPerRfc3986(): void
+    {
+        self::assertSame('a%20b', Escaper::url('a b'));
+        self::assertSame('a%2Fb', Escaper::url('a/b'));
+        self::assertSame('%3Cscript%3E', Escaper::url('<script>'));
+    }
+
+    /**
+     * Not `urlencode()`: that renders a space as `+`, which is correct only in a
+     * `x-www-form-urlencoded` body and wrong in a path segment, where `+` is a literal plus.
+     */
+    public function testUrlUsesRawEncodingNotFormEncoding(): void
+    {
+        self::assertNotSame(urlencode('a b'), Escaper::url('a b'));
+    }
+
+    /**
+     * The likely misuse, pinned as a *safe* failure: passing a whole URL encodes its `:` and `/`,
+     * producing an inert relative path rather than a working link. A broken link is a visible
+     * failure; the point of asserting it is that the failure mode is not a silent hole.
+     */
+    public function testUrlOnAWholeUrlProducesAnInertRelativePathRatherThanAScheme(): void
+    {
+        self::assertSame('javascript%3Aalert%281%29', Escaper::url('javascript:alert(1)'));
+        self::assertStringNotContainsString(':', Escaper::url('https://example.com/a'));
+    }
+
+    // ---- the separation between contexts -------------------------------------------------------
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function xssPayloads(): iterable
+    {
+        yield 'script tag' => ['<script>alert(1)</script>'];
+        yield 'img onerror' => ['<img src=x onerror=alert(1)>'];
+        yield 'svg onload' => ['<svg/onload=alert(1)>'];
+        yield 'quote break-out, double' => ['" onfocus=alert(1) autofocus="'];
+        yield 'quote break-out, single' => ["' onfocus=alert(1) autofocus='"];
+        yield 'unquoted attribute break-out' => ['x onmouseover=alert(1)'];
+        yield 'script close inside string' => ['</script><script>alert(1)</script>'];
+        yield 'js string break-out' => ["';alert(1);//"];
+        yield 'backtick template literal' => ['`${alert(1)}`'];
+        yield 'html comment' => ['<!--<script>alert(1)</script>-->'];
+        yield 'entity-encoded' => ['&lt;script&gt;alert(1)&lt;/script&gt;'];
+        yield 'unicode line terminator' => ["';\u{2028}alert(1);//"];
+        yield 'null byte' => ["<scr\0ipt>alert(1)</scr\0ipt>"];
+    }
+
+    /**
+     * After `html()`, no payload can still open a tag or close an attribute with a quote.
+     */
+    #[DataProvider('xssPayloads')]
+    public function testHtmlNeutralisesTagAndQuoteCharacters(string $payload): void
+    {
+        $escaped = Escaper::html($payload);
+
+        self::assertStringNotContainsString('<', $escaped);
+        self::assertStringNotContainsString('>', $escaped);
+        self::assertStringNotContainsString('"', $escaped);
+        self::assertStringNotContainsString("'", $escaped);
+    }
+
+    /**
+     * After `attr()`, nothing but alphanumerics survives — so no delimiter of any kind remains,
+     * quoted context or not.
+     */
+    #[DataProvider('xssPayloads')]
+    public function testAttrLeavesOnlyAlphanumericsAndEntities(string $payload): void
+    {
+        $escaped = Escaper::attr($payload);
+
+        self::assertSame(1, preg_match('/^(?:[a-zA-Z0-9]|&#x[0-9A-F]{2};|[\x80-\xFF]+)*$/', $escaped));
+    }
+
+    /**
+     * After `js()`, the output is pure ASCII alphanumerics and `\x`/`\u` escapes — nothing that
+     * can terminate a string literal, a statement, or the enclosing `<script>` element.
+     */
+    #[DataProvider('xssPayloads')]
+    public function testJsLeavesNothingThatCanTerminateAStringOrTheScriptElement(string $payload): void
+    {
+        $escaped = Escaper::js($payload);
+
+        self::assertSame(1, preg_match('/^(?:[a-zA-Z0-9]|\\\\x[0-9A-F]{2}|\\\\u[0-9A-F]{4})*$/', $escaped));
+        self::assertStringNotContainsString('/', $escaped);
+        self::assertStringNotContainsString("'", $escaped);
+        self::assertStringNotContainsString('"', $escaped);
+    }
+
+    /**
+     * The reason FR-09 asks for four methods and not one: `html()` output is **not** safe in the
+     * other contexts, and this asserts that rather than leaving it as advice in a docblock.
+     */
+    public function testHtmlOutputIsNotSufficientForTheOtherContexts(): void
+    {
+        // Safe in quoted-attribute and element-text context …
+        self::assertSame('x&#039;y', Escaper::html("x'y"));
+
+        // … but unchanged where the attribute is unquoted, and a space still delimits.
+        self::assertSame('a b', Escaper::html('a b'));
+        self::assertStringNotContainsString(' ', Escaper::attr('a b'));
+
+        // … and inside a script element, `html()` leaves the slash that closes it.
+        self::assertStringContainsString('/', Escaper::html('</script>'));
+        self::assertStringNotContainsString('/', Escaper::js('</script>'));
+    }
+
+    public function testEveryContextHandlesTheEmptyString(): void
+    {
+        self::assertSame('', Escaper::html(''));
+        self::assertSame('', Escaper::attr(''));
+        self::assertSame('', Escaper::js(''));
+        self::assertSame('', Escaper::url(''));
+    }
+
+    /**
+     * All four must agree about malformed input, so a template that switches context does not
+     * also switch failure behaviour.
+     */
+    public function testAllContextsAgreeThatInvalidUtf8BecomesTheReplacementCharacter(): void
+    {
+        $bad = "a\xC3\x28b";
+
+        self::assertStringContainsString("\u{FFFD}", Escaper::html($bad));
+        self::assertStringContainsString("\u{FFFD}", Escaper::attr($bad));
+        self::assertStringContainsString('\\uFFFD', Escaper::js($bad));
+    }
+}

--- a/src/test/php/d4np/utils/Support/StaticUtilityContractTest.php
+++ b/src/test/php/d4np/utils/Support/StaticUtilityContractTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace D4np\Utils\Tests\Support;
 
+use D4np\Utils\Security\Escaper;
 use D4np\Utils\Support\Env;
 use D4np\Utils\Support\File;
 use D4np\Utils\Support\Json;
@@ -41,6 +42,7 @@ final class StaticUtilityContractTest extends TestCase
         yield 'File' => [File::class];
         yield 'Env' => [Env::class];
         yield 'Json' => [Json::class];
+        yield 'Escaper' => [Escaper::class];
     }
 
     /**


### PR DESCRIPTION
## Summary

Roadmap item 5.1, **opening Milestone 5**. RFC-0001's third security mechanism: context-aware output escaping at render time.

### Three probes ran before any code, and each changed the design

| probe | result |
|---|---|
| `htmlspecialchars()` on invalid UTF-8 **without** `ENT_SUBSTITUTE` | returns **`''`** — the entire value silently vanishes |
| `htmlspecialchars()` on `/` and `` ` `` | never escaped, under any flags |
| `mb_convert_encoding($s,'UTF-8','UTF-8')` on bad input | substitutes **`?`**, not U+FFFD |

The first is the one I'd have gotten wrong from the spec alone. FR-09 pins `ENT_SUBSTITUTE` and it reads like a tidiness flag; it's actually the difference between a visible replacement character and a template that renders **nothing** where a username should be. That finding drove the rest: `attr()` and `js()` do their own escaping, so they reproduce the same U+FFFD substitution — via PCRE, since `mbstring` isn't a declared extension (NFR-08) *and* would have disagreed with `html()`.

## The decision worth reviewing: `attr()` assumes the attribute is **unquoted**

`html()` suffices for `x="…"` and `x='…'`. It's useless for `x=…`, where a space ends the attribute and the next token starts a new one — `onmouseover=alert(1)` needs no quote character at all.

**An escaper cannot see its own call site.** The two possible assumptions aren't symmetric:

- assume quoted → wrong toward an **XSS hole**
- assume unquoted → wrong toward **verbose output**

So every non-alphanumeric ASCII becomes `&#xHH;`. Every space in every attribute, forever — paid on the path where the caller *did* quote, in exchange for correctness where they didn't. Same shape as ADR-0015's identifier reasoning: prefer the total rule over one that's correct only if the caller did something the callee can't verify.

**Where the literal spec reading would be wrong:** OWASP's "escape all characters with ASCII values less than 256" predates UTF-8 being default. Read literally it means escaping continuation bytes — one entity per byte, mojibake, defending against nothing (no multibyte byte can terminate an attribute). Implemented the intent and pinned it with a test, the same move item 4.2 made when FR-07's regex turned out to be a bypass.

## `js()` is not "escape quotes and backslashes"

- **`/`** — inside `<script>` the HTML parser runs first and ends the element at `</script>` regardless of JS string state
- **U+2028 / U+2029** — JavaScript line terminators pre-ES2019; the reason `js()` can't pass non-ASCII through the way `attr()` safely can
- **allowlist, not denylist** — a denylist in an escaper is a list of the attacks its author had heard of

Output is pure ASCII with surrogate pairs above U+FFFF. Documented plainly: this makes a value safe **as a string in** JavaScript, not safe **as** JavaScript.

## Test plan

- [x] **Seven planted defects, each caught and reverted:** `attr()`→`html()` (16 failures), `ENT_COMPAT` (6), `js()` denylist (6), `js()` passing non-ASCII (6), `toValidUtf8()` no-op (3), dropping `ENT_SUBSTITUTE` (2), `urlencode()` (2)
- [x] Overlong encodings, surrogate halves, codepoints > U+10FFFF each verified rejected
- [x] `vendor/bin/phpunit` — 661 tests, 1433 assertions, 7 skipped
- [x] PHPStan max clean · deptrac 0/0 (`Security` is now a third real group) · consistency + action-pin lints OK
- [ ] CI

One probe needed redoing: my first denylist attempt produced a broken regex and 61 *errors* — not a meaningful signal, since an error means the code didn't run rather than a test catching something. Redone cleanly for a real 6 failures.

## Scope notes

- **OWASP cheat-sheet snapshot corpus is item 5.4** and is not pre-empted here.
- `url()` covers one URL *component*. Its likely misuse (a whole URL) encodes `:` and `/` into an inert relative path — a **visible** failure, pinned as a test because the failure mode is favourable. It is **not** the defence for `href="…"`, which needs scheme allowlisting: named as a gap, not half-built.
- No CSS context. Named, not half-implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)