### PR TITLE
perf(database): correct NFR-03's benchmarked workload, resolve the driver once

### DIFF
--- a/.eados-core/learning/runs/2026-08-04-utils-3.yaml
+++ b/.eados-core/learning/runs/2026-08-04-utils-3.yaml
@@ -1,0 +1,36 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-04"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}
+route_mismatch:
+  routed: "fast/medium"
+  session: "frontier-reasoning"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,31 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   recorded honestly rather than adjusted to pass, shipped non-blocking by explicit maintainer
   decision, with closing the gap filed as roadmap item 3.7. The `benchmark` CI job (self-skipped
   since item 1.9) is now active, since `phpbench.json.dist` exists.
+### Fixed
+
+- **NFR-03's benchmark measured the wrong workload** (**ADR-0020**, correcting **ADR-0018**). The
+  subject added a five-column `select()`, an `orderBy`, a `limit` and an `offset` on top of its
+  five conditions — twelve quoted identifiers where NFR-03 budgets a *"5-condition SELECT"* — while
+  its own docblock claimed to count exactly five conditions. Roughly two thirds of the ~23 µs gap
+  reported at item 4.5 was benchmark scope, not builder cost. The subject now matches the spec's
+  wording; the heavier shape is **kept and still published** as `benchBuildRealisticPagedQuery`,
+  asserting nothing, so the correction cannot be mistaken for a benchmark narrowed until it passed.
+  Item 4.5's report and ADR-0018 are annotated rather than silently edited.
+
+### Changed
+
+- `QueryBuilder` resolves its driver's quoting characters **once per builder** instead of per
+  identifier (**ADR-0020**), and builds conditions by concatenation rather than `sprintf()`.
+  Together: **14.430 → 12.979 µs** (−10.1%) on the corrected five-condition subject. The driver
+  saving is sub-noise per call, so it is pinned by an exact **count** (7 → 1 lookups for a
+  five-condition query, 13 → 1 for a paged one) rather than a flaky timing assertion.
+  **NFR-03 remains unmet** — ~30% over ≤ 10 µs, versus the 2.3× previously reported. The residual
+  is deferred to item 7.1 because phpbench (12.979 µs) and a plain in-process loop (9.246 µs)
+  disagree by more than the remaining overage, and an empty phpbench subject costs 0.079 µs — so
+  it is not harness overhead, and which instrument is authoritative is NFR-06/7.1's question.
+
+### Added
+
 - `D4np\Utils\Security\Escaper` (**ADR-0019**) — opens Milestone 5. RFC-0001's third security
   mechanism: context-aware output escaping. Four methods — `html()`, `attr()`, `js()`, `url()` —
   and deliberately **no general-purpose `escape()`**, because a method that did not name its

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Four grammars, and the assumption an escaper cannot check](docs/journal/2026/08/2026-08-04-escaper-contexts.md).
+  [2026-08-04 — The benchmark was measuring the wrong thing, and I wrote it](docs/journal/2026/08/2026-08-04-nfr03-correction.md).
 
 ## Model & effort routing (advisory)
 
@@ -247,11 +247,23 @@ Safe-by-default PDO access (RFC-0001).
       immutability. Same shape as item 3.5's NFR-01 finding; handled the same way per ADR-0011's
       precedent — shipped non-blocking, real number recorded, absolute enforcement stays item
       7.1's job, gap filed as item 4.6 rather than fixed under this item's `fast/medium` route.*
-- [ ] 4.6 Close NFR-03's build-time gap: a 5-condition `QueryBuilder` SELECT currently measures
-      ~23µs against a ≤10µs budget (item 4.5, **ADR-0018**). Most plausibly caching the `driver()`
-      value the constructor already resolves once, rather than the repeated `PDO::getAttribute()`
-      call currently paid per identifier quoted — without weakening the allowlist (ADR-0015) or the
-      immutability guarantee. Needs its own measure-first pass — route: TBD (route at pickup)
+- [x] 4.6 Close NFR-03's build-time gap: a 5-condition `QueryBuilder` SELECT currently measures
+      ~23µs against a ≤10µs budget (item 4.5, **ADR-0018**) — route: fast / medium (run at
+      frontier: the change touches ADR-0015's allowlist, so a perf edit here has a security
+      failure mode; mismatch recorded) · **ADR-0020**. ***The premise was wrong on both counts,
+      and profiling first is what found it.*** *The named hypothesis (`driver()` lookups) is
+      ~1.5-2.5µs of ~23µs, not the gap. More importantly the **workload was wrong**: item 4.5's
+      subject added a 5-column `select()`, `orderBy`, `limit` and `offset` on top of its five
+      conditions — twelve identifiers where NFR-03 names five conditions — so ~2/3 of the reported
+      gap was benchmark scope, not builder cost. Subject corrected (heavier shape **kept and still
+      published**, so this is not a benchmark narrowed until it passed). Two changes: driver
+      resolved once per builder (7→1 and 13→1 lookups, pinned by an exact **count** since the
+      saving is sub-noise) and concatenation over `sprintf`. **14.430 → 12.979µs (−10.1%).**
+      **NFR-03 is still NOT met** — ~30% over, vs the 2.3× reported. Residual deferred to item 7.1
+      because the instruments disagree by ~3.8µs (phpbench 12.979 vs in-process 9.246; an empty
+      phpbench subject costs 0.079µs, so not harness overhead) — more than the ~3.0µs overage, so
+      whether NFR-03 passes depends on which instrument is authoritative, which is NFR-06/7.1's
+      question.*
 
 ---
 

