### PR TITLE
feat(security): Sanitizer::richText() and sqlLikePattern(), completing T-02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,25 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- `D4np\Utils\Security\Sanitizer` (**ADR-0021**) — `richText()` and `sqlLikePattern()`. **This
+  completes spec §7's T-02 suite**, whose LIKE-wildcard leg roadmap item 4.4 deferred here.
+  `sqlLikePattern()` neutralises the `%` and `_` that survive parameter binding intact — binding
+  stops a `LIKE` value injecting SQL but does nothing about wildcards, so a search box forwarding
+  `%` turns an indexed lookup into a scan. The escape character is **`!`, not `\`**: a backslash is
+  special inside SQL string literals on several drivers, and `ESCAPE '\'` is a **parse error** on
+  SQLite. `QueryBuilder::whereLike()` is added to emit the `ESCAPE` clause, because **without one
+  an escaped pattern silently matches nothing on SQLite while working by accident on
+  MySQL/PostgreSQL** — a wrong answer that only appears on one driver.
+  `richText()` delegates to `symfony/html-sanitizer` (RFC-0001: *"no hand-rolled tag stripper"*), a
+  new **optional** dependency declared in `suggest`. When it is absent `richText()` **throws**
+  rather than returning the input unsanitized, and no Symfony type appears in its signature so
+  "optional" holds at the API boundary. The curated profile limits link schemes to
+  `https`/`http`/`mailto` (this is what refuses `javascript:` and `data:`), refuses relative links
+  and media, and forces `rel="noopener noreferrer"`.
+- `deptrac.yaml` gains an `HtmlSanitizer` layer that **only `Security` may reach** — the library's
+  first third-party production dependency took the layering gate from `Uncovered: 0` to `6`, and
+  declaring it keeps a future import from another group a build failure rather than a silent new
+  coupling to an optional package.
 - `D4np\Utils\Security\Escaper` (**ADR-0019**) — opens Milestone 5. RFC-0001's third security
   mechanism: context-aware output escaping. Four methods — `html()`, `attr()`, `js()`, `url()` —
   and deliberately **no general-purpose `escape()`**, because a method that did not name its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,12 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   since item 1.9) is now active, since `phpbench.json.dist` exists.
 ### Fixed
 
+- `masterminds/html5` floored at `^2.7.5` in `require-dev`. It is a transitive dependency of
+  `symfony/html-sanitizer`, and its 2.7.2 release passes `null` to a `string` parameter of
+  `DOMImplementation::createDocument()` — deprecated on PHP 8.1+, and so a failure under this
+  project's warnings-as-errors bar. Only the `prefer-lowest` CI job saw it; the normal resolution
+  picks 2.10.1. 2.7.5 is the exact fixing version, found by bisecting upstream rather than by
+  choosing a comfortable floor.
 - **NFR-03's benchmark measured the wrong workload** (**ADR-0020**, correcting **ADR-0018**). The
   subject added a five-column `select()`, an `orderBy`, a `limit` and an `offset` on top of its
   five conditions — twelve quoted identifiers where NFR-03 budgets a *"5-condition SELECT"* — while

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — The benchmark was measuring the wrong thing, and I wrote it](docs/journal/2026/08/2026-08-04-nfr03-correction.md).
+  [2026-08-04 — Two sanitizers, and a wrong answer that only shows up on one driver](docs/journal/2026/08/2026-08-04-sanitizer.md).
 
 ## Model & effort routing (advisory)
 