--- a/docs/adr/0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md
+++ b/docs/adr/0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md
@@ -1,6 +1,8 @@
 # ADR-0018: QueryBuilder's benchmark measures NFR-03 now; the ~23µs build-time gap is deliberately deferred
 
-- **Status:** Accepted
+- **Status:** Accepted, **partially corrected by [ADR-0020](0020-correct-the-nfr03-workload-and-resolve-the-driver-once.md)**
+  — its central measurement (~23 µs) was taken on a workload heavier than NFR-03 specifies.
+  The reasoning about *how to handle* a measured gap stands; the number does not.
 - **Date:** 2026-08-04
 - **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
 - **Related:** ROADMAP item 4.5 (opens the follow-up, item 4.6) · spec NFR-03, NFR-06 ·

--- a/docs/adr/0020-correct-the-nfr03-workload-and-resolve-the-driver-once.md
+++ b/docs/adr/0020-correct-the-nfr03-workload-and-resolve-the-driver-once.md
@@ -1,0 +1,135 @@
+# ADR-0020: Correct NFR-03's benchmarked workload, resolve the driver once, and defer the residual to the reference machine
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 4.6 · spec NFR-03, NFR-06 · item 7.1 (the reference-machine harness) ·
+  **corrects** [ADR-0018](0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md) ·
+  [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) (whose allowlist and
+  immutability are the structural cost measured here) · **Benchmark record:**
+  [`docs/benchmarks/2026/08/nfr03-querybuilder-build-time-corrected.md`](../benchmarks/2026/08/nfr03-querybuilder-build-time-corrected.md)
+
+## Context
+
+Item 4.6 was filed by item 4.5 on this premise: *"a 5-condition `QueryBuilder` SELECT currently
+measures ~23 µs against a ≤10 µs budget"*, with a named hypothesis — that the cost was the
+repeated `PDO::getAttribute()` call in `quote()`.
+
+**Both halves of that premise turned out to be wrong**, and profiling before changing anything is
+what found it.
+
+**The hypothesis was wrong about magnitude.** `DatabaseConnection::driver()` measures 0.125–0.213 µs.
+Across twelve identifiers that is ~1.5–2.5 µs of ~23 µs — real, but nowhere near the gap. The cost
+is distributed across identifier validation, quoting, `sprintf`, per-call cloning and method
+dispatch, not concentrated anywhere.
+
+**The premise was wrong about the workload, and that is the important finding.** NFR-03 budgets a
+*"5-condition SELECT"*. Item 4.5's subject built five `WHERE`-family conditions **plus** a
+five-column `select()` list, an `orderBy`, a `limit` and an `offset` — twelve quoted identifiers
+where the NFR names five conditions. Its own docblock claimed to count *"exactly five calls that
+each contribute one condition"*, so the documentation and the code disagreed and nobody noticed,
+including the author. Measured separately:
+
+| workload | µs |
+|---|---|
+| literal NFR-03 — `SELECT *` + 5 `WHERE` conditions | **14.43** |
+| item 4.5's subject (+ 5-column select, order, limit, offset) | 24.69 |
+
+**Roughly two thirds of the reported gap was benchmark scope, not builder cost.**
+
+## Decision
+
+### 1. Split the subject; keep both, and keep the heavier one visible
+
+`benchBuildFiveConditionSelect` is now `SELECT *` with exactly five `WHERE` conditions — the shape
+the budget applies to. `benchBuildRealisticPagedQuery` keeps item 4.5's heavier shape, asserting
+nothing.
+
+Keeping the heavier subject is deliberate and is the safeguard against the obvious objection to
+this ADR: **narrowing a benchmark until it improves is exactly how a metric gets gamed.** The
+defence is that nothing was deleted — the heavier number is still measured, still published, still
+worse — and that the narrowing follows the spec's wording rather than the direction of a nicer
+result. A column list is not a condition.
+
+### 2. Resolve the driver's quote characters once per builder
+
+The driver cannot change during a builder's life, so `quote()` no longer asks per identifier.
+Resolved in the constructor, carried across clones for free.
+
+**Pinned by counting, not by timing.** The saving (~0.13 µs per identifier) is inside end-to-end
+noise, but the count is exact and machine-independent: 7 → 1 lookups for the five-condition query,
+13 → 1 for the realistic one. `testTheDriverIsResolvedOncePerBuilderRegardlessOfChainLength()` fails
+with `13 is not identical to 1` if the lookup returns to `quote()` — where a timing assertion for a
+sub-microsecond saving would be flaky and would teach people to ignore it.
+
+### 3. Concatenation instead of `sprintf()` on the per-condition paths
+
+Measured at roughly a third the cost (0.080 µs vs 0.259 µs), executed once per condition, per
+`orderBy`, and in `toSql()`.
+
+### 4. **NFR-03 is still not met, and the residual is deferred to item 7.1 — for a stated reason**
+
+After both changes: **12.979 µs against ≤ 10 µs**, about 30% over (versus the 2.3× item 4.5
+reported). The budget is *not* met and this ADR does not claim otherwise.
+
+Further micro-optimisation is deferred, because **the two instruments disagree by more than the
+remaining overage**:
+
+| instrument | five-condition SELECT |
+|---|---|
+| phpbench (the project's declared harness) | **12.979 µs** |
+| a plain in-process loop, median of 7 rounds | **9.246 µs** |
+
+An empty phpbench subject costs 0.079 µs, so this is *not* harness overhead — checked, because
+that was the first hypothesis. The ~3.8 µs disagreement exceeds the ~3.0 µs by which the budget is
+missed, which means **whether NFR-03 passes today depends on which instrument is used.** That makes
+the next question a methodology question before it is an optimisation one, and spec NFR-06's
+methodology and reference machine (a Ryzen 7 5800X, not this i7) are implemented by roadmap item
+**7.1**. Optimising further against an instrument that may not be the authoritative one risks
+tuning the measurement rather than the program.
+
+What remains is also increasingly structural: ~2.6 µs of identifier validation and quoting, and
+~1.5 µs of the six `clone`s immutability requires — roughly 4 µs that is the direct cost of
+ADR-0015's two recorded decisions and is not available without revisiting them.
+
+## Alternatives Considered
+
+- **Optimise until the phpbench number reaches ≤ 10 µs** — rejected on the instrument
+  disagreement above: it would mean chasing ~3 µs against a measurement that differs from an
+  in-process one by ~3.8 µs, i.e. tuning to the harness.
+- **Report the in-process figure (9.25 µs) and declare NFR-03 met** — rejected, and it is the more
+  tempting error. phpbench is the project's declared instrument (NFR-06, item 3.5's precedent, the
+  CI job), and switching instruments because the other one gives a passing number is precisely the
+  behaviour every previous ADR in this project has refused.
+- **Quietly fix the subject without flagging item 4.5's error** — rejected. The wrong number is
+  published in a benchmark record, an ADR, a changelog entry and a merged PR body; correcting it
+  silently would leave four artefacts disagreeing with reality.
+- **Delete the heavier subject now that it is out of NFR-03's scope** — rejected: it is what an
+  application actually builds, and removing the number that motivated the item would make this
+  change indistinguishable from gaming the benchmark.
+- **Cache quoted identifiers** (the same column is often quoted twice) — not attempted; it adds
+  per-builder state for a saving smaller than the instrument disagreement, and would be measured
+  against the wrong baseline until item 7.1 lands.
+- **Revisit NFR-03's number** — premature for the same reason: the authoritative measurement does
+  not exist yet.
+
+## Consequences
+
+- The subject NFR-03's budget is compared against now matches NFR-03's wording, and the heavier
+  shape remains measured and published alongside it.
+- **14.430 → 12.979 µs** (−10.1%) on the corrected subject; **24.690 → 22.168 µs** (−10.2%) on the
+  realistic one. Full suite green throughout; no behaviour changed.
+- The driver-lookup property is regression-proof by an exact count rather than a flaky timing
+  assertion — a pattern worth reusing wherever a saving is real but sub-noise.
+- ADR-0018 is marked as partially corrected, and item 4.5's benchmark report carries a banner
+  pointing here. Its *reasoning* about handling a measured gap stands; its central number does not.
+- **NFR-03 remains unmet**, by ~30% on the declared instrument, with the residual explicitly
+  parked on item 7.1 rather than left implicit. That is a smaller and better-understood gap than
+  the one item 4.6 was filed with, but it is still open, and the roadmap says so.
+
+## References
+
+- Spec NFR-03 (the budget and its exact wording), NFR-06 (methodology, reference machine)
+- ADR-0018 — the decision this corrects; its handling-of-a-gap reasoning is unaffected
+- ADR-0015 — the allowlist and immutability that account for ~4 µs of what remains
+- Benchmark record: `docs/benchmarks/2026/08/nfr03-querybuilder-build-time-corrected.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0017](0017-prove-binding-at-the-pdo-boundary-and-defer-t02s-like-leg.md) | Prove binding at the PDO boundary, and ship T-02 with its LIKE leg openly deferred | Accepted |
 | [0018](0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md) | QueryBuilder's benchmark measures NFR-03 now; the ~23µs build-time gap is deliberately deferred | Accepted |
 | [0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md) | Four escaping contexts, no general `escape()`, and assume the attribute is unquoted | Accepted |
+| [0020](0020-correct-the-nfr03-workload-and-resolve-the-driver-once.md) | Correct NFR-03's benchmarked workload, resolve the driver once, and defer the residual to the reference machine | Accepted |

--- a/docs/benchmarks/2026/08/nfr03-querybuilder-build-time-corrected.md
+++ b/docs/benchmarks/2026/08/nfr03-querybuilder-build-time-corrected.md
@@ -1,0 +1,100 @@
+# Benchmark Report: NFR-03 QueryBuilder build time — corrected workload, and two optimisations
+
+- **Date:** 2026-08-04
+- **Version / commit:** v0.0.0 @ `f532f1c` (baseline) → this branch (`perf/querybuilder-build-time`)
+- **Environment:** 12th Gen Intel Core i7-12700, 31.7 GB RAM, Windows 11 Pro 10.0.26200,
+  PHP 8.3.1 CLI, phpbench 1.4.3, OPcache **off**, JIT **off**, Xdebug **off**
+- **Command:** `vendor/bin/phpbench run src/bench/php/d4np/utils/QueryBuilderBench.php --report=aggregate`
+  (locally with `--php-disable-ini --php-config='{"extension_dir":"…","extension":"pdo_sqlite"}'`,
+  per the item 4.5 record — CI needs neither flag)
+
+**This report corrects [the item 4.5 report](nfr03-querybuilder-build-time.md).** See §Correction.
+
+## Correction: the earlier report measured the wrong workload
+
+Spec NFR-03 budgets a **"5-condition SELECT"**. Item 4.5's benchmark subject built a query with
+five `WHERE`-family conditions **plus** a five-column `select()` list, an `orderBy`, a `limit` and
+an `offset` — twelve quoted identifiers against the five conditions the NFR names. Its own docblock
+claimed to count *"exactly five calls that each contribute one condition"*, so the documentation
+and the code disagreed, and the code was measuring roughly twice the work.
+
+That figure (~23 µs) was then reported as NFR-03's, and item 4.6 was filed on the strength of it.
+**Most of the "gap" was benchmark scope, not builder cost.**
+
+The subject is now split, and both halves are reported:
+
+- `benchBuildFiveConditionSelect` — `SELECT *` with exactly five `WHERE` conditions. **This is the
+  one NFR-03's budget applies to.**
+- `benchBuildRealisticPagedQuery` — the heavier item-4.5 shape, kept deliberately, asserting
+  nothing. It is what an application actually builds, and keeping it visible is what stops the
+  correction from reading as a benchmark quietly rewritten until it passed.
+
+## Results
+
+Two attributable changes were made, and measured on a quiet machine (all rstdev < 3%):
+
+| subject | before | after | change |
+|---|---|---|---|
+| `benchBuildFiveConditionSelect` | 14.430 µs ±2.59% | **12.979 µs** ±2.49% | **−10.1%** |
+| `benchBuildRealisticPagedQuery` | 24.690 µs ±1.57% | 22.168 µs ±2.29% | −10.2% |
+
+### Change 1 — resolve the driver's quote characters once per builder
+
+`quote()` asked `DatabaseConnection::driver()` — a `PDO::getAttribute()` round trip — on **every
+identifier**. The driver cannot change during a builder's life, so it is now resolved once in the
+constructor and carried across clones for free.
+
+Proven **by counting rather than by timing**, because the per-call saving (~0.13 µs) is inside the
+noise of an end-to-end run, while the count is exact:
+
+| workload | before | after |
+|---|---|---|
+| five-condition SELECT (6 identifiers) | **7** lookups | **1** |
+| realistic paged query (12 identifiers) | **13** lookups | **1** |
+
+Pinned by `QueryBuilderTest::testTheDriverIsResolvedOncePerBuilderRegardlessOfChainLength()`, which
+fails with `13 is not identical to 1` if the lookup returns to `quote()`.
+
+### Change 2 — concatenation instead of `sprintf()` on the per-condition paths
+
+Measured at roughly a third the cost (0.080 µs vs 0.259 µs per call) and executed once per
+condition, per `orderBy`, and once in `toSql()`.
+
+## Interpretation
+
+**NFR-03's budget is still not met on the project's declared instrument.** 12.979 µs against
+≤ 10 µs — about 30% over, versus the 2.3× over that item 4.5 reported. Roughly two thirds of the
+apparent gap was the workload error; the optimisations closed about 10% of what remained.
+
+**The instruments disagree by more than the remaining overage, which is why further
+micro-optimisation here would be premature.** Measured on the same quiet machine, minutes apart:
+
+| instrument | five-condition SELECT |
+|---|---|
+| phpbench (`--report=aggregate`, 10×1000) | **12.979 µs** |
+| a plain in-process loop (60 000 iterations, median of 7 rounds) | **9.246 µs** |
+
+An empty phpbench subject costs 0.079 µs, so this is **not** harness overhead — it is a real
+difference in what the two measure, and it is ~3.8 µs, larger than the ~3.0 µs by which the
+benchmark misses the budget. Whether NFR-03 passes today depends on which instrument is used,
+which makes the remaining question a **methodology** question before it is an optimisation one.
+Spec NFR-06 fixes the methodology and the reference machine (a Ryzen 7 5800X, not this i7), and
+roadmap item **7.1** is what implements it. Tuning against an instrument that may not be the
+authoritative one risks optimising for the measurement rather than the program.
+
+**What is structural.** For the five-condition query, roughly 2.6 µs is identifier validation and
+quoting (ADR-0015's allowlist, six identifiers) and ~1.5 µs is the six `clone`s ADR-0015's
+immutability requires. Those ~4 µs are the direct cost of two recorded security/design decisions
+and are not available to optimise without revisiting them.
+
+## Reproduce
+
+```bash
+composer install && vendor/bin/phpbench run src/bench/php/d4np/utils/QueryBuilderBench.php --report=aggregate
+```
+
+The driver-lookup count, which is deterministic and machine-independent:
+
+```bash
+vendor/bin/phpunit --filter testTheDriverIsResolvedOncePerBuilderRegardlessOfChainLength
+```

--- a/docs/benchmarks/2026/08/nfr03-querybuilder-build-time.md
+++ b/docs/benchmarks/2026/08/nfr03-querybuilder-build-time.md
@@ -1,5 +1,12 @@
 # Benchmark Report: NFR-03 QueryBuilder build time
 
+> **CORRECTED by [the item 4.6 report](nfr03-querybuilder-build-time-corrected.md).** The
+> subject measured here builds a five-column `select()` list, an `orderBy`, a `limit` and an
+> `offset` **in addition to** its five conditions — roughly twice the work NFR-03's
+> "5-condition SELECT" describes. The ~23 µs figure below is real, but it is **not** the
+> number NFR-03's budget applies to. Kept unedited as the record of what was measured and
+> concluded at the time.
+
 - **Date:** 2026-08-04
 - **Version / commit:** v0.0.0 @ `b68a12e`
 - **Environment:** 12th Gen Intel Core i7-12700, 31.7 GB RAM, Windows 11 Pro 10.0.26200,

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -23,5 +23,6 @@ One report per measured scenario, from [`template.md`](template.md). Keep the in
 
 | Date | Scenario | Version | Headline result | Report |
 |------|----------|---------|-----------------|--------|
-| 2026-08-04 | NFR-03 QueryBuilder build time (5-condition SELECT) | v0.0.0 | **~23 µs** vs. ≤ 10 µs budget; over on dev hardware, non-blocking, follow-up filed (item 4.6) | [report](2026/08/nfr03-querybuilder-build-time.md) |
+| 2026-08-04 | NFR-03 QueryBuilder build time — **corrected workload** + 2 optimisations | v0.0.0 | literal 5-condition SELECT **14.43 → 12.98 µs**; still over ≤ 10 µs, but 1.3× not 2.3× | [report](2026/08/nfr03-querybuilder-build-time-corrected.md) |
+| 2026-08-04 | NFR-03 QueryBuilder build time (~~5-condition SELECT~~ — wrong workload) | v0.0.0 | ~23 µs — **superseded**, measured ~2× the work NFR-03 specifies | [report](2026/08/nfr03-querybuilder-build-time.md) |
 | 2026-08-04 | NFR-01 DTO hydration (10 scalar props), compiled closure vs. interpreter | v0.0.0 | **15.40× → 2.74×** manual construction (14.155 µs → 2.511 µs); NFR-01 met | [report](2026/08/nfr01-hydration-compiled-closure.md) |

--- a/docs/journal/2026/08/2026-08-04-nfr03-correction.md
+++ b/docs/journal/2026/08/2026-08-04-nfr03-correction.md
@@ -1,0 +1,108 @@
+# 2026-08-04 — The benchmark was measuring the wrong thing, and I wrote it
+
+Roadmap item **4.6**, run under `/eados optimize`. Routed `fast / medium`; ran at frontier tier
+because the change touches `QueryBuilder`, whose allowlist is the sole identifier defence — a
+performance edit there has a security failure mode. Mismatch recorded rather than papered over by
+picking a flag that would have manufactured a match.
+
+## The premise was wrong on both counts
+
+Item 4.6 was filed by item 4.5 saying: *a 5-condition SELECT measures ~23µs against ≤10µs, most
+plausibly because `quote()` re-fetches the driver per identifier.*
+
+Profiling before changing anything killed both halves.
+
+**The hypothesis was wrong about magnitude.** `driver()` costs 0.125–0.213µs. Twelve of them is
+~1.5–2.5µs of ~23µs. Real, but not the gap. The cost is spread across validation, quoting,
+`sprintf`, cloning and method dispatch — concentrated nowhere.
+
+**The workload was wrong, and that's the finding that matters.** NFR-03 budgets a *"5-condition
+SELECT"*. My item-4.5 subject built five conditions **plus** a five-column `select()` list, an
+`orderBy`, a `limit` and an `offset` — twelve quoted identifiers where the spec names five
+conditions.
+
+| workload | µs |
+|---|---|
+| literal NFR-03 (`SELECT *` + 5 conditions) | **14.43** |
+| what I actually benchmarked at 4.5 | 24.69 |
+
+Roughly two thirds of the "gap" I reported was my own benchmark's scope.
+
+The part that stings: **the benchmark's own docblock said it was counting "exactly five calls that
+each contribute one condition."** The doc and the code disagreed, and I wrote both. Nobody caught
+it because the number looked plausible and confirmed a story that was already coherent — hydration
+had missed its budget too, so a builder missing its budget fit the pattern.
+
+## Correcting a published wrong number
+
+The ~23µs figure is in a benchmark record, an ADR, a changelog entry, and a merged PR body. Fixing
+the code quietly would leave four artefacts disagreeing with reality. So:
+
+- item 4.5's benchmark report keeps its text and gains a banner pointing here
+- ADR-0018 is marked partially corrected — its *reasoning* about handling a measured gap stands,
+  its central number doesn't
+- the benchmarks index shows both rows, the old one struck through
+
+## Guarding against the obvious objection
+
+Narrowing a benchmark until it improves is exactly how a metric gets gamed, and that is a fair
+thing to suspect here. Two things are the defence:
+
+1. **Nothing was deleted.** The heavier shape survives as `benchBuildRealisticPagedQuery`,
+   asserting nothing, still measured, still worse. It's what an application actually builds.
+2. **The narrowing follows the spec's wording, not the direction of a nicer result.** A column list
+   is not a condition.
+
+If I'd only kept the narrow subject, this change would be indistinguishable from gaming it.
+
+## Two changes, one of them provable without timing
+
+**Driver resolved once per builder.** The saving is ~0.13µs per identifier — genuinely inside
+end-to-end noise. So I pinned it by **counting** instead: 7→1 lookups for the five-condition query,
+13→1 for the realistic one. Exact, deterministic, machine-independent. The test fails with
+`13 is not identical to 1` if the lookup creeps back into `quote()`, where a timing assertion for a
+sub-microsecond saving would be flaky and would train people to ignore it.
+
+That feels like a reusable pattern: when a real improvement is smaller than the noise floor, assert
+the *mechanism* rather than the *duration*.
+
+**Concatenation over `sprintf`** — a third the cost, once per condition.
+
+Result: **14.430 → 12.979µs (−10.1%)** on the corrected subject, 24.690 → 22.168µs on the heavy one.
+
+## Why I stopped, rather than pushing to 10µs
+
+**NFR-03 is still not met** — ~30% over. I could have kept going. I didn't, because the two
+instruments disagree by more than the remaining overage:
+
+| instrument | five-condition SELECT |
+|---|---|
+| phpbench (declared instrument) | 12.979µs |
+| plain in-process loop | 9.246µs |
+
+My first guess was phpbench harness overhead. Checked it — an empty subject costs **0.079µs**, so
+no. The ~3.8µs disagreement is real and exceeds the ~3.0µs overage, which means **whether NFR-03
+passes today depends on which instrument you use.**
+
+That makes the next question methodological, not algorithmic. NFR-06 fixes the methodology and the
+reference machine (a Ryzen 7 5800X, not this i7); item **7.1** implements it. Tuning another 3µs
+against an instrument that may not be authoritative is optimising the measurement.
+
+The tempting move was to report the 9.246µs figure and declare NFR-03 met. That's the same species
+of error as lowering a threshold, and every prior ADR here has refused it.
+
+## An environment note worth recording
+
+Mid-item the machine became heavily loaded — phpbench rstdev hit 42% and it retried endlessly.
+Numbers taken then (15.3µs) were meaningless. I discarded them and re-measured once it was quiet
+(all rstdev < 3%). Worth noting because the noisy readings looked precise enough to quote.
+
+## Bar
+
+662 tests / 1434 assertions green. PHPStan max clean, deptrac 0/0.
+
+## Milestone 4
+
+4.1–4.6 done. NFR-03's residual sits with **7.1**, alongside NFR-01's absolute half and the nightly
+regression harness — that item is accumulating everything that needs a trustworthy reference
+measurement.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — The benchmark was measuring the wrong thing, and I wrote it](2026/08/2026-08-04-nfr03-correction.md)
 - [2026-08-04 — Four grammars, and the assumption an escaper cannot check](2026/08/2026-08-04-escaper-contexts.md)
 - [2026-08-04 — The same shape as NFR-01, found in a different class](2026/08/2026-08-04-nfr03-querybuilder-bench.md)
 - [2026-08-04 — Measuring what the old tests would have missed](2026/08/2026-08-04-t02-injection-suite.md)

--- a/src/bench/php/d4np/utils/QueryBuilderBench.php
+++ b/src/bench/php/d4np/utils/QueryBuilderBench.php
@@ -46,11 +46,42 @@ final class QueryBuilderBench
     }
 
     /**
-     * Five conditions, per NFR-03's own wording — a `where()`, an `orderBy()` and a `limit()`
-     * each add a clause too, but the NFR names the `WHERE` count specifically, so that is what
-     * this counts: exactly five calls that each contribute one condition.
+     * **The workload NFR-03 actually names**: a `SELECT` with five conditions.
+     *
+     * This subject was corrected at roadmap item 4.6 (ADR-0020). Item 4.5's version of it also
+     * selected five named columns and applied `orderBy`/`limit`/`offset`, then reported the
+     * resulting figure as NFR-03's — while its own docblock claimed to be counting "exactly five
+     * calls that each contribute one condition". The doc and the code disagreed, and the code was
+     * measuring roughly three times the work the NFR describes.
+     *
+     * A column list is not a condition. `SELECT *` keeps this subject to precisely the five
+     * `WHERE` conditions NFR-03 budgets, so the number it produces is the one the budget can
+     * legitimately be compared against. The heavier shape is still measured, and still reported —
+     * as {@see benchBuildRealisticPagedQuery()}, under its own name, against no budget.
      */
     public function benchBuildFiveConditionSelect(): void
+    {
+        $query = (new QueryBuilder($this->connection, 'users'))
+            ->where('status', Operator::Equals, 'active')
+            ->where('age', Operator::GreaterThan, 18)
+            ->where('name', Operator::NotEquals, '')
+            ->where('email', Operator::Like, '%@example.com')
+            ->where('id', Operator::LessThan, 999);
+
+        $query->toSql();
+        $query->bindings();
+    }
+
+    /**
+     * A realistic listing query: named columns, five conditions, ordering and pagination.
+     *
+     * **NFR-03 does not budget this shape**, and this subject deliberately asserts nothing. It
+     * exists so that item 4.5's measurement is not silently dropped now that the subject above has
+     * been narrowed to the spec's wording — the heavier number is real, it is what an application
+     * actually builds, and it is several times the five-condition figure. Keeping it visible is
+     * what stops the correction from reading as a benchmark quietly rewritten until it passed.
+     */
+    public function benchBuildRealisticPagedQuery(): void
     {
         $query = (new QueryBuilder($this->connection, 'users'))
             ->select('id', 'name', 'email', 'age', 'status')

--- a/src/main/php/d4np/utils/Database/QueryBuilder.php
+++ b/src/main/php/d4np/utils/Database/QueryBuilder.php
@@ -77,12 +77,35 @@ final class QueryBuilder
     private ?int $offset = null;
 
     /**
+     * The driver's quoting characters, resolved once (roadmap 4.6, ADR-0020).
+     *
+     * `[open, close]`. Every identifier this builder quotes uses the same pair, because the
+     * connection's driver cannot change during the builder's life — but before this was cached,
+     * {@see quote()} asked {@see DatabaseConnection::driver()} afresh on every call, which is a
+     * `PDO::getAttribute()` round trip per identifier. Measured at 0.125 µs each, paid a dozen
+     * times in a realistic query.
+     *
+     * Carried across clones for free: `clone` copies the property, so the fluent chain resolves
+     * the driver exactly once no matter how long it gets.
+     *
+     * @var array{string, string}
+     */
+    private readonly array $quoteCharacters;
+
+    /**
      * @throws DatabaseException if the table name fails the allowlist
      */
     public function __construct(
         private readonly DatabaseConnection $connection,
         private readonly string $table,
     ) {
+        $this->quoteCharacters = match ($connection->driver()) {
+            'mysql' => ['`', '`'],
+            'sqlsrv', 'dblib', 'mssql' => ['[', ']'],
+            // The SQL standard's own form, and what SQLite, PostgreSQL, Oracle and the rest use.
+            default => ['"', '"'],
+        };
+
         $this->identifier($table);
     }
 
@@ -111,7 +134,9 @@ final class QueryBuilder
     public function where(string $column, Operator $operator, mixed $value): self
     {
         $clone = clone $this;
-        $clone->conditions[] = sprintf('%s %s ?', $this->identifier($column), $operator->value);
+        // Concatenation rather than sprintf(): measured at roughly a third the cost, and this
+        // runs once per condition (roadmap 4.6).
+        $clone->conditions[] = $this->identifier($column) . ' ' . $operator->value . ' ?';
         $clone->bindings[] = $value;
 
         return $clone;
@@ -142,11 +167,8 @@ final class QueryBuilder
         }
 
         $clone = clone $this;
-        $clone->conditions[] = sprintf(
-            '%s IN (%s)',
-            $this->identifier($column),
-            implode(', ', array_fill(0, count($values), '?')),
-        );
+        $clone->conditions[] = $this->identifier($column)
+            . ' IN (' . implode(', ', array_fill(0, count($values), '?')) . ')';
         foreach ($values as $value) {
             $clone->bindings[] = $value;
         }
@@ -192,7 +214,7 @@ final class QueryBuilder
     public function orderBy(string $column, Sort $direction = Sort::Asc): self
     {
         $clone = clone $this;
-        $clone->orderBy[] = sprintf('%s %s', $this->identifier($column), $direction->value);
+        $clone->orderBy[] = $this->identifier($column) . ' ' . $direction->value;
 
         return $clone;
     }
@@ -227,11 +249,9 @@ final class QueryBuilder
      */
     public function toSql(): string
     {
-        $sql = sprintf(
-            'SELECT %s FROM %s',
-            $this->columns === [] ? '*' : implode(', ', $this->columns),
-            $this->quote($this->table),
-        );
+        $sql = 'SELECT '
+            . ($this->columns === [] ? '*' : implode(', ', $this->columns))
+            . ' FROM ' . $this->quote($this->table);
 
         if ($this->conditions !== []) {
             $sql .= ' WHERE ' . implode(' AND ', $this->conditions);
@@ -328,12 +348,9 @@ final class QueryBuilder
      */
     private function quote(string $identifier): string
     {
-        return match ($this->connection->driver()) {
-            'mysql' => '`' . str_replace('`', '``', $identifier) . '`',
-            'sqlsrv', 'dblib', 'mssql' => '[' . str_replace(']', ']]', $identifier) . ']',
-            // The SQL standard's own form, and what SQLite, PostgreSQL, Oracle and the rest use.
-            default => '"' . str_replace('"', '""', $identifier) . '"',
-        };
+        [$open, $close] = $this->quoteCharacters;
+
+        return $open . str_replace($close, $close . $close, $identifier) . $close;
     }
 
     /**

--- a/src/test/php/d4np/utils/Database/Fixture/DriverLookupCountingPdo.php
+++ b/src/test/php/d4np/utils/Database/Fixture/DriverLookupCountingPdo.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database\Fixture;
+
+use PDO;
+
+/**
+ * Counts how many times anything asks the connection for its driver name.
+ *
+ * `QueryBuilder` quotes identifiers with characters that depend on the driver, and before roadmap
+ * item 4.6 it re-asked the connection on *every* quote — one `PDO::getAttribute()` round trip per
+ * identifier. That is now resolved once per builder (ADR-0020).
+ *
+ * The saving this makes is small enough that an end-to-end timing assertion would be flaky, so
+ * the property is pinned **by counting instead of by timing**: the count is exact, deterministic,
+ * and independent of how loaded the machine is. A regression that reintroduced the per-identifier
+ * lookup would change 1 back to N and fail here, where a benchmark might merely look noisy.
+ */
+final class DriverLookupCountingPdo extends PDO
+{
+    public int $driverLookups = 0;
+
+    public function __construct()
+    {
+        parent::__construct('sqlite::memory:');
+    }
+
+    public function getAttribute(int $attribute): mixed
+    {
+        if ($attribute === PDO::ATTR_DRIVER_NAME) {
+            $this->driverLookups++;
+        }
+
+        return parent::getAttribute($attribute);
+    }
+}

--- a/src/test/php/d4np/utils/Database/QueryBuilderTest.php
+++ b/src/test/php/d4np/utils/Database/QueryBuilderTest.php
@@ -9,6 +9,7 @@ use D4np\Utils\Database\Operator;
 use D4np\Utils\Database\QueryBuilder;
 use D4np\Utils\Database\Sort;
 use D4np\Utils\Support\DatabaseException;
+use D4np\Utils\Tests\Database\Fixture\DriverLookupCountingPdo;
 use D4np\Utils\Tests\Database\Fixture\LoggedStatement;
 use D4np\Utils\Tests\Database\Fixture\PretendDriverPdo;
 use D4np\Utils\Tests\Database\Fixture\QueryLog;
@@ -204,6 +205,37 @@ final class QueryBuilderTest extends TestCase
         self::assertSame('SELECT * FROM "users"', $base->toSql());
         self::assertSame([], $base->bindings());
         self::assertNotSame($base, $filtered);
+    }
+
+    /**
+     * The driver is resolved **once per builder**, however long the fluent chain gets (ADR-0020).
+     *
+     * Pinned by counting rather than by timing. The saving is a fraction of a microsecond per
+     * identifier, which is well inside the noise of an end-to-end benchmark on a loaded machine —
+     * but the *count* is exact and deterministic. A regression that put the `getAttribute()` call
+     * back inside `quote()` would turn 1 into 13 here, and would merely look like noise in a
+     * timing assertion.
+     */
+    public function testTheDriverIsResolvedOncePerBuilderRegardlessOfChainLength(): void
+    {
+        $pdo = new DriverLookupCountingPdo();
+        $connection = new DatabaseConnection($pdo);
+        $pdo->driverLookups = 0; // discount DatabaseConnection's own attribute pinning
+
+        (new QueryBuilder($connection, 'users'))
+            ->select('id', 'name', 'email', 'age', 'status')
+            ->where('status', Operator::Equals, 'active')
+            ->where('age', Operator::GreaterThan, 18)
+            ->where('name', Operator::NotEquals, '')
+            ->whereNotNull('email')
+            ->whereIn('status', ['active', 'pending'])
+            ->orderBy('name', Sort::Asc)
+            ->limit(10)
+            ->offset(0)
+            ->toSql();
+
+        // Twelve identifiers are quoted in that chain; the driver is asked about exactly once.
+        self::assertSame(1, $pdo->driverLookups);
     }
 
     /**


### PR DESCRIPTION
## Summary

Roadmap item 4.6, run under `/eados optimize`.

## ⚠️ The premise this item was filed on was wrong on both counts

Item 4.5 filed this as *"a 5-condition SELECT measures ~23µs against ≤10µs, most plausibly because `quote()` re-fetches the driver per identifier."* Profiling before changing anything killed both halves.

**The hypothesis was wrong about magnitude.** `driver()` costs 0.125–0.213µs — twelve of them is ~1.5–2.5µs of ~23µs. Real, but not the gap.

**The workload was wrong, and that's what matters.** NFR-03 budgets a *"5-condition SELECT"*. My item-4.5 subject built five conditions **plus** a five-column `select()`, an `orderBy`, a `limit` and an `offset` — twelve quoted identifiers where the spec names five conditions:

| workload | µs |
|---|---|
| literal NFR-03 (`SELECT *` + 5 conditions) | **14.43** |
| what I actually benchmarked at 4.5 | 24.69 |

**Roughly two thirds of the gap I reported was my own benchmark's scope.** The part worth flagging: that benchmark's docblock claimed to count *"exactly five calls that each contribute one condition"* — the doc and the code disagreed, and I wrote both. The number looked plausible and confirmed a story that was already coherent, since hydration had missed its budget too.

### Correcting a published wrong number

The ~23µs figure is in a benchmark record, an ADR, a changelog entry and a merged PR body — so nothing is silently edited. Item 4.5's report keeps its text and gains a banner; ADR-0018 is marked partially corrected (its *reasoning* stands, its number doesn't); the benchmarks index carries both rows.

### Guarding against the obvious objection

Narrowing a benchmark until it improves is how a metric gets gamed, and that's fair to suspect here. The defence: **nothing was deleted** — the heavier shape survives as `benchBuildRealisticPagedQuery`, asserting nothing, still measured, still worse — and the narrowing follows the spec's wording, not the direction of a nicer result. A column list is not a condition.

## Two changes

| subject | before | after |
|---|---|---|
| `benchBuildFiveConditionSelect` | 14.430µs ±2.59% | **12.979µs** ±2.49% (−10.1%) |
| `benchBuildRealisticPagedQuery` | 24.690µs ±1.57% | 22.168µs ±2.29% (−10.2%) |

1. **Driver resolved once per builder.** The saving is ~0.13µs/identifier — inside end-to-end noise — so it's pinned by an exact **count**: 7→1 lookups (five-condition), 13→1 (paged). The test fails with `13 is not identical to 1` if the lookup creeps back into `quote()`. *When a real improvement is smaller than the noise floor, assert the mechanism rather than the duration.*
2. **Concatenation instead of `sprintf()`** on per-condition paths — roughly a third the cost.

## NFR-03 is still **not** met, and I stopped deliberately

~30% over, versus the 2.3× previously reported. I could have kept going; I didn't, because the two instruments disagree by more than the remaining overage:

| instrument | five-condition SELECT |
|---|---|
| phpbench (declared) | 12.979µs |
| plain in-process loop | 9.246µs |

First guess was phpbench harness overhead — checked, an empty subject costs **0.079µs**, so no. The ~3.8µs disagreement exceeds the ~3.0µs overage, so **whether NFR-03 passes depends on which instrument you use.** That's a methodology question, and NFR-06's methodology + reference machine belong to item **7.1**. Tuning another 3µs against a possibly-non-authoritative instrument is optimising the measurement.

The tempting move was to report 9.246µs and declare NFR-03 met — the same species of error as lowering a threshold.

## Test plan

- [x] Driver-lookup count verified before/after (7→1, 13→1); test proved non-vacuous by reverting the cache → `13 is not identical to 1`
- [x] `vendor/bin/phpunit` — 662 tests, 1434 assertions, 7 skipped
- [x] PHPStan max clean · deptrac 0/0 · consistency + action-pin lints OK
- [ ] CI

**Environment note:** mid-item the machine became heavily loaded (phpbench rstdev up to 42%, endless retries). Readings from then (15.3µs) were meaningless and discarded; everything above was re-measured once quiet (all rstdev < 3%). Flagging it because the noisy readings looked precise enough to quote.

Route mismatch recorded — ran above the `fast/medium` route deliberately, since this touches ADR-0015's allowlist and a perf edit there has a security failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)