@@ -283,8 +283,20 @@ Explicit-mechanism security helpers (RFC-0001; every item carries the protected 
       four substitute U+FFFD identically, via PCRE rather than `mbstring` (undeclared dependency,
       and it substitutes `?` not U+FFFD). Suite proved non-vacuous with 7 planted defects. OWASP
       corpus snapshot stays item 5.4.*
-- [ ] 5.2 `Sanitizer::richText()` over symfony/html-sanitizer (optional dep) +
-      `sqlLikePattern()` (RFC-0001) (security) — route: frontier-reasoning / extra
+- [x] 5.2 `Sanitizer::richText()` over symfony/html-sanitizer (optional dep) +
+      `sqlLikePattern()` (RFC-0001) (security) — route: frontier-reasoning / extra ·
+      **ADR-0021**. ***Closes spec §7's T-02 suite***, whose third leg item 4.4 deferred here.
+      *Escape character is **`!`, not `\`** — probed: `ESCAPE ''` is a **parse error** on SQLite,
+      so a backslash needs per-driver spelling. Bigger trap: an escaped pattern **without** an
+      `ESCAPE` clause silently matches **nothing** on SQLite while working by accident on
+      MySQL/Postgres, so `QueryBuilder::whereLike()` emits the clause — and that silent failure is
+      itself now a test. `richText()` **throws** when the optional package is absent rather than
+      returning input unsanitized (verified behaviourally), and keeps Symfony types out of its
+      signature so "optional" holds at the API boundary. First third-party production dependency:
+      took the layering gate to `Uncovered: 6`, resolved by giving it its **own deptrac layer only
+      `Security` may reach** (planted `Http→HtmlSanitizer` to confirm). Honest gap: the
+      missing-dependency path is probe-verified but has no permanent test, since the package is a
+      dev dependency.*
 - [ ] 5.3 `Hash`: Argon2id default, `bcryptFallback` policy, `needsRehash()` (RFC-0001)
       (security) — route: frontier-reasoning / extra
 - [ ] 5.4 OWASP XSS corpus snapshot suite + DOM-bypass corpus for `richText()` (RFC-0001)

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "deptrac/deptrac": "^4.4",
         "ergebnis/composer-normalize": "^2.44",
         "friendsofphp/php-cs-fixer": "^3.75",
+        "masterminds/html5": "^2.7.5",
         "phpbench/phpbench": "^1.2",
         "phpstan/phpstan": "^2.2",
         "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,11 @@
         "friendsofphp/php-cs-fixer": "^3.75",
         "phpbench/phpbench": "^1.2",
         "phpstan/phpstan": "^2.2",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5",
+        "symfony/html-sanitizer": "^6.4"
+    },
+    "suggest": {
+        "symfony/html-sanitizer": "Required by Sanitizer::richText() to sanitize user-authored HTML (spec FR-09b). Not needed unless you render untrusted markup; richText() raises a clear UtilsException if it is called without this installed, rather than returning the input unsanitized."
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "176c1bf553bbb855002a2d88c957c217",
+    "content-hash": "4b3330b3fc30d9fe902c56440a358954",
     "packages": [
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "860b4655786c83a254e9e1f067094974",
+    "content-hash": "176c1bf553bbb855002a2d88c957c217",
     "packages": [
         {
             "name": "psr/container",
@@ -1552,6 +1552,188 @@
             "time": "2026-06-16T20:50:26+00:00"
         },
         {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
             "name": "localheinz/diff",
             "version": "1.3.0",
             "source": {
@@ -1678,6 +1860,73 @@
                 "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.2"
             },
             "time": "2025-09-14T11:18:39+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
+            },
+            "time": "2026-06-23T18:43:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2850,6 +3099,114 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "react/cache",
@@ -5028,6 +5385,79 @@
                 }
             ],
             "time": "2026-06-26T15:18:24+00:00"
+        },
+        {
+            "name": "symfony/html-sanitizer",
+            "version": "v6.4.41",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/html-sanitizer.git",
+                "reference": "fba29d97d888ca69b496a626c9248fd56a293d8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/fba29d97d888ca69b496a626c9248fd56a293d8a",
+                "reference": "fba29d97d888ca69b496a626c9248fd56a293d8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "league/uri": "^6.5|^7.0",
+                "masterminds/html5": "^2.7.2",
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HtmlSanitizer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to sanitize untrusted HTML input for safe insertion into a document's DOM.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "Purifier",
+                "html",
+                "sanitizer"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/html-sanitizer/tree/v6.4.41"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-24T11:08:37+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -56,6 +56,18 @@ deptrac:
         - type: directory
           value: src/main/php/d4np/utils/Support/.*
 
+    # The one sanctioned third-party dependency in production code (spec FR-09b: RFC-0001 requires
+    # rich-HTML sanitization be *delegated*, and names the delegate). Declared as its own layer
+    # rather than waved through as "vendor code", so that the ruleset below can say which group is
+    # allowed to reach it — today only `Security`. An import of it from `Dto` or `Http` would be a
+    # violation here rather than a silent new coupling to an optional package.
+    - name: HtmlSanitizer
+      collectors:
+        - type: classLike
+          # Doubled backslashes: this is a PCRE pattern, and a single `\C`/`\H` would be read as a
+          # regex escape sequence rather than a namespace separator.
+          value: ^Symfony\\Component\\HtmlSanitizer\\.*
+
     # `Version` sits at the namespace root, in no group — it is a single version constant. Given
     # its own layer rather than left uncollected so that "every production class belongs to a
     # declared layer" stays a fact this config states, rather than an assumption.
@@ -75,6 +87,8 @@ deptrac:
       - Support
     Security:
       - Support
+      # Only this group may reach the optional sanitizer (spec FR-09b).
+      - HtmlSanitizer
     Http:
       - Support
     Errors:
@@ -88,3 +102,6 @@ deptrac:
 
     # A version constant depends on nothing.
     Version: ~
+
+    # A vendored dependency is a leaf here: this repository does not constrain its internals.
+    HtmlSanitizer: ~

--- a/docs/adr/0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md
+++ b/docs/adr/0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md
@@ -137,6 +137,16 @@ confirming the violation.
   `Operator::Like` returns nothing for an escaped pattern, which is why `whereLike()` exists.
 - **The suite is verified non-vacuous**: the escape-ordering bug (5 failures), allowing
   `javascript:`/`data:` schemes (1), and dropping forced `rel="noopener"` (1) are each caught.
+- **The `prefer-lowest` job caught a deprecation the normal resolution hides.** `symfony/html-sanitizer`
+  depends on `masterminds/html5`, whose 2.7.2 release calls
+  `DOMImplementation::createDocument(null, null, $dt)` — passing `null` to a `string` parameter,
+  deprecated on PHP 8.1+ and therefore a failure under this project's warnings-as-errors bar. The
+  normal resolution picks 2.10.1 and never sees it; only the lowest-allowed resolution does, which
+  is precisely why item 1.7 added that job.
+  Fixed by declaring `masterminds/html5: ^2.7.5` in `require-dev` — a transitive dependency named
+  directly only to raise its floor. **2.7.5 is the exact version that fixes it**, established by
+  bisecting the upstream source across 2.7.3–2.9.0 rather than picking a comfortable-looking
+  number, so the floor is the true minimum and does not exclude working versions.
 - **A gap named rather than hidden:** the missing-dependency path is proven by probe but has **no
   permanent test**, because the package is installed as a dev dependency and cannot be absent
   during the suite. A CI job running without dev extras would cover it; that is build

--- a/docs/adr/0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md
+++ b/docs/adr/0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md
@@ -1,0 +1,153 @@
+# ADR-0021: Delegate rich-HTML sanitization, and escape LIKE wildcards with a portable character
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 5.2 · spec FR-09b, FR-10, §7 T-02, NFR-08 · item 4.4 (which left T-02's
+  third leg open, closed here) · [RFC-0001](../rfc/0001-egl-utils-library.md) §Context (security
+  mechanisms 1 and 4) · [ADR-0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md)
+  (mechanism 3) · [ADR-0012](0012-enforce-the-layering-rule-by-directory-over-src-main.md) (the
+  layering rule this item first tested against an external package)
+
+## Context
+
+Two deliverables, addressing the two places output escaping does not reach.
+
+**FR-09b — rich HTML.** When rendering user-authored markup *is* the feature, escaping it defeats
+the feature. RFC-0001 requires delegation and says so in as many words: *"no hand-rolled tag
+stripper"*. HTML sanitization is a parsing problem, and a regex stripper is defeated by the same
+mutation-XSS corpus every time one is written.
+
+**FR-10 — `LIKE` wildcards.** Item 4.4's injection suite proved a `LIKE` value binds safely and
+cannot inject SQL. It also documented what binding does *not* fix: `%` and `_` are **pattern**
+syntax, not SQL syntax, so they survive binding intact. A search box forwarding `%` turns an
+indexed lookup into a full scan, and a per-user search into one matching every row the query's
+other conditions allow. Item 4.4 left this open, named FR-10 as the owner, and pinned the gap with
+a test saying which assertion should change when this item landed.
+
+Three things were probed before designing, and two changed the design:
+
+| probe | result |
+|---|---|
+| bound `LIKE '100%'` against a seeded table | matches `100%`, `100X`, `1000` — the wildcard is live |
+| escaped pattern **without** an `ESCAPE` clause, on SQLite | matches **nothing** — silently |
+| `ESCAPE '\'` written as a SQL literal, on SQLite | **parse error**: `unrecognized token` |
+
+## Decision
+
+### 1. The escape character is `!`, not `\`
+
+The obvious choice is a backslash, and it is wrong for a portable library. A backslash is itself
+special inside a string literal on several drivers, so the `ESCAPE` clause needs a different
+spelling per driver — and on SQLite `ESCAPE '\'` does not merely misbehave, it **fails to parse**.
+`!` has no meaning inside a string literal anywhere, so one spelling works on every driver.
+
+Exposed as `Sanitizer::LIKE_ESCAPE` because an escaped pattern is useless without the matching
+clause, and a caller writing that clause by hand needs to know which character to name.
+
+### 2. The escape character is escaped **first**
+
+`str_replace` is applied with the escape character ahead of the wildcards it introduces. Reversed,
+the pass over `%` would insert `!` characters that the later pass over `!` would then double —
+turning `100%` into `100!!%`, a literal `!` followed by a live wildcard. Pinned by a test
+(`'!%'` → `'!!!%'`), and probed: the reversed ordering fails five tests.
+
+### 3. `QueryBuilder::whereLike()` emits the `ESCAPE` clause, so the common path cannot fail silently
+
+This is the part that matters most, because the failure it prevents is invisible. `where()` with
+`Operator::Like` emits no `ESCAPE` clause. Without one:
+
+- **MySQL and PostgreSQL** treat backslash as an escape by default, so a backslash-escaped pattern
+  appears to work
+- **SQLite** has no default escape at all, and the pattern **silently matches nothing**
+
+So code written and tested against MySQL returns quietly wrong results on SQLite. `whereLike()`
+emits `LIKE ? ESCAPE '!'` unconditionally, which changes nothing for an unescaped pattern and makes
+an escaped one correct everywhere.
+
+**It does not escape the pattern for you**, deliberately: it cannot know which wildcards the caller
+meant. A prefix search is `Sanitizer::sqlLikePattern($term) . '%'`, where the user's portion is
+literal and the trailing `%` is the caller's. Escaping the whole pattern would turn every `LIKE`
+into an equality test.
+
+**The escape character is duplicated across the two groups rather than shared**, because RFC-0001's
+layering rule forbids `Database` → `Security` (ADR-0012, enforced by deptrac). `SanitizerTest`
+asserts the two constants agree via reflection, so the copy is checked rather than trusted — the
+same treatment ADR-0010 gave the docblock/attribute duplication it could not avoid.
+
+### 4. `richText()` delegates, throws when the delegate is absent, and keeps Symfony out of its signature
+
+`symfony/html-sanitizer` is **optional** (NFR-08 keeps the core free of third-party implementation
+code), declared in `suggest` and installed only as a dev dependency here.
+
+**A missing optional dependency is a security question, not a convenience one, and it throws.**
+Returning the input unchanged would hand a caller who asked for sanitization their attacker's
+markup; returning `''` would silently destroy content. Neither announces itself. Verified
+behaviourally by pointing the guard at a class that genuinely does not exist and confirming
+`UtilsException` is raised rather than the input returned.
+
+**No Symfony type appears in the public signature** — `richText(string): string`. A type-hint
+naming a class from an optional package makes that package effectively required for anyone
+reflecting over this class, which is the opposite of optional. The cost is that the profile is not
+caller-configurable; that is FR-09b's *"curated allowlist profile"* read literally, and a consumer
+needing a different one can use the component directly.
+
+The profile starts from Symfony's own `allowSafeElements()` — delegation applied one level down,
+rather than re-deriving a list of safe elements here — and adds what that alone does not cover:
+link schemes limited to `https`/`http`/`mailto` (this is what refuses `javascript:` and `data:`),
+relative links and media refused, and `rel="noopener noreferrer"` forced onto every link.
+
+### 5. The optional dependency gets its own deptrac layer
+
+This is the library's **first third-party dependency in production code**, and it took the layering
+gate from `Uncovered: 0` to `Uncovered: 6` — exactly the signal ADR-0012 built it to give.
+
+Rather than waving vendor code through, `HtmlSanitizer` is declared as its own layer that **only
+`Security` may reach**. An import of it from `Dto` or `Http` is now a build failure rather than a
+silent new coupling to an optional package. Verified by planting `Http → HtmlSanitizer` and
+confirming the violation.
+
+## Alternatives Considered
+
+- **A backslash escape character**, matching most tutorials — rejected on the probe: `ESCAPE '\'`
+  is a parse error on SQLite, and the clause would need per-driver spelling.
+- **Escaping the whole `LIKE` pattern inside `whereLike()`** — rejected: it cannot distinguish the
+  caller's own wildcards from the user's, and would silently degrade every `LIKE` to equality.
+- **Returning the input unchanged when `symfony/html-sanitizer` is absent** — rejected, and it is
+  the tempting one because it "keeps working". It keeps working by handing back exactly what the
+  caller asked to be made safe.
+- **Sharing `LIKE_ESCAPE` through a `Support` constant** so the two groups could not drift —
+  rejected as putting a SQL-dialect concern in the layer that is supposed to know nothing about
+  SQL. A reflection-based agreement test is cheaper and keeps the concern where it belongs.
+- **Accepting an `HtmlSanitizerConfig` parameter** for a caller-supplied profile — rejected: it
+  puts an optional package's type in a public signature (see §4).
+- **A blanket deptrac rule ignoring `vendor/`** — rejected: it would have silenced this finding and
+  every future one, which is the opposite of what item 3.6 built the gate for.
+
+## Consequences
+
+- **Spec §7's T-02 suite is complete.** Its third leg, open since item 4.4 and explicitly deferred
+  there, is closed; the item-4.4 test that asserted the gap now asserts the fix, and
+  `--group T-02` runs 343 tests.
+- `sqlLikePattern()` is asserted **against a real driver**, not on strings alone. Asserting that
+  `%` became `!%` would only prove the method does what it was written to do; whether the driver
+  then treats it as a literal is a question only the driver can answer.
+- The silent-failure mode is itself a test:
+  `testWithoutTheEscapeClauseAnEscapedPatternSilentlyMatchesNothing()` pins that `where()` +
+  `Operator::Like` returns nothing for an escaped pattern, which is why `whereLike()` exists.
+- **The suite is verified non-vacuous**: the escape-ordering bug (5 failures), allowing
+  `javascript:`/`data:` schemes (1), and dropping forced `rel="noopener"` (1) are each caught.
+- **A gap named rather than hidden:** the missing-dependency path is proven by probe but has **no
+  permanent test**, because the package is installed as a dev dependency and cannot be absent
+  during the suite. A CI job running without dev extras would cover it; that is build
+  infrastructure rather than a test, and is not built here.
+- `richText()` is not caller-configurable. Stated in the class rather than left to be discovered.
+
+## References
+
+- Spec FR-09b (delegation, "no hand-rolled tag stripper"), FR-10 (wildcard escaping), §7 T-02,
+  NFR-08 (dependency policy)
+- ADR-0012 — the layering gate that surfaced the new external dependency
+- ADR-0019 — output escaping, the mechanism this one complements
+- Verified directly on PHP 8.3.1 / `pdo_sqlite`: live wildcards under binding, the missing-`ESCAPE`
+  silent failure, and `ESCAPE '\'` as a parse error

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0018](0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md) | QueryBuilder's benchmark measures NFR-03 now; the ~23µs build-time gap is deliberately deferred | Accepted |
 | [0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md) | Four escaping contexts, no general `escape()`, and assume the attribute is unquoted | Accepted |
 | [0020](0020-correct-the-nfr03-workload-and-resolve-the-driver-once.md) | Correct NFR-03's benchmarked workload, resolve the driver once, and defer the residual to the reference machine | Accepted |
+| [0021](0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md) | Delegate rich-HTML sanitization, and escape LIKE wildcards with a portable character | Accepted |

--- a/docs/journal/2026/08/2026-08-04-sanitizer.md
+++ b/docs/journal/2026/08/2026-08-04-sanitizer.md
@@ -1,0 +1,105 @@
+# 2026-08-04 — Two sanitizers, and a wrong answer that only shows up on one driver
+
+Roadmap item **5.2**. Route `frontier-reasoning / extra`; session is Fable 5 — match.
+
+Two deliverables that share a class and almost nothing else: rich-HTML sanitization (FR-09b) and
+`LIKE`-wildcard escaping (FR-10). The second closes spec §7's **T-02** suite, whose third leg item
+4.4 deliberately left open and named this item as owner.
+
+## The bug that only appears on one driver
+
+Three probes before designing. Two changed the design.
+
+**Binding doesn't neutralise wildcards.** Item 4.4 already proved a `LIKE` value can't inject SQL.
+It can still *scan*: `%` and `_` are pattern syntax, not SQL syntax, so they survive binding
+intact. Confirmed against a seeded table — bound `LIKE '100%'` matched `100%`, `100X` and `1000`.
+
+**Then the one worth the whole item.** An escaped pattern **without** an `ESCAPE` clause matches
+**nothing** on SQLite. Silently. Meanwhile MySQL and PostgreSQL treat backslash as a default escape,
+so the identical code appears to work there.
+
+That's the nastiest shape a bug can have: written and tested against MySQL, correct; deployed
+against SQLite, quietly returns no rows. No error, no warning.
+
+So `QueryBuilder::whereLike()` emits the clause unconditionally. It changes nothing for an
+unescaped pattern and makes an escaped one correct everywhere. And the silent failure is itself
+now a test — `testWithoutTheEscapeClauseAnEscapedPatternSilentlyMatchesNothing()` pins that
+`where()` + `Operator::Like` returns `[]` for an escaped pattern, which is the reason `whereLike()`
+had to exist.
+
+**Third probe: the escape character.** The obvious choice is `\`. It's wrong for a portable
+library — a backslash is special inside string literals on several drivers, and on SQLite
+`ESCAPE '\'` isn't merely awkward, it's a **parse error** (`unrecognized token`). `!` has no
+meaning in a string literal anywhere, so one spelling works everywhere.
+
+## Ordering that looks arbitrary and isn't
+
+The escape character has to be escaped **before** the wildcards. Reversed, the `%` pass inserts `!`
+characters that the `!` pass then doubles — `100%` becomes `100!!%`, a literal `!` followed by a
+*live* wildcard. Exactly the thing being defended against, reintroduced by getting two lines in the
+wrong order. Pinned with `'!%'` → `'!!!%'`; the reversed order fails five tests.
+
+## A duplication I couldn't avoid, so I checked it instead
+
+`QueryBuilder` (Database) needs the escape character. `Sanitizer` (Security) defines it. RFC-0001's
+layering rule forbids `Database → Security`, and deptrac enforces it.
+
+Options were: put a SQL-dialect concern in `Support` (wrong layer), or duplicate the character and
+verify. Chose duplication plus a reflection test asserting the two constants agree. Same treatment
+ADR-0010 gave the docblock/attribute duplication it also couldn't avoid — if you can't remove a
+duplication, make it impossible for it to drift unnoticed.
+
+## The optional dependency, and where "optional" actually bites
+
+`symfony/html-sanitizer` is the library's **first third-party dependency in production code**.
+
+**What happens when it's absent is a security question, not a convenience one.** Returning the
+input unchanged hands a caller who asked for sanitization their attacker's markup. Returning `''`
+silently destroys content. Neither announces itself. So it throws — verified behaviourally by
+pointing the guard at a class that genuinely doesn't exist and confirming `UtilsException` rather
+than a passthrough.
+
+**No Symfony type in the public signature.** `richText(string): string`. A type-hint naming a class
+from an optional package makes that package effectively required for anyone reflecting over the
+class — the opposite of optional. Cost: the profile isn't caller-configurable, which is FR-09b's
+"curated allowlist profile" read literally.
+
+## The layering gate earning its keep, again
+
+Adding the dependency took deptrac from `Uncovered: 0` to `Uncovered: 6` — precisely the signal
+item 3.6 built it to give.
+
+The lazy fix is a blanket "ignore vendor" rule, which would have silenced this finding and every
+future one. Instead `HtmlSanitizer` gets its **own layer that only `Security` may reach**. Planted
+`Http → HtmlSanitizer` and confirmed the violation, so a future group quietly coupling itself to an
+optional package is now a build failure.
+
+My first attempt at the layer regex was wrong in a way worth noting: I wrote single backslashes in
+the YAML, so PCRE read `\C` and `\H` as escape sequences rather than namespace separators. It
+matched nothing and `Uncovered` stayed at 6 — which is how I found it, rather than by reading it.
+
+## Non-vacuity
+
+| planted | failures |
+|---|---|
+| escape character processed last (ordering bug) | 5 |
+| `javascript:`/`data:` schemes allowed | 1 |
+| forced `rel="noopener noreferrer"` removed | 1 |
+| `Http → HtmlSanitizer` import | deptrac violation |
+| guard pointed at a non-existent class | throws, does not passthrough |
+
+## Honest gap
+
+The missing-dependency path is **probe-verified but has no permanent test** — the package is a dev
+dependency and cannot be absent during the suite. A CI job without dev extras would cover it; that
+is build infrastructure rather than a test, and I didn't build it here. Named in the ADR and the
+roadmap rather than left as an assumption.
+
+## Bar
+
+685 tests / 1483 assertions green (up from 662). `--group T-02` runs 343 — **T-02 is complete**.
+PHPStan max clean, deptrac 0 violations / 0 uncovered, `composer validate --strict` clean.
+
+## Next
+
+**5.3** `Hash` — Argon2id default, `bcryptFallback` policy, `needsRehash()`. Same route.

--- a/docs/journal/2026/08/2026-08-04-sanitizer.md
+++ b/docs/journal/2026/08/2026-08-04-sanitizer.md
@@ -88,6 +88,33 @@ matched nothing and `Uncovered` stayed at 6 — which is how I found it, rather 
 | `Http → HtmlSanitizer` import | deptrac violation |
 | guard pointed at a non-existent class | throws, does not passthrough |
 
+## The prefer-lowest job earning its keep
+
+CI went green everywhere except `quality / prefer-lowest install + test`. Tests passed there too —
+685 of them — but with **1 deprecation**, which the warnings-as-errors bar turns into a failure.
+
+`symfony/html-sanitizer` pulls in `masterminds/html5`. Its 2.7.2 release calls
+`DOMImplementation::createDocument(null, null, $dt)`, passing `null` to a `string` parameter —
+deprecated on PHP 8.1+. The normal resolution picks 2.10.1 and never sees it. Only the
+lowest-allowed resolution does, which is exactly the failure mode item 1.7 added that job for.
+
+Fixed by naming `masterminds/html5: ^2.7.5` in `require-dev` — a transitive dependency declared
+directly only to raise its floor.
+
+Worth noting *how* I picked 2.7.5: by fetching `DOMTreeBuilder.php` from each upstream tag and
+bisecting.
+
+```
+2.7.3 -> createDocument(null, null, $dt)
+2.7.4 -> createDocument(null, null, $dt)
+2.7.5 -> createDocument(null, '',   $dt)   <- fixed here
+```
+
+The comfortable move is `^2.9` — safely past, obviously works, no thought required. But that
+excludes 2.7.5–2.8.x for no reason, and a floor that isn't the true minimum is a constraint nobody
+can later justify. Verified afterwards that prefer-lowest resolves exactly 2.7.5 and the
+deprecation is gone.
+
 ## Honest gap
 
 The missing-dependency path is **probe-verified but has no permanent test** — the package is a dev

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — Two sanitizers, and a wrong answer that only shows up on one driver](2026/08/2026-08-04-sanitizer.md)
 - [2026-08-04 — The benchmark was measuring the wrong thing, and I wrote it](2026/08/2026-08-04-nfr03-correction.md)
 - [2026-08-04 — Four grammars, and the assumption an escaper cannot check](2026/08/2026-08-04-escaper-contexts.md)
 - [2026-08-04 — The same shape as NFR-01, found in a different class](2026/08/2026-08-04-nfr03-querybuilder-bench.md)

--- a/src/main/php/d4np/utils/Database/QueryBuilder.php
+++ b/src/main/php/d4np/utils/Database/QueryBuilder.php
@@ -60,6 +60,16 @@ final class QueryBuilder
      */
     private const IDENTIFIER = '/^[A-Za-z_][A-Za-z0-9_]*\z/';
 
+    /**
+     * The escape character {@see whereLike()} declares in its `ESCAPE` clause.
+     *
+     * Deliberately duplicated from `Sanitizer::LIKE_ESCAPE` rather than imported: `Sanitizer` is
+     * in the `Security` group and RFC-0001's layering rule (enforced by deptrac, ADR-0012) allows
+     * groups to depend downward on `Support` only. `SanitizerTest` asserts the two constants
+     * agree, so the copy is checked rather than trusted.
+     */
+    private const LIKE_ESCAPE = '!';
+
     /** @var list<string> */
     private array $columns = [];
 
@@ -138,6 +148,41 @@ final class QueryBuilder
         // runs once per condition (roadmap 4.6).
         $clone->conditions[] = $this->identifier($column) . ' ' . $operator->value . ' ?';
         $clone->bindings[] = $value;
+
+        return $clone;
+    }
+
+    /**
+     * `WHERE <column> LIKE ? ESCAPE '!'`, with the pattern bound.
+     *
+     * Exists because {@see where()} with {@see Operator::Like} emits no `ESCAPE` clause, and
+     * **without one an escaped pattern is silently wrong in a driver-dependent way**: MySQL and
+     * PostgreSQL treat backslash as an escape by default so it appears to work, while SQLite has
+     * no default escape and the pattern matches nothing. Verified directly rather than assumed.
+     *
+     * So the clause is emitted here, unconditionally, and the escape character is the one
+     * `Sanitizer::sqlLikePattern()` applies. `!` rather than `\` because a backslash is special
+     * inside a SQL string literal on several drivers — `ESCAPE '\'` is a *parse error* on SQLite —
+     * whereas `!` needs no per-driver spelling.
+     *
+     * **The pattern is passed through as-is.** This does not escape it, because it cannot know
+     * which wildcards the caller meant: a prefix search is
+     * `Sanitizer::sqlLikePattern($term) . '%'`, where the user's portion is literal and the
+     * trailing `%` is the caller's own. Escaping the whole pattern here would turn every `LIKE`
+     * into an equality test.
+     *
+     * `Sanitizer` lives in the `Security` group and this class in `Database`, and RFC-0001's
+     * layering rule forbids the import — hence the escape character is spelled out on both sides
+     * rather than shared. `SanitizerTest` asserts the two agree, so the duplication cannot drift
+     * unnoticed.
+     *
+     * @throws DatabaseException if the column fails the allowlist
+     */
+    public function whereLike(string $column, string $pattern): self
+    {
+        $clone = clone $this;
+        $clone->conditions[] = $this->identifier($column) . " LIKE ? ESCAPE '" . self::LIKE_ESCAPE . "'";
+        $clone->bindings[] = $pattern;
 
         return $clone;
     }

--- a/src/main/php/d4np/utils/Security/Sanitizer.php
+++ b/src/main/php/d4np/utils/Security/Sanitizer.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Security;
+
+use D4np\Utils\Support\UtilsException;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+
+/**
+ * Input sanitization for the two cases where escaping is not the right tool (spec FR-09b, FR-10,
+ * ADR-0021).
+ *
+ * {@see Escaper} covers RFC-0001's third security mechanism — escaping at output. This class
+ * covers the two places that mechanism does not reach:
+ *
+ * - **{@see richText()}** — the fourth mechanism. When the *point* is to render user-authored
+ *   HTML, escaping it defeats the feature, so the markup has to be parsed and reduced to an
+ *   allowlist. RFC-0001 requires this be delegated, and names the delegate.
+ * - **{@see sqlLikePattern()}** — a gap the *first* mechanism leaves open. Parameter binding
+ *   stops a `LIKE` value injecting SQL, but it does nothing about the wildcards inside it: a
+ *   user-supplied `%` still turns an intended lookup into a scan.
+ */
+final class Sanitizer
+{
+    /**
+     * The escape character {@see sqlLikePattern()} uses, and the one a `LIKE` clause must declare.
+     *
+     * **`!`, not the more familiar `\`, and the choice is load-bearing.** A backslash is itself
+     * special inside a SQL string literal on several drivers, so the `ESCAPE` clause has to be
+     * written differently per driver — and `ESCAPE '\'` is not merely awkward but a *parse error*
+     * on SQLite (`unrecognized token`), verified directly. `!` has no meaning inside a string
+     * literal anywhere, so one spelling of the clause works on every driver.
+     *
+     * Exposed as a constant because the escaped pattern is useless without the matching `ESCAPE`
+     * clause — see {@see sqlLikePattern()} — and a caller writing that clause by hand needs to
+     * know which character to name.
+     */
+    public const LIKE_ESCAPE = '!';
+
+    private static ?HtmlSanitizer $htmlSanitizer = null;
+
+    private function __construct()
+    {
+        // Static-only: no instances.
+    }
+
+    /**
+     * Neutralise the wildcards in a value destined for a `LIKE` pattern (spec FR-10).
+     *
+     * **Binding is not enough here, and that is the whole point of this method.** A bound `LIKE`
+     * value cannot inject SQL — item 4.4's injection suite proves that — but `%` and `_` are
+     * *pattern syntax*, not SQL syntax, so binding passes them through intact. A search box that
+     * forwards `%` to `LIKE` has turned an indexed lookup into a full scan, and a search intended
+     * to match one user's records into one that matches every row the query's other conditions
+     * allow.
+     *
+     * **The escaped value only works if the SQL also declares the escape character.** This is the
+     * trap worth stating loudly, because the failure is silent and driver-dependent:
+     *
+     * ```sql
+     * -- Correct, everywhere:
+     * SELECT * FROM t WHERE name LIKE ? ESCAPE '!'
+     * ```
+     *
+     * Without that `ESCAPE` clause, MySQL and PostgreSQL treat backslash as an escape by default
+     * and a backslash-escaped pattern happens to work, while **SQLite has no default escape at
+     * all and the pattern silently matches nothing** — verified. Code written and tested against
+     * MySQL therefore returns quietly wrong results on SQLite. `QueryBuilder::whereLike()`
+     * (roadmap 4.2, extended here) emits the clause so the common path cannot get this wrong.
+     *
+     * Note what is *not* escaped: this escapes the wildcards inside a value, and the caller
+     * appends whatever wildcards the search itself needs — `Sanitizer::sqlLikePattern($term) . '%'`
+     * is a prefix search whose user portion is literal. Escaping the caller's own wildcards too
+     * would make every `LIKE` an equality test.
+     *
+     * @param string $escape the escape character the accompanying `ESCAPE` clause declares
+     */
+    public static function sqlLikePattern(string $value, string $escape = self::LIKE_ESCAPE): string
+    {
+        // The escape character must be escaped first. Doing it after would also escape the escape
+        // characters this method just introduced, doubling them into literals.
+        return str_replace(
+            [$escape, '%', '_'],
+            [$escape . $escape, $escape . '%', $escape . '_'],
+            $value,
+        );
+    }
+
+    /**
+     * Reduce user-authored HTML to a curated allowlist (spec FR-09b).
+     *
+     * **Delegated, and RFC-0001 says so in as many words: *"no hand-rolled tag stripper"*.** HTML
+     * sanitization is a parsing problem, and a regex-based stripper is defeated by the same
+     * corpus of mutation-XSS and namespace-confusion payloads every time someone writes one. This
+     * calls `symfony/html-sanitizer`, which parses the markup into a DOM and rebuilds it from an
+     * allowlist.
+     *
+     * **`symfony/html-sanitizer` is an optional dependency** (spec NFR-08 keeps the core free of
+     * third-party implementation code), so a consumer who never renders user HTML never installs
+     * it. That makes the missing-dependency path a security question rather than a convenience
+     * one, and it is answered the only defensible way: **this throws.** Returning the input
+     * unchanged would hand a caller who asked for sanitization their attacker's markup, and
+     * returning `''` would silently destroy content. Neither failure announces itself; an
+     * exception does.
+     *
+     * The public signature takes and returns `string` only — no Symfony type appears in it. That
+     * is deliberate: a type-hint naming a class from an optional package makes the package
+     * effectively required for anyone reflecting over this class, which is the opposite of
+     * optional. The cost is that the profile below is not caller-configurable; that is FR-09b's
+     * *"curated allowlist profile"* read literally, and a consumer needing a different profile can
+     * use the component directly.
+     *
+     * The profile:
+     *
+     * - `allowSafeElements()` — Symfony's own list of elements and attributes with no scripting
+     *   capability. Starting from *their* curated list rather than one written here is the same
+     *   delegation decision applied one level down.
+     * - **Link schemes limited to `https`, `http` and `mailto`.** This is what stops
+     *   `javascript:` and `data:` URLs, which `allowSafeElements()` alone does not.
+     * - **Relative links and relative media are refused.** A relative URL's meaning depends on the
+     *   page it lands on, which is not knowable here.
+     * - **`rel="noopener noreferrer"` is forced onto every link**, so a sanitized document cannot
+     *   hand `window.opener` to a third-party page.
+     *
+     * The 20 000-byte input cap is Symfony's default and is left in place: it bounds the work an
+     * untrusted document can demand, and raising it would be a denial-of-service decision made on
+     * a consumer's behalf.
+     *
+     * @throws UtilsException if `symfony/html-sanitizer` is not installed
+     */
+    public static function richText(string $html): string
+    {
+        return self::htmlSanitizer()->sanitize($html);
+    }
+
+    /**
+     * @throws UtilsException
+     */
+    private static function htmlSanitizer(): HtmlSanitizer
+    {
+        if (self::$htmlSanitizer instanceof HtmlSanitizer) {
+            return self::$htmlSanitizer;
+        }
+
+        if (!class_exists(HtmlSanitizer::class)) {
+            throw new UtilsException(
+                'Sanitizer::richText() needs symfony/html-sanitizer, which is an optional '
+                . 'dependency of this library and is not installed. Run '
+                . '`composer require symfony/html-sanitizer`. This raises rather than returning '
+                . 'the input unchanged, because handing back unsanitized markup to a caller who '
+                . 'asked for it to be sanitized is the failure this method exists to prevent.',
+            );
+        }
+
+        // Built once: the configuration is immutable and describes a fixed policy, so there is
+        // nothing per-call to vary. Same reasoning as the shared hydrator in ADR-0008.
+        return self::$htmlSanitizer = new HtmlSanitizer(
+            (new HtmlSanitizerConfig())
+                ->allowSafeElements()
+                ->allowLinkSchemes(['https', 'http', 'mailto'])
+                ->allowRelativeLinks(false)
+                ->allowMediaSchemes(['https', 'http'])
+                ->allowRelativeMedias(false)
+                ->forceAttribute('a', 'rel', 'noopener noreferrer'),
+        );
+    }
+}

--- a/src/test/php/d4np/utils/Database/InjectionTest.php
+++ b/src/test/php/d4np/utils/Database/InjectionTest.php
@@ -9,6 +9,7 @@ use D4np\Utils\Database\Operator;
 use D4np\Utils\Database\QueryBuilder;
 use D4np\Utils\Database\Sort;
 use D4np\Utils\Database\Transaction;
+use D4np\Utils\Security\Sanitizer;
 use D4np\Utils\Tests\Database\Fixture\LoggedStatement;
 use D4np\Utils\Tests\Database\Fixture\QueryLog;
 use PDO;
@@ -32,9 +33,10 @@ use PHPUnit\Framework\TestCase;
  * and `whereIn`, and the same through a `Transaction`.
  *
  * The other two legs of T-02: identifier injection is covered by `QueryBuilderTest` (17 hostile
- * identifiers × 4 surfaces, same group), and **LIKE-wildcard escaping is not covered here** —
- * `Sanitizer::sqlLikePattern()` is roadmap item 5.2 and does not exist yet. See the class-level
- * note on {@see self::testLikePatternsStillBindButWildcardsAreNotYetEscaped()}.
+ * identifiers × 4 surfaces, same group), and LIKE-wildcard escaping — open when this file was
+ * written at item 4.4 — is closed by roadmap item 5.2, with
+ * {@see self::testLikeWildcardsAreNeutralisedWhileTheValueStillBinds()} here and the driver-level
+ * cases in `SanitizerTest`. **T-02 is now complete.**
  */
 #[Group('T-02')]
 #[RequiresPhpExtension('pdo_sqlite')]
@@ -225,35 +227,34 @@ final class InjectionTest extends TestCase
     }
 
     /**
-     * **T-02's third leg is not covered, and this test says so rather than leaving a gap that
-     * looks like coverage.**
+     * **T-02's third leg — *"LIKE-wildcard escapes"* — closed by roadmap item 5.2.**
      *
-     * Spec §7 asks T-02 for *"LIKE-wildcard escapes"*. The mechanism for that is FR-10's
-     * `Sanitizer::sqlLikePattern()`, which is **roadmap item 5.2** and does not exist yet — it is
-     * a Milestone 5 deliverable, and building it here would jump a milestone and duplicate that
-     * item.
+     * Item 4.4 shipped this test asserting the *gap*: a `LIKE` value bound safely but its
+     * wildcards were live, so a user-supplied `%` turned an intended lookup into a scan. It named
+     * FR-10's `Sanitizer::sqlLikePattern()` as the owner and said which assertion should change
+     * when it landed. This is that change.
      *
-     * What is true today, and asserted below: a `LIKE` value **binds** like any other, so it
-     * cannot inject SQL. What is *not* true today is that its wildcards are neutralised — a
-     * user-supplied `%` still behaves as a wildcard, turning an intended exact-ish match into a
-     * scan. That is a real gap with a real consequence (unbounded scans; matching rows a user
-     * should not see), and it is FR-10's to close.
+     * Both halves are asserted, because the pairing is what makes it work: the value still binds
+     * (no injection), *and* the wildcard is now inert. `whereLike()` supplies the `ESCAPE` clause
+     * without which the escaped pattern would silently match nothing on SQLite.
      */
-    public function testLikePatternsStillBindButWildcardsAreNotYetEscaped(): void
+    public function testLikeWildcardsAreNeutralisedWhileTheValueStillBinds(): void
     {
         $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['secret-document']);
         $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['public-note']);
 
-        $rows = (new QueryBuilder($this->connection, 'users'))
-            ->where('name', Operator::Like, '%')
+        // Unescaped, a lone '%' still matches everything — it is legitimate pattern syntax, and
+        // neutralising it unconditionally would break every prefix search in the library.
+        $unescaped = (new QueryBuilder($this->connection, 'users'))->whereLike('name', '%')->get();
+        self::assertCount(2, $unescaped);
+
+        // Escaped, the same input is a literal and matches nothing.
+        $escaped = (new QueryBuilder($this->connection, 'users'))
+            ->whereLike('name', Sanitizer::sqlLikePattern('%'))
             ->get();
+        self::assertSame([], $escaped, 'the wildcard should now be a literal percent sign');
 
-        // Binding held — no injection, no error.
+        // And binding held throughout — the payload never entered the statement text.
         $this->assertNeverInStatementText('%');
-
-        // But the wildcard still matched everything. When item 5.2 lands, a caller passing a
-        // literal '%' through Sanitizer::sqlLikePattern() will match nothing here, and this
-        // assertion is the one that should change.
-        self::assertCount(2, $rows, 'wildcard escaping is FR-10 / item 5.2, not yet implemented');
     }
 }

--- a/src/test/php/d4np/utils/Security/SanitizerTest.php
+++ b/src/test/php/d4np/utils/Security/SanitizerTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Security;
+
+use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\Operator;
+use D4np\Utils\Database\QueryBuilder;
+use D4np\Utils\Security\Sanitizer;
+use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use ReflectionClassConstant;
+
+/**
+ * Spec FR-09b (`richText()`) and FR-10 (`sqlLikePattern()`).
+ *
+ * The `sqlLikePattern()` cases run against a **real SQLite database**, not on strings alone.
+ * Asserting that `%` became `!%` would only prove this class does what it was written to do; what
+ * matters is whether the driver then treats it as a literal, and that is a question only the
+ * driver can answer. These are `#[Group('T-02')]` because they close the third leg of spec §7's
+ * T-02 suite, left open at roadmap item 4.4.
+ */
+#[Group('T-02')]
+final class SanitizerTest extends TestCase
+{
+    // ---- sqlLikePattern() ----------------------------------------------------------------------
+
+    public function testWildcardsAndTheEscapeCharacterAreEscaped(): void
+    {
+        self::assertSame('100!%', Sanitizer::sqlLikePattern('100%'));
+        self::assertSame('a!_b', Sanitizer::sqlLikePattern('a_b'));
+        self::assertSame('ex!!clam', Sanitizer::sqlLikePattern('ex!clam'));
+    }
+
+    public function testOrdinaryTextIsUntouched(): void
+    {
+        self::assertSame('Grace Hopper', Sanitizer::sqlLikePattern('Grace Hopper'));
+        self::assertSame('', Sanitizer::sqlLikePattern(''));
+    }
+
+    /**
+     * The escape character has to be escaped *first*. Escaping it last would also double the
+     * escape characters this method had just introduced, turning `100%` into `100!!%` — a literal
+     * `!` followed by a live wildcard.
+     */
+    public function testTheEscapeCharacterIsProcessedBeforeTheWildcardsItIntroduces(): void
+    {
+        self::assertSame('!!!%', Sanitizer::sqlLikePattern('!%'));
+    }
+
+    public function testTheEscapeCharacterIsConfigurable(): void
+    {
+        self::assertSame('100\\%', Sanitizer::sqlLikePattern('100%', '\\'));
+    }
+
+    // ---- sqlLikePattern() against a real driver ------------------------------------------------
+
+    private function seeded(): DatabaseConnection
+    {
+        $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
+        $connection->execute('CREATE TABLE t (v TEXT)');
+        foreach (['100%', '100X', '1000', 'a_b', 'axb', 'plain'] as $value) {
+            $connection->execute('INSERT INTO t (v) VALUES (?)', [$value]);
+        }
+
+        return $connection;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function matching(DatabaseConnection $connection, string $pattern): array
+    {
+        return array_map(
+            static function (array $row): string {
+                self::assertIsString($row['v']);
+
+                return $row['v'];
+            },
+            (new QueryBuilder($connection, 't'))->select('v')->whereLike('v', $pattern)->get(),
+        );
+    }
+
+    /**
+     * The vulnerability, stated as a test: a bound-but-unescaped `%` is still pattern syntax.
+     */
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testAnUnescapedWildcardMatchesEverythingWithThatPrefix(): void
+    {
+        self::assertSame(['100%', '100X', '1000'], $this->matching($this->seeded(), '100%'));
+    }
+
+    /**
+     * The fix: the same input, escaped, matches only itself.
+     */
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testAnEscapedWildcardMatchesOnlyTheLiteralValue(): void
+    {
+        $connection = $this->seeded();
+
+        self::assertSame(['100%'], $this->matching($connection, Sanitizer::sqlLikePattern('100%')));
+        self::assertSame(['a_b'], $this->matching($connection, Sanitizer::sqlLikePattern('a_b')));
+    }
+
+    /**
+     * The caller's own wildcards still work — a prefix search is the escaped term plus a live `%`.
+     * If this method escaped the whole pattern, every `LIKE` would degrade to an equality test.
+     */
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testTheCallersOwnWildcardStillSearchesByPrefix(): void
+    {
+        self::assertSame(
+            ['100%', '100X', '1000'],
+            $this->matching($this->seeded(), Sanitizer::sqlLikePattern('100') . '%'),
+        );
+    }
+
+    /**
+     * **The trap this pairing exists to close.** `where()` with `Operator::Like` emits no `ESCAPE`
+     * clause, so on SQLite an escaped pattern matches *nothing* — silently, and differently from
+     * MySQL, where backslash-as-default-escape makes the same code appear to work.
+     */
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testWithoutTheEscapeClauseAnEscapedPatternSilentlyMatchesNothing(): void
+    {
+        $connection = $this->seeded();
+        $escaped = Sanitizer::sqlLikePattern('100%');
+
+        $withoutClause = (new QueryBuilder($connection, 't'))
+            ->select('v')
+            ->where('v', Operator::Like, $escaped)
+            ->get();
+
+        self::assertSame([], $withoutClause, 'this is the silent failure whereLike() exists to prevent');
+        self::assertSame(['100%'], $this->matching($connection, $escaped));
+    }
+
+    /**
+     * `QueryBuilder` cannot import `Sanitizer` — RFC-0001's layering rule forbids a `Database` →
+     * `Security` dependency — so the escape character is spelled out in both. This is the check
+     * that keeps the two copies honest.
+     */
+    public function testTheBuilderAndTheSanitizerAgreeOnTheEscapeCharacter(): void
+    {
+        // A private constant needs no setAccessible() — ReflectionClassConstant reads it directly.
+        $builderConstant = new ReflectionClassConstant(QueryBuilder::class, 'LIKE_ESCAPE');
+
+        self::assertSame(Sanitizer::LIKE_ESCAPE, $builderConstant->getValue());
+    }
+
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testTheEscapeClauseNamesTheSameCharacter(): void
+    {
+        $sql = (new QueryBuilder(new DatabaseConnection(new PDO('sqlite::memory:')), 't'))
+            ->whereLike('v', 'x')
+            ->toSql();
+
+        self::assertStringContainsString("LIKE ? ESCAPE '" . Sanitizer::LIKE_ESCAPE . "'", $sql);
+    }
+
+    // ---- richText() ----------------------------------------------------------------------------
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function markup(): iterable
+    {
+        yield 'ordinary formatting survives' => ['<p>Hello <b>world</b></p>', '<p>Hello <b>world</b></p>'];
+        yield 'script element is removed' => ['<script>alert(1)</script>', ''];
+        yield 'style element is removed' => ['<style>body{}</style>', ''];
+        yield 'iframe is removed' => ['<iframe src="https://evil.example"></iframe>', ''];
+        yield 'svg payload is removed' => ['<svg onload=alert(1)>', ''];
+    }
+
+    #[DataProvider('markup')]
+    public function testRichTextReducesMarkupToTheAllowlist(string $html, string $expected): void
+    {
+        self::assertSame($expected, Sanitizer::richText($html));
+    }
+
+    public function testEventHandlerAttributesAreStripped(): void
+    {
+        $sanitized = Sanitizer::richText('<img src="https://ok.example/a.png" onerror="alert(1)">');
+
+        self::assertStringNotContainsString('onerror', $sanitized);
+        self::assertStringNotContainsString('alert', $sanitized);
+    }
+
+    /**
+     * `allowSafeElements()` alone does not do this — the scheme allowlist is what does.
+     */
+    public function testJavascriptAndDataSchemesAreRefused(): void
+    {
+        foreach (['javascript:alert(1)', 'data:text/html;base64,PHNjcmlwdD4='] as $href) {
+            $sanitized = Sanitizer::richText(sprintf('<a href="%s">x</a>', $href));
+
+            self::assertStringNotContainsString('javascript:', $sanitized);
+            self::assertStringNotContainsString('data:', $sanitized);
+        }
+    }
+
+    public function testHttpsLinksSurviveAndCarryRelNoopener(): void
+    {
+        $sanitized = Sanitizer::richText('<a href="https://ok.example">ok</a>');
+
+        self::assertStringContainsString('https://ok.example', $sanitized);
+        self::assertStringContainsString('noopener', $sanitized);
+        self::assertStringContainsString('noreferrer', $sanitized);
+    }
+
+    /**
+     * A relative URL's meaning depends on the page it is rendered into, which is not knowable here.
+     */
+    public function testRelativeLinksAreRefused(): void
+    {
+        self::assertStringNotContainsString('/admin', Sanitizer::richText('<a href="/admin">x</a>'));
+    }
+
+    public function testTheSanitizerIsBuiltOnceAndReused(): void
+    {
+        // Two calls must agree; the memoised instance is shared process-wide (see ADR-0008's
+        // reasoning for the hydrator, applied here).
+        self::assertSame(Sanitizer::richText('<p>a</p>'), Sanitizer::richText('<p>a</p>'));
+    }
+}

--- a/src/test/php/d4np/utils/Support/StaticUtilityContractTest.php
+++ b/src/test/php/d4np/utils/Support/StaticUtilityContractTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace D4np\Utils\Tests\Support;
 
 use D4np\Utils\Security\Escaper;
+use D4np\Utils\Security\Sanitizer;
 use D4np\Utils\Support\Env;
 use D4np\Utils\Support\File;
 use D4np\Utils\Support\Json;
@@ -43,6 +44,7 @@ final class StaticUtilityContractTest extends TestCase
         yield 'Env' => [Env::class];
         yield 'Json' => [Json::class];
         yield 'Escaper' => [Escaper::class];
+        yield 'Sanitizer' => [Sanitizer::class];
     }
 
     /**


### PR DESCRIPTION
## Summary

Roadmap item 5.2 (spec FR-09b, FR-10). **Completes spec §7's T-02 suite** — its LIKE-wildcard leg was deliberately left open at item 4.4, which named this item as owner.

## ⚠️ The finding worth the whole item: a wrong answer that only appears on one driver

Three probes ran before designing. Two changed the design.

**Binding doesn't neutralise wildcards.** Item 4.4 proved a `LIKE` value can't inject SQL — it can still *scan*. `%` and `_` are *pattern* syntax, not SQL syntax, so they survive binding intact. Confirmed: bound `LIKE '100%'` matched `100%`, `100X` and `1000`.

**Then the serious one.** An escaped pattern **without** an `ESCAPE` clause matches **nothing** on SQLite — silently — while MySQL and PostgreSQL treat backslash as a default escape so the identical code appears to work.

That's the nastiest shape a bug can have: written and tested against MySQL, correct; deployed against SQLite, quietly returns no rows. No error, no warning. So `QueryBuilder::whereLike()` emits the clause unconditionally, and **the silent failure is itself now a test**.

**Third probe — the escape character.** The obvious `\` is wrong for a portable library: a backslash is special inside SQL string literals on several drivers, and on SQLite `ESCAPE '\'` is a **parse error**. `!` has no meaning in a string literal anywhere.

## Ordering that looks arbitrary and isn't

The escape character must be escaped **before** the wildcards it introduces. Reversed, the `%` pass inserts `!` characters the `!` pass then doubles — `100%` → `100!!%`, a literal `!` followed by a **live** wildcard. The exact thing being defended against, reintroduced by two lines in the wrong order.

## A duplication I couldn't remove, so I made it undriftable

`QueryBuilder` (Database) needs the escape character; `Sanitizer` (Security) defines it; RFC-0001's layering rule forbids the import. Options were a SQL concern in `Support` (wrong layer) or duplication. Chose duplication **plus a reflection test asserting the two constants agree** — same treatment ADR-0010 gave the docblock/attribute pair it also couldn't avoid.

## The optional dependency, and where "optional" actually bites

`symfony/html-sanitizer` is the library's **first third-party production dependency**.

- **Absence throws.** Returning input unchanged hands a caller who asked for sanitization their attacker's markup; returning `''` silently destroys content. Neither announces itself. Verified behaviourally by pointing the guard at a class that genuinely doesn't exist.
- **No Symfony type in the public signature.** A type-hint naming an optional package's class makes it effectively required for anyone reflecting over the class — the opposite of optional.

## The layering gate earning its keep again

The dependency took deptrac from `Uncovered: 0` → `6`. The lazy fix is a blanket ignore-vendor rule, which would silence this and every future finding. Instead `HtmlSanitizer` gets **its own layer only `Security` may reach**, confirmed by planting `Http → HtmlSanitizer`.

My first regex attempt used single backslashes in YAML, so PCRE read `\C`/`\H` as escape sequences. It matched nothing and `Uncovered` stayed at 6 — which is how I found it.

## Test plan

- [x] `sqlLikePattern()` asserted **against a real driver**, not on strings alone — asserting `%` became `!%` would only prove the method does what it was written to do
- [x] **Non-vacuity:** escape-ordering bug (5 failures), `javascript:`/`data:` allowed (1), forced `rel="noopener"` removed (1), `Http → HtmlSanitizer` (deptrac violation)
- [x] `vendor/bin/phpunit` — 685 tests, 1483 assertions, 7 skipped
- [x] `--group T-02` → 343 tests, **T-02 complete**
- [x] PHPStan max clean · deptrac 0/0 · `composer validate --strict` · consistency + action-pin lints OK
- [ ] CI

## Honest gap

The missing-dependency path is **probe-verified but has no permanent test** — the package is a dev dependency and can't be absent during the suite. A CI job without dev extras would cover it; that's build infrastructure rather than a test, and I didn't build it here. Named in ADR-0021 and the roadmap rather than left as an assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)