### PR TITLE
feat(security): Hash with an Argon2id default and a construction-time fallback

### DIFF
--- a/.eados-core/learning/runs/2026-08-04-utils-4.yaml
+++ b/.eados-core/learning/runs/2026-08-04-utils-4.yaml
@@ -1,0 +1,36 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-04"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}
+route_mismatch:
+  routed: "frontier-reasoning/extra"
+  session: "standard"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,24 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- `D4np\Utils\Security\Hash` (**ADR-0022**) — password hashing with an Argon2id default, per spec
+  FR-11. **`PASSWORD_DEFAULT` is deliberately not used**: it is bcrypt (`'2y'`) on every PHP release
+  to date, even where Argon2id is available, so code reaching for it expecting "whatever is
+  strongest" silently gets the weaker algorithm — pinned by a test so the day PHP changes it, the
+  suite says so. Availability is `defined('PASSWORD_ARGON2ID')`, checked *before* use because an
+  unknown algorithm raises a bare `ValueError` outside ADR-0004's exception family.
+  Unlike `Escaper` and `Sanitizer` this is an **instance**, because it carries a policy and a
+  collaborator, and security configuration that can change mid-request is the wrong shape. The
+  fallback is decided **once at construction**: `bcryptFallback: false` refuses to construct at all
+  (so a misconfigured deployment fails while being wired, not at the first user registration), and
+  the default `true` logs a single WARNING rather than one per hash. `algorithm()` exposes the
+  outcome as a **value**, so a deployment without a PSR-3 logger can still detect the degradation.
+  `verify()` works across algorithms and `needsRehash()` flags both a weaker algorithm and weaker
+  *parameters*, which is what makes upgrade-on-login work.
+- `deptrac.yaml` gains a `Psr` layer, granted to `Security` only for now. `psr/log` is a *required*
+  interface-only dependency (RFC-0001 R-3) rather than an optional one, and further groups will
+  need it as `Errors` (PSR-3) and `Container` (PSR-11) arrive, so it is granted per group as each
+  does.
 - `D4np\Utils\Security\Sanitizer` (**ADR-0021**) — `richText()` and `sqlLikePattern()`. **This
   completes spec §7's T-02 suite**, whose LIKE-wildcard leg roadmap item 4.4 deferred here.
   `sqlLikePattern()` neutralises the `%` and `_` that survive parameter binding intact — binding

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -307,8 +307,12 @@ Explicit-mechanism security helpers (RFC-0001; every item carries the protected 
       Fallback decided **once at construction** — `false` refuses to construct (fail fast means at
       wiring time, not first registration), `true` logs one WARNING rather than one per hash. The
       fallback is also a **value** (`algorithm()`), so a deployment without a logger can still
-      detect it. Honest gap: the fallback branch is unreachable on any build with Argon2id — proven
-      by a probe that **passed**, so the WARNING level is unasserted; item 5.5 owns that matrix.*
+      detect it. The fallback branch is unreachable in-process (`defined()` cannot be un-defined),
+      which a probe **passing** exposed and the coverage gate then forced to a real fix: the policy
+      is extracted as `selectAlgorithm()` — a pure function taking availability as an argument — so
+      the refusal, the bcrypt selection and the WARNING **level** are all asserted. The seam exposes
+      the **decision, not the weak algorithm**: there is still no way to hash with bcrypt on a
+      capable build. Item 5.5 keeps NFR-05 timing and the wider matrix.*
 - [ ] 5.4 OWASP XSS corpus snapshot suite + DOM-bypass corpus for `richText()` (RFC-0001)
       (security) — route: frontier-reasoning / extra
 - [ ] 5.5 Hash matrix tests (argon2id/bcrypt fallback, rehash triggers) + NFR-05 timing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — Two sanitizers, and a wrong answer that only shows up on one driver](docs/journal/2026/08/2026-08-04-sanitizer.md).
+  [2026-08-04 — The constant that reads like "strongest" and means bcrypt](docs/journal/2026/08/2026-08-04-hash.md).
 
 ## Model & effort routing (advisory)
 
@@ -297,8 +297,18 @@ Explicit-mechanism security helpers (RFC-0001; every item carries the protected 
       `Security` may reach** (planted `Http→HtmlSanitizer` to confirm). Honest gap: the
       missing-dependency path is probe-verified but has no permanent test, since the package is a
       dev dependency.*
-- [ ] 5.3 `Hash`: Argon2id default, `bcryptFallback` policy, `needsRehash()` (RFC-0001)
-      (security) — route: frontier-reasoning / extra
+- [x] 5.3 `Hash`: Argon2id default, `bcryptFallback` policy, `needsRehash()` (RFC-0001)
+      (security) — route: frontier-reasoning / extra *(run at standard tier; mismatch accepted by
+      the maintainer and recorded)* · **ADR-0022**. *Probed: **`PASSWORD_DEFAULT` is bcrypt**
+      (`'2y'`) even where Argon2id is available — code reaching for it expecting "whatever is
+      strongest" silently gets the weaker algorithm, which is why FR-11 names Argon2id. An
+      instance, not a static helper like `Escaper`/`Sanitizer`: it carries a **policy** and a
+      **collaborator**, and security configuration that can change mid-request is the wrong shape.
+      Fallback decided **once at construction** — `false` refuses to construct (fail fast means at
+      wiring time, not first registration), `true` logs one WARNING rather than one per hash. The
+      fallback is also a **value** (`algorithm()`), so a deployment without a logger can still
+      detect it. Honest gap: the fallback branch is unreachable on any build with Argon2id — proven
+      by a probe that **passed**, so the WARNING level is unasserted; item 5.5 owns that matrix.*
 - [ ] 5.4 OWASP XSS corpus snapshot suite + DOM-bypass corpus for `richText()` (RFC-0001)
       (security) — route: frontier-reasoning / extra
 - [ ] 5.5 Hash matrix tests (argon2id/bcrypt fallback, rehash triggers) + NFR-05 timing

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -68,6 +68,19 @@ deptrac:
           # regex escape sequence rather than a namespace separator.
           value: ^Symfony\\Component\\HtmlSanitizer\\.*
 
+    # The interface-only PSR packages. RFC-0001 R-3 carves these out of spec NFR-08's
+    # "no third-party implementation dependencies": a package that *implements* PSR-11 or PSR-3
+    # necessarily requires the interface package, so they are required rather than optional. They
+    # get a layer for the same reason `HtmlSanitizer` does — so that which groups may reach them is
+    # a stated rule rather than an accident. Unlike the sanitizer, more than one group legitimately
+    # needs them (`Security` logs, `Errors` will implement PSR-3, `Container` will implement
+    # PSR-11), so the ruleset below grants them individually as each group arrives.
+    - name: Psr
+      collectors:
+        - type: classLike
+          # Doubled backslashes: a PCRE pattern, where a single `\L` would be a regex escape.
+          value: ^Psr\\(Log|Container)\\.*
+
     # `Version` sits at the namespace root, in no group — it is a single version constant. Given
     # its own layer rather than left uncollected so that "every production class belongs to a
     # declared layer" stays a fact this config states, rather than an assumption.
@@ -89,6 +102,8 @@ deptrac:
       - Support
       # Only this group may reach the optional sanitizer (spec FR-09b).
       - HtmlSanitizer
+      # Hash logs its bcrypt-fallback WARNING through PSR-3 (spec FR-11).
+      - Psr
     Http:
       - Support
     Errors:
@@ -105,3 +120,4 @@ deptrac:
 
     # A vendored dependency is a leaf here: this repository does not constrain its internals.
     HtmlSanitizer: ~
+    Psr: ~

--- a/docs/adr/0022-argon2id-by-default-with-a-fallback-decided-at-construction.md
+++ b/docs/adr/0022-argon2id-by-default-with-a-fallback-decided-at-construction.md
@@ -116,12 +116,30 @@ a number that has to keep moving. Item **5.5** owns the NFR-05 timing measuremen
   dead defensive code is worse than none, because it implies a failure mode that does not exist.
   Likewise an `assertTrue(defined('PASSWORD_ARGON2ID'))` guard became a `markTestSkipped`, since a
   guard that is statically true is not a guard.
-- **The bcrypt-fallback branch is unreachable on any build that has Argon2id, and is therefore
-  untested here.** This is not glossed: a deliberate probe (logging at `info` instead of `warning`)
-  **passed**, which is the proof that the WARNING *level* is currently unasserted. Three other
-  planted defects — `PASSWORD_DEFAULT`, a `needsRehash()` stuck at `false`, and a `verify()` doing
-  raw string comparison — each failed 4–6 tests. Roadmap item **5.5** owns the fallback matrix, and
-  reaching that branch needs either a PHP built without Argon2 or a seam this ADR declines to add.
+- **The bcrypt-fallback branch is unreachable in-process, so the *policy* was extracted to make it
+  testable.** `defined('PASSWORD_ARGON2ID')` is a compile-time fact no test can vary, so the
+  fallback branch could not be executed at all. That was first documented as an accepted gap —
+  and a deliberate probe (logging at `info` instead of `warning`) **passed**, proving the WARNING
+  level was unasserted. It then also dropped total line coverage to **89.03%**, under ADR-0007's
+  90% floor.
+
+  Neither available shortcut was acceptable: lowering the floor is the exact failure this project's
+  discipline exists to prevent, and a `@codeCoverageIgnore` would have hidden the most
+  security-relevant branch in the class from measurement entirely. So `selectAlgorithm()` was
+  extracted — the policy as a pure function of *"is Argon2id available"*, with the availability
+  supplied as an argument. The fail-fast refusal, the bcrypt selection, the WARNING **level**, and
+  the fact that refusing does *not* also log are now each asserted. Re-running the probe that had
+  passed: it now fails.
+
+  **The seam exposes the decision, not the weak algorithm.** There is no route to hashing with
+  bcrypt on a build that supports Argon2id — the difference between making a policy testable and
+  making it configurable, and the reason the rejected "offer bcrypt explicitly" alternative above
+  is still rejected.
+- Four planted defects each fail 1–6 tests: `PASSWORD_DEFAULT`, a `needsRehash()` stuck at `false`,
+  a `verify()` doing raw string comparison, and the `info`-instead-of-`warning` probe that only
+  became catchable after the extraction.
+- Item **5.5** still owns the NFR-05 timing measurement and the wider fallback matrix; what this
+  item closes is the policy's own correctness.
 
 ## References
 

--- a/docs/adr/0022-argon2id-by-default-with-a-fallback-decided-at-construction.md
+++ b/docs/adr/0022-argon2id-by-default-with-a-fallback-decided-at-construction.md
@@ -1,0 +1,132 @@
+# ADR-0022: Argon2id by name, not by `PASSWORD_DEFAULT`, with the fallback decided at construction
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 5.3 · spec FR-11, NFR-05, NFR-08 · item 5.5 (the fallback matrix and
+  NFR-05 timing, which this item deliberately does not pre-empt) ·
+  [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md) ·
+  [ADR-0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md) /
+  [ADR-0021](0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md) (the
+  static `Security` helpers this one deliberately is not) ·
+  [ADR-0012](0012-enforce-the-layering-rule-by-directory-over-src-main.md)
+
+## Context
+
+Spec FR-11: *"password_hash wrapper, Argon2id default; availability via
+`defined('PASSWORD_ARGON2ID')`; bcryptFallback: true default logged at WARNING or false to fail
+fast; self-describing hashes; needsRehash() upgrades on login."*
+
+Probed against PHP 8.3.1 before designing:
+
+| probe | result |
+|---|---|
+| `PASSWORD_DEFAULT` | **`'2y'` — bcrypt**, even though Argon2id is available |
+| `password_hash()` with an unknown algorithm | raises a bare `ValueError` |
+| `password_needs_rehash($bcryptHash, PASSWORD_ARGON2ID)` | `true` — upgrade correctly detected |
+| `password_verify()` against `''` / `'not-a-hash'` | `false`, no exception |
+| `password_needs_rehash('not-a-hash', …)` | `true` |
+
+The first is the one that shapes the class. `PASSWORD_DEFAULT` reads like *"whatever PHP thinks is
+strongest"* and is bcrypt on every release to date. Code reaching for it expecting Argon2id gets
+the weaker algorithm silently, which is exactly why FR-11 names Argon2id rather than deferring.
+
+## Decision
+
+### 1. `Hash` is an instance, breaking with the rest of the `Security` group
+
+`Escaper` and `Sanitizer` are static, and are pure functions of their input. Hashing is not: it
+carries a **policy** (what to do when Argon2id is unavailable) and a **collaborator** (the logger
+that policy announces itself through). Threading both through static calls means either global
+mutable configuration or repeating them at every call site — and configuration that can change
+halfway through a request is the wrong shape for a security decision.
+
+RFC-0001's API contract writes `Hash::make()/verify()/needsRehash()`, but its `::` notation is
+loose in the same list (`QueryBuilder::orderBy()` is an instance method), so this is not a
+departure from the spec's signatures.
+
+### 2. Argon2id is named explicitly; `PASSWORD_DEFAULT` is never used
+
+Pinned by a test that asserts `PASSWORD_DEFAULT === PASSWORD_BCRYPT`, so the day PHP changes it,
+the suite says so rather than the behaviour quietly shifting.
+
+### 3. Availability is `defined('PASSWORD_ARGON2ID')`, checked *before* use
+
+Argon2 support is a compile-time option, so the constant's absence is the honest signal. The check
+happens before `password_hash()` rather than as a rescue afterwards, because an unknown algorithm
+raises a bare `ValueError` — outside ADR-0004's family, and something a caller catching
+`UtilsThrowable` would miss.
+
+### 4. The fallback decision is made **once, at construction**
+
+- `bcryptFallback: false` → an unavailable Argon2id raises immediately. A misconfigured deployment
+  fails while it is being *wired*, not the first time a user tries to register. That is what "fail
+  fast" has to mean to be worth anything.
+- `bcryptFallback: true` (FR-11's default) → one WARNING at construction, not one per `make()`. A
+  warning emitted on every password hash is one that gets filtered out, and the signal is lost in
+  the volume it generates.
+
+### 5. The fallback is a **value**, not only a log line
+
+`algorithm()` returns what will actually be used. The logger is optional — requiring a PSR-3
+implementation to hash a password is a heavy demand for a utility — but that would make the
+fallback undetectable in a deployment without one. Exposing it as a value means a health check can
+assert on it, and the warning is not the only way to find out.
+
+### 6. Cost parameters are PHP's own defaults
+
+Spec NFR-05 budgets `make()` at 50–200 ms and calls the slowness deliberate. PHP's defaults are
+chosen per release by people tracking hardware; overriding them here would mean this library owning
+a number that has to keep moving. Item **5.5** owns the NFR-05 timing measurement.
+
+## Alternatives Considered
+
+- **A static `Hash` for consistency with `Escaper`/`Sanitizer`** — rejected in §1. Consistency of
+  shape is not worth global mutable security configuration.
+- **`PASSWORD_DEFAULT`** — rejected on the probe: it is bcrypt, and using it would silently
+  contradict FR-11's central requirement.
+- **Catching the `ValueError` from an unknown algorithm** instead of checking `defined()` first —
+  rejected: it is FR-11's specified mechanism, and a rescue after the fact would mean the failure
+  path runs through an exception type outside this library's family.
+- **Failing at first `make()` rather than at construction** — rejected: it moves the discovery of a
+  misconfiguration from deployment to the first user registration.
+- **Logging the WARNING per `make()`** — rejected; see §4.
+- **Requiring a `LoggerInterface`** so the warning can never be lost — rejected as too heavy for a
+  utility, and mitigated by §5 instead.
+- **Choosing cost parameters here** — rejected in §6.
+- **Offering "use bcrypt" as a supported explicit option** (which would have made the fallback
+  branch directly testable) — rejected: it turns the weaker algorithm into a first-class choice,
+  and the testability gain is not worth advertising it.
+
+## Consequences
+
+- Upgrade-on-login works as FR-11 describes: a bcrypt hash stored before this deployment still
+  verifies, reports `needsRehash()`, and is replaced with Argon2id — asserted end to end.
+- **Weaker *parameters* under the same algorithm also trigger a rehash**, so moving to a PHP with
+  stronger defaults upgrades users on next login with no change here.
+- A malformed stored hash returns `false` from `verify()` and `true` from `needsRehash()` — the
+  safe direction: it matches nothing, and cannot be left looking current.
+- `psr/log` gets a deptrac layer (`Psr`), granted to `Security` only for now. It is a *required*
+  interface-only dependency under RFC-0001 R-3, unlike `HtmlSanitizer`'s optional one, and more
+  groups will need it (`Errors` implements PSR-3, `Container` PSR-11), so the ruleset grants it per
+  group as each arrives. Verified by planting `Dto → LoggerInterface` and confirming the violation.
+- **PHPStan at max removed defensive code that could not fire.** A guard on `password_hash()`
+  returning `''` was flagged as an always-false comparison — the function is typed
+  `non-empty-string` and lost its `false` return in PHP 8.0. It was deleted rather than suppressed:
+  dead defensive code is worse than none, because it implies a failure mode that does not exist.
+  Likewise an `assertTrue(defined('PASSWORD_ARGON2ID'))` guard became a `markTestSkipped`, since a
+  guard that is statically true is not a guard.
+- **The bcrypt-fallback branch is unreachable on any build that has Argon2id, and is therefore
+  untested here.** This is not glossed: a deliberate probe (logging at `info` instead of `warning`)
+  **passed**, which is the proof that the WARNING *level* is currently unasserted. Three other
+  planted defects — `PASSWORD_DEFAULT`, a `needsRehash()` stuck at `false`, and a `verify()` doing
+  raw string comparison — each failed 4–6 tests. Roadmap item **5.5** owns the fallback matrix, and
+  reaching that branch needs either a PHP built without Argon2 or a seam this ADR declines to add.
+
+## References
+
+- Spec FR-11 (the policy), NFR-05 (the timing budget item 5.5 measures), NFR-08 / RFC-0001 R-3
+  (why `psr/log` is a permitted required dependency)
+- ADR-0004 — the exception family the `ValueError` avoidance protects
+- Verified directly on PHP 8.3.1: `PASSWORD_DEFAULT === PASSWORD_BCRYPT`, the `ValueError` on an
+  unknown algorithm, and `password_verify`/`password_needs_rehash` behaviour on malformed input

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,3 +37,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md) | Four escaping contexts, no general `escape()`, and assume the attribute is unquoted | Accepted |
 | [0020](0020-correct-the-nfr03-workload-and-resolve-the-driver-once.md) | Correct NFR-03's benchmarked workload, resolve the driver once, and defer the residual to the reference machine | Accepted |
 | [0021](0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md) | Delegate rich-HTML sanitization, and escape LIKE wildcards with a portable character | Accepted |
+| [0022](0022-argon2id-by-default-with-a-fallback-decided-at-construction.md) | Argon2id by name, not by `PASSWORD_DEFAULT`, with the fallback decided at construction | Accepted |

--- a/docs/journal/2026/08/2026-08-04-hash.md
+++ b/docs/journal/2026/08/2026-08-04-hash.md
@@ -66,7 +66,7 @@ to `markTestSkipped`, which is what it should have been anyway: on a build witho
 tests should *skip*, not fail — the absence is a property of the interpreter, not a defect in the
 library. A guard that is statically true is not a guard.
 
-## A probe that passed, which is the finding
+## A probe that passed, then a coverage floor that refused to let me leave it
 
 Four planted defects:
 
@@ -77,18 +77,36 @@ Four planted defects:
 | `verify()` doing raw string comparison | 5 |
 | fallback logged at `info` instead of `warning` | **0 — passed** |
 
-That fourth one passing is not a gap in the probe, it's the *proof* of a gap in coverage: the
-fallback branch is unreachable on any build that has Argon2id, so the WARNING **level** is
-currently unasserted. I'd rather have run the probe and learned that than assumed the branch was
-covered because the code looked right.
+That fourth one passing wasn't a weak probe, it was the *proof* of a coverage gap: the fallback
+branch is unreachable on any build with Argon2id, so the WARNING **level** was unasserted. I
+documented it as an accepted gap and pointed at item 5.5.
 
-Roadmap **5.5** explicitly owns the argon2id/bcrypt fallback matrix, so that's where it belongs —
-not something to solve here by adding a "please use bcrypt" option, which would make the weaker
-algorithm a first-class supported choice for the sake of testability.
+Then CI's coverage job failed: **89.03%**, under the 90% floor. The uncovered lines were exactly
+that branch.
+
+Both easy exits were unacceptable. Lowering the floor is the precise failure this project's
+discipline exists to prevent. A `@codeCoverageIgnore` would have hidden the most security-relevant
+branch in the class from measurement — and since it's the branch that *only* runs on a degraded
+build, that's the last place to stop looking.
+
+So I extracted the policy: `selectAlgorithm(bool $argon2idAvailable, bool $bcryptFallback, ?LoggerInterface)`
+— a pure function with availability as an argument. Now asserted: bcrypt is selected, the refusal
+throws, the WARNING is at **WARNING** level with the right context, and refusing does *not* also log
+(a hard failure is loud already; a warning beside it would imply the run continued degraded).
+
+Re-ran the probe that had passed. It fails now.
+
+**The seam exposes the decision, not the weak algorithm.** There's still no way to hash with bcrypt
+on a build that supports Argon2id — which is the difference between making a policy testable and
+making it configurable, and why the "just offer bcrypt explicitly" alternative stays rejected.
+
+Worth naming the sequence: I'd written the gap up as acceptable and moved on. The coverage gate is
+what made me go back and actually solve it. That's the gate doing its job on me, not on some
+hypothetical future contributor.
 
 ## Bar
 
-701 tests / 1510 assertions green (up from 685). PHPStan max clean, deptrac 0 violations / 0
+706 tests / 1520 assertions green (up from 685), coverage back above the 90% floor. PHPStan max clean, deptrac 0 violations / 0
 uncovered — `psr/log` got a `Psr` layer granted to `Security` only, verified by planting
 `Dto → LoggerInterface`. Unlike the sanitizer's optional dependency, this one is *required*
 (RFC-0001 R-3), and more groups will need it as `Errors` and `Container` arrive, so the ruleset

--- a/docs/journal/2026/08/2026-08-04-hash.md
+++ b/docs/journal/2026/08/2026-08-04-hash.md
@@ -1,0 +1,107 @@
+# 2026-08-04 — The constant that reads like "strongest" and means bcrypt
+
+Roadmap item **5.3**. Route `frontier-reasoning / extra`; session is Opus 5 (standard) — **below**
+the route. Flagged it before starting rather than proceeding silently, since this is the most
+security-sensitive item so far and the model had just been switched twice in succession. The
+maintainer chose to proceed at standard; mismatch recorded via `record_run.py`.
+
+Before any of that, a recovery: `git checkout master` failed with `Permission denied` writing
+`.git/HEAD` — a lock from the background composer processes still finishing — which left the
+working tree on master's content while HEAD stayed on the feature branch, and the follow-up
+`push --delete` removed the remote branch anyway. Nothing was lost: I verified
+`git diff <branch> origin/master` was **empty** before discarding anything, confirming the squash
+merge had landed byte-identical content. A `reset --hard` was blocked by the safety classifier,
+correctly — a plain checkout resolved it without needing one.
+
+## The finding
+
+```
+PASSWORD_DEFAULT === '2y'     // bcrypt
+PASSWORD_ARGON2ID === 'argon2id'   // available on this build
+```
+
+`PASSWORD_DEFAULT` reads like "whatever PHP thinks is strongest". It is **bcrypt**, on every
+release to date, even where Argon2id is compiled in. Code reaching for it expecting the strong
+algorithm silently gets the weaker one — no error, no warning, and a hash that looks perfectly
+fine.
+
+That is precisely why FR-11 says *"Argon2id default"* rather than deferring to PHP. Pinned with a
+test asserting `PASSWORD_DEFAULT === PASSWORD_BCRYPT`, so the day PHP changes it, the suite says so
+instead of the behaviour quietly shifting under us.
+
+## Breaking with the group's own shape, deliberately
+
+`Escaper` and `Sanitizer` are static. `Hash` is an instance, and that inconsistency is the point:
+hashing carries a **policy** (what to do when Argon2id is missing) and a **collaborator** (the
+logger that policy announces itself through). Static would mean either global mutable configuration
+or repeating both at every call site — and security configuration that can change halfway through a
+request is the wrong shape regardless of which of those you pick.
+
+## "Fail fast" only means something if it's early
+
+`bcryptFallback: false` refuses at **construction**, not at first `make()`. A misconfigured
+deployment then fails while it's being *wired*, rather than the first time a real user tries to
+register. Failing at first use would technically be "fail fast" and would find out at the worst
+possible moment.
+
+The `true` path logs **one** WARNING at construction rather than one per hash. A warning emitted on
+every password hash is one that gets filtered out — the signal drowns in the volume it generates.
+
+And the fallback is exposed as a **value** (`algorithm()`), not only a log line. The logger is
+optional, because demanding a PSR-3 implementation to hash a password is heavy for a utility — but
+that would make the degradation undetectable in deployments without one. A health check can assert
+on the value.
+
+## PHPStan deleted my defensive code, and was right
+
+Two findings, both worth keeping:
+
+**A guard on `password_hash()` returning `''`** — flagged as an always-false comparison. PHP 8 types
+it `non-empty-string` and it lost its `false` return in 8.0. I deleted the guard rather than
+suppressing the warning: dead defensive code is worse than none, because it implies a failure mode
+that doesn't exist and invites the next reader to preserve it.
+
+**An `assertTrue(defined('PASSWORD_ARGON2ID'))`** — always true against PHPStan's stubs. Converted
+to `markTestSkipped`, which is what it should have been anyway: on a build without Argon2id these
+tests should *skip*, not fail — the absence is a property of the interpreter, not a defect in the
+library. A guard that is statically true is not a guard.
+
+## A probe that passed, which is the finding
+
+Four planted defects:
+
+| planted | failures |
+|---|---|
+| `PASSWORD_DEFAULT` instead of Argon2id | 6 |
+| `needsRehash()` always `false` | 4 |
+| `verify()` doing raw string comparison | 5 |
+| fallback logged at `info` instead of `warning` | **0 — passed** |
+
+That fourth one passing is not a gap in the probe, it's the *proof* of a gap in coverage: the
+fallback branch is unreachable on any build that has Argon2id, so the WARNING **level** is
+currently unasserted. I'd rather have run the probe and learned that than assumed the branch was
+covered because the code looked right.
+
+Roadmap **5.5** explicitly owns the argon2id/bcrypt fallback matrix, so that's where it belongs —
+not something to solve here by adding a "please use bcrypt" option, which would make the weaker
+algorithm a first-class supported choice for the sake of testability.
+
+## Bar
+
+701 tests / 1510 assertions green (up from 685). PHPStan max clean, deptrac 0 violations / 0
+uncovered — `psr/log` got a `Psr` layer granted to `Security` only, verified by planting
+`Dto → LoggerInterface`. Unlike the sanitizer's optional dependency, this one is *required*
+(RFC-0001 R-3), and more groups will need it as `Errors` and `Container` arrive, so the ruleset
+grants it per group rather than globally.
+
+## One slip worth recording
+
+While removing a test PHPStan had flagged, my Python slice took out the neighbouring test too — the
+suite count dropped by 2 when I'd meant 1. Caught it by checking the count rather than trusting the
+edit, and restored it. Editing PHP by string-slicing in Python has now cost time twice today; the
+Edit tool is the right instrument for anything with structure.
+
+## Next
+
+**5.4** (OWASP XSS corpus snapshot suite) and **5.5** (Hash matrix + NFR-05 timing), both
+`frontier-reasoning / extra`.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — The constant that reads like "strongest" and means bcrypt](2026/08/2026-08-04-hash.md)
 - [2026-08-04 — Two sanitizers, and a wrong answer that only shows up on one driver](2026/08/2026-08-04-sanitizer.md)
 - [2026-08-04 — The benchmark was measuring the wrong thing, and I wrote it](2026/08/2026-08-04-nfr03-correction.md)
 - [2026-08-04 — Four grammars, and the assumption an escaper cannot check](2026/08/2026-08-04-escaper-contexts.md)

--- a/src/main/php/d4np/utils/Security/Hash.php
+++ b/src/main/php/d4np/utils/Security/Hash.php
@@ -72,13 +72,43 @@ final class Hash
         private readonly bool $bcryptFallback = true,
         private readonly ?LoggerInterface $logger = null,
     ) {
-        if (defined('PASSWORD_ARGON2ID')) {
-            $this->algorithm = PASSWORD_ARGON2ID;
+        $this->algorithm = self::selectAlgorithm(
+            defined('PASSWORD_ARGON2ID'),
+            $this->bcryptFallback,
+            $this->logger,
+        );
+    }
 
-            return;
+    /**
+     * The fallback policy itself, as a pure function of "is Argon2id available".
+     *
+     * **Separated from the constructor so it can be tested.** The constructor's own check —
+     * `defined('PASSWORD_ARGON2ID')` — is a compile-time fact that no test can vary: a constant
+     * cannot be un-defined, so on any build with Argon2 support the entire fallback branch is
+     * unreachable. Left inline, the most security-relevant decision in this class would have been
+     * unexecuted by the suite, and its coverage would have had to be waived rather than earned.
+     *
+     * Note what this does *not* expose: there is no way to make {@see make()} hash with bcrypt on
+     * a build that supports Argon2id. The seam is the **decision**, not the weak algorithm — which
+     * is the difference between making a policy testable and making it configurable.
+     *
+     * `@internal` because the availability argument has exactly one honest value in production,
+     * and that value is supplied by the constructor.
+     *
+     * @internal
+     *
+     * @throws UtilsException when Argon2id is unavailable and the fallback is disabled
+     */
+    public static function selectAlgorithm(
+        bool $argon2idAvailable,
+        bool $bcryptFallback,
+        ?LoggerInterface $logger = null,
+    ): string {
+        if ($argon2idAvailable) {
+            return PASSWORD_ARGON2ID;
         }
 
-        if (!$this->bcryptFallback) {
+        if (!$bcryptFallback) {
             throw new UtilsException(
                 'Argon2id is not available in this PHP build (PASSWORD_ARGON2ID is not defined), '
                 . 'and bcryptFallback is disabled, so this Hash refuses to construct rather than '
@@ -88,16 +118,16 @@ final class Hash
             );
         }
 
-        $this->algorithm = PASSWORD_BCRYPT;
-
-        // Once, here, rather than once per make(): a warning repeated on every password hash is
-        // one nobody reads.
-        $this->logger?->warning(
+        // Once, at construction, rather than once per make(): a warning repeated on every password
+        // hash is one nobody reads.
+        $logger?->warning(
             'Argon2id is unavailable in this PHP build; falling back to bcrypt for password '
             . 'hashing. Rebuild PHP with --with-password-argon2 to use the stronger algorithm, '
             . 'or construct Hash with bcryptFallback: false to make this a hard failure.',
             ['algorithm' => PASSWORD_BCRYPT],
         );
+
+        return PASSWORD_BCRYPT;
     }
 
     /**

--- a/src/main/php/d4np/utils/Security/Hash.php
+++ b/src/main/php/d4np/utils/Security/Hash.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Security;
+
+use D4np\Utils\Support\UtilsException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Password hashing with an Argon2id default and an explicit fallback policy (spec FR-11,
+ * ADR-0022).
+ *
+ * **This is an instance, not a static helper, and that is a deliberate break from the rest of the
+ * `Security` group.** {@see Escaper} and {@see Sanitizer} are pure functions of their input, so
+ * static suits them. Hashing is not: it carries a *policy* (what to do when Argon2id is
+ * unavailable) and a *collaborator* (the logger that policy has to announce itself through).
+ * Threading both through static calls would mean either global mutable configuration or repeating
+ * them at every call site, and configuration that can be changed halfway through a request is
+ * exactly the wrong shape for a security decision.
+ *
+ * **`PASSWORD_DEFAULT` is not used, and cannot be.** It is `bcrypt` on every PHP release to date —
+ * verified on 8.3, where it evaluates to `'2y'` even though Argon2id is available. Code that
+ * reaches for `PASSWORD_DEFAULT` expecting "whatever is best" silently gets the weaker algorithm,
+ * which is precisely why FR-11 names Argon2id rather than deferring to PHP.
+ *
+ * **Availability is `defined('PASSWORD_ARGON2ID')`,** the check FR-11 specifies. Argon2 support is
+ * a compile-time option (`--with-password-argon2`), so the constant's absence is the honest signal
+ * that this build cannot do it. Passing an algorithm identifier PHP does not know raises a bare
+ * `ValueError` — outside ADR-0004's exception family — so the check happens *before* that, not as
+ * a rescue afterwards.
+ *
+ * **The fallback decision is made once, at construction, not per call.** With
+ * `bcryptFallback: false` an unavailable Argon2id raises immediately, so a misconfigured
+ * deployment fails while it is being wired rather than the first time a user tries to register.
+ * With the default `true` it logs one WARNING at construction rather than one per hash, which
+ * would bury the signal in the noise it generates.
+ *
+ * ```php
+ * $hash = new Hash(logger: $psrLogger);          // Argon2id, bcrypt fallback, warned about
+ * $hash = new Hash(bcryptFallback: false);       // Argon2id or nothing
+ *
+ * $stored = $hash->make($password);
+ * if ($hash->verify($password, $stored) && $hash->needsRehash($stored)) {
+ *     $stored = $hash->make($password);          // upgrade on login (FR-11)
+ * }
+ * ```
+ */
+final class Hash
+{
+    /**
+     * The algorithm this instance will actually use — `argon2id` or `2y` (bcrypt).
+     *
+     * PHP types these constants as `string` since 7.4.
+     */
+    private readonly string $algorithm;
+
+    /**
+     * @param bool $bcryptFallback whether to fall back to bcrypt when Argon2id is unavailable.
+     *                             `true` (the FR-11 default) degrades and logs; `false` refuses to
+     *                             construct at all
+     * @param LoggerInterface|null $logger where the fallback WARNING goes. Optional, because
+     *                             requiring a PSR-3 implementation to hash a password would be a
+     *                             heavy demand for a utility — but see {@see algorithm()}: the
+     *                             fallback is queryable as a value precisely so that a deployment
+     *                             without a logger can still *detect* it rather than only be told
+     *                             about it
+     *
+     * @throws UtilsException when Argon2id is unavailable and `$bcryptFallback` is `false`
+     */
+    public function __construct(
+        private readonly bool $bcryptFallback = true,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+        if (defined('PASSWORD_ARGON2ID')) {
+            $this->algorithm = PASSWORD_ARGON2ID;
+
+            return;
+        }
+
+        if (!$this->bcryptFallback) {
+            throw new UtilsException(
+                'Argon2id is not available in this PHP build (PASSWORD_ARGON2ID is not defined), '
+                . 'and bcryptFallback is disabled, so this Hash refuses to construct rather than '
+                . 'silently hashing with a weaker algorithm. Either rebuild PHP with '
+                . '--with-password-argon2, or construct with bcryptFallback: true and accept '
+                . 'bcrypt deliberately.',
+            );
+        }
+
+        $this->algorithm = PASSWORD_BCRYPT;
+
+        // Once, here, rather than once per make(): a warning repeated on every password hash is
+        // one nobody reads.
+        $this->logger?->warning(
+            'Argon2id is unavailable in this PHP build; falling back to bcrypt for password '
+            . 'hashing. Rebuild PHP with --with-password-argon2 to use the stronger algorithm, '
+            . 'or construct Hash with bcryptFallback: false to make this a hard failure.',
+            ['algorithm' => PASSWORD_BCRYPT],
+        );
+    }
+
+    /**
+     * The algorithm identifier in use — `argon2id`, or `2y` when the fallback is engaged.
+     *
+     * Exists so the fallback is a value a caller can assert on, not only a line in a log a caller
+     * may not have configured. A health check can compare it against what it expects.
+     */
+    public function algorithm(): string
+    {
+        return $this->algorithm;
+    }
+
+    /**
+     * Hash a password.
+     *
+     * The cost parameters are PHP's own defaults, deliberately: they are chosen per release by
+     * people tracking hardware, and spec NFR-05 budgets the result at 50–200 ms on the reference
+     * machine — *slowness is the feature*. Overriding them here would mean this library, rather
+     * than PHP, owning a number that has to keep moving.
+     *
+     * The result is **self-describing**: `$argon2id$v=19$m=…` or `$2y$10$…` carries the algorithm
+     * and its parameters, which is what lets {@see verify()} and {@see needsRehash()} work on a
+     * stored hash without a separate column recording how it was made.
+     *
+     */
+    public function make(string $password): string
+    {
+        // No defensive check on the result: on PHP 8 `password_hash()` returns a non-empty string
+        // or throws — it lost its `false` return in PHP 8.0. A guard here was written and then
+        // removed, because PHPStan at max level correctly reported the comparison as dead: the
+        // return type is `non-empty-string`. Dead defensive code is worse than none, since it
+        // implies a failure mode that does not exist.
+        return password_hash($password, $this->algorithm);
+    }
+
+    /**
+     * Whether `$password` matches `$hash`.
+     *
+     * Delegates to `password_verify()`, which compares in constant time — a hand-rolled `===` here
+     * would leak the length of the matching prefix through timing.
+     *
+     * **Works across algorithms**, which is what makes upgrade-on-login possible: a bcrypt hash
+     * stored before this deployment still verifies against an Argon2id-configured instance,
+     * because the algorithm is read from the hash rather than assumed. A malformed or empty stored
+     * hash returns `false` rather than raising (verified) — the honest answer, since an
+     * unparseable hash matches nothing.
+     */
+    public function verify(string $password, string $hash): bool
+    {
+        return password_verify($password, $hash);
+    }
+
+    /**
+     * Whether `$hash` was made with something other than this instance's current settings.
+     *
+     * The upgrade-on-login half of FR-11. It is `true` for a hash made with a *different
+     * algorithm* (a bcrypt hash under an Argon2id instance) and also for one made with the same
+     * algorithm at *weaker parameters* — PHP compares the cost factors recorded in the hash
+     * against the current defaults, so a deployment that moves to a newer PHP with stronger
+     * defaults re-hashes on next login without any change here.
+     *
+     * Only meaningful after {@see verify()} has returned `true`: rehashing requires the plaintext,
+     * and the only moment it legitimately exists is the login that just succeeded.
+     *
+     * A malformed hash reports `true` (verified). That is the safe direction — it cannot be
+     * upgraded in place, but it also cannot be left looking current.
+     */
+    public function needsRehash(string $hash): bool
+    {
+        return password_needs_rehash($hash, $this->algorithm);
+    }
+}

--- a/src/test/php/d4np/utils/Security/HashTest.php
+++ b/src/test/php/d4np/utils/Security/HashTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Security;
+
+use D4np\Utils\Security\Hash;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-11's hashing policy.
+ *
+ * **The bcrypt-fallback matrix is roadmap item 5.5, not this file.** Reaching the fallback branch
+ * requires a PHP built without Argon2 support, which this suite cannot produce — `defined()`
+ * cannot be un-defined. What is asserted here is everything reachable on a build that *has*
+ * Argon2id, plus the properties that hold regardless of which algorithm is selected. The gap is
+ * named in ADR-0022 rather than left to look like coverage.
+ */
+#[Group('T-06')]
+final class HashTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // A build without Argon2id cannot exercise any of this, and should **skip** rather than
+        // fail: the absence is a property of the interpreter, not a defect in the library. This
+        // replaced an `assertTrue(defined(...))`, which PHPStan correctly flagged as always-true
+        // against its own stubs — a guard that is statically true is not a guard.
+        if (!defined('PASSWORD_ARGON2ID')) {
+            self::markTestSkipped('this PHP build has no Argon2id support');
+        }
+    }
+
+    public function testArgon2idIsSelectedWhenAvailable(): void
+    {
+        self::assertSame(PASSWORD_ARGON2ID, (new Hash())->algorithm());
+    }
+
+    /**
+     * The trap FR-11 exists to avoid. `PASSWORD_DEFAULT` reads like "whatever is strongest" and is
+     * bcrypt on every PHP release to date — verified here rather than asserted in prose, so the
+     * day it changes this test says so.
+     */
+    public function testPasswordDefaultWouldHaveSilentlySelectedBcrypt(): void
+    {
+        self::assertSame(PASSWORD_BCRYPT, PASSWORD_DEFAULT);
+        self::assertNotSame(PASSWORD_DEFAULT, (new Hash())->algorithm());
+    }
+
+    public function testAHashVerifiesAgainstItsOwnPassword(): void
+    {
+        $hash = new Hash();
+        $stored = $hash->make('correct horse battery staple');
+
+        self::assertTrue($hash->verify('correct horse battery staple', $stored));
+    }
+
+    public function testAWrongPasswordDoesNotVerify(): void
+    {
+        $hash = new Hash();
+
+        self::assertFalse($hash->verify('wrong', $hash->make('right')));
+    }
+
+    /**
+     * Salting is what makes this true, and it is the reason a stored hash cannot be compared with
+     * `===` or used as a lookup key.
+     */
+    public function testTheSamePasswordHashesDifferentlyEveryTime(): void
+    {
+        $hash = new Hash();
+
+        self::assertNotSame($hash->make('same'), $hash->make('same'));
+    }
+
+    /**
+     * Self-describing output (FR-11): the algorithm and its parameters travel with the hash, which
+     * is what lets `verify()` and `needsRehash()` work without a separate column recording how the
+     * hash was made.
+     */
+    public function testTheHashDescribesItsOwnAlgorithm(): void
+    {
+        $stored = (new Hash())->make('pw');
+
+        self::assertStringStartsWith('$argon2id$', $stored);
+        self::assertSame('argon2id', password_get_info($stored)['algoName']);
+    }
+
+    public function testAFreshHashDoesNotNeedRehashing(): void
+    {
+        $hash = new Hash();
+
+        self::assertFalse($hash->needsRehash($hash->make('pw')));
+    }
+
+    /**
+     * The upgrade-on-login case FR-11 names: a hash stored under the old algorithm still verifies,
+     * and reports that it should be replaced.
+     */
+    public function testABcryptHashVerifiesButReportsThatItNeedsRehashing(): void
+    {
+        $hash = new Hash();
+        $legacy = password_hash('pw', PASSWORD_BCRYPT);
+
+        self::assertTrue($hash->verify('pw', $legacy), 'a legacy hash must still let its owner log in');
+        self::assertTrue($hash->needsRehash($legacy), 'and must be flagged for upgrade');
+    }
+
+    /**
+     * The full FR-11 login sequence, end to end.
+     */
+    public function testUpgradeOnLoginReplacesALegacyHash(): void
+    {
+        $hash = new Hash();
+        $stored = password_hash('pw', PASSWORD_BCRYPT);
+
+        if ($hash->verify('pw', $stored) && $hash->needsRehash($stored)) {
+            $stored = $hash->make('pw');
+        }
+
+        self::assertStringStartsWith('$argon2id$', $stored);
+        self::assertTrue($hash->verify('pw', $stored));
+        self::assertFalse($hash->needsRehash($stored));
+    }
+
+    /**
+     * Weaker *parameters* under the same algorithm also warrant a rehash — PHP compares the cost
+     * factors recorded in the hash against the current ones, so a move to stronger defaults
+     * upgrades on next login without any change to this class.
+     */
+    public function testWeakerParametersUnderTheSameAlgorithmAlsoNeedRehashing(): void
+    {
+        $weak = password_hash('pw', PASSWORD_ARGON2ID, ['memory_cost' => 8192, 'time_cost' => 1, 'threads' => 1]);
+
+        self::assertTrue((new Hash())->needsRehash($weak));
+    }
+
+    /**
+     * A stored value that is not a hash at all must not raise, and must not verify.
+     */
+    public function testAMalformedStoredHashDoesNotVerifyAndDoesNotRaise(): void
+    {
+        $hash = new Hash();
+
+        self::assertFalse($hash->verify('pw', ''));
+        self::assertFalse($hash->verify('pw', 'not-a-hash'));
+        // It also cannot be left looking current: unparseable means "replace it".
+        self::assertTrue($hash->needsRehash('not-a-hash'));
+    }
+
+    public function testAnEmptyPasswordIsHashedRatherThanRefused(): void
+    {
+        // Whether an empty password is acceptable is an application policy, not a hashing one;
+        // this class does not silently invent a validation rule the caller did not ask for.
+        $hash = new Hash();
+        $stored = $hash->make('');
+
+        self::assertTrue($hash->verify('', $stored));
+        self::assertFalse($hash->verify('x', $stored));
+    }
+
+    /**
+     * PHP's own password functions are byte-safe; a password is not required to be text.
+     */
+    public function testPasswordsWithNullBytesAndUnicodeRoundTrip(): void
+    {
+        $hash = new Hash();
+
+        foreach (["with\0null", 'héllo 漢 🙂', str_repeat('a', 200)] as $password) {
+            self::assertTrue($hash->verify($password, $hash->make($password)), $password);
+        }
+    }
+
+    /**
+     * On a build that has Argon2id, disabling the fallback changes nothing — the point of the
+     * assertion is that it does not throw, so `bcryptFallback: false` is safe to set as a default
+     * posture rather than something only brave deployments enable.
+     */
+    public function testDisablingTheFallbackIsHarmlessWhenArgon2idIsAvailable(): void
+    {
+        self::assertSame(PASSWORD_ARGON2ID, (new Hash(bcryptFallback: false))->algorithm());
+    }
+
+    /**
+     * No WARNING is logged when nothing was degraded — a logger that cries wolf on a correctly
+     * configured system is one whose warnings get filtered out.
+     */
+    public function testNoWarningIsLoggedWhenArgon2idIsAvailable(): void
+    {
+        $logger = new RecordingLogger();
+
+        new Hash(logger: $logger);
+
+        self::assertSame([], $logger->records);
+    }
+
+    /**
+     * `bcryptFallback: false` is documented as failing at *construction*, not at first use. On a
+     * build with Argon2id the throw cannot be triggered, so what is asserted is the shape of the
+     * contract that makes it fail fast: the algorithm is already fixed before any password has
+     * been hashed, so no hashing call is needed to discover a misconfiguration.
+     */
+    public function testTheFallbackDecisionIsMadeAtConstructionNotAtFirstUse(): void
+    {
+        $hash = new Hash(bcryptFallback: false);
+
+        self::assertNotSame('', $hash->algorithm());
+        self::assertSame($hash->algorithm(), $hash->algorithm());
+    }
+}

--- a/src/test/php/d4np/utils/Security/HashTest.php
+++ b/src/test/php/d4np/utils/Security/HashTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace D4np\Utils\Tests\Security;
 
 use D4np\Utils\Security\Hash;
+use D4np\Utils\Support\UtilsException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
 
 /**
  * Spec FR-11's hashing policy.
@@ -206,5 +208,69 @@ final class HashTest extends TestCase
 
         self::assertNotSame('', $hash->algorithm());
         self::assertSame($hash->algorithm(), $hash->algorithm());
+    }
+
+    // ---- the fallback policy, on a simulated build without Argon2id ----------------------------
+    //
+    // `defined('PASSWORD_ARGON2ID')` is a compile-time fact no test can vary, so the policy is
+    // exercised through `selectAlgorithm()` with the availability supplied as an argument. Without
+    // this the most security-relevant branch in the class would be unexecuted, and its coverage
+    // waived rather than earned.
+
+    public function testWithoutArgon2idTheFallbackSelectsBcrypt(): void
+    {
+        self::assertSame(PASSWORD_BCRYPT, Hash::selectAlgorithm(false, true));
+    }
+
+    /**
+     * The WARNING level is part of the contract: this is an operational degradation someone needs
+     * to see, not an informational note. A probe that logged at `info` instead previously **passed**
+     * — because the branch was unreachable — which is what motivated making it testable.
+     */
+    public function testTheFallbackIsAnnouncedAtWarningLevel(): void
+    {
+        $logger = new RecordingLogger();
+
+        Hash::selectAlgorithm(false, true, $logger);
+
+        self::assertCount(1, $logger->records);
+        self::assertSame(LogLevel::WARNING, $logger->records[0]['level']);
+        self::assertStringContainsString('bcrypt', $logger->records[0]['message']);
+        self::assertSame(['algorithm' => PASSWORD_BCRYPT], $logger->records[0]['context']);
+    }
+
+    public function testWithoutArgon2idAndWithoutFallbackItRefuses(): void
+    {
+        $this->expectException(UtilsException::class);
+        $this->expectExceptionMessageMatches('/bcryptFallback is disabled/');
+
+        Hash::selectAlgorithm(false, false);
+    }
+
+    /**
+     * Refusing must not also log: a hard failure is already loud, and a WARNING alongside it would
+     * suggest the run continued in a degraded state when it did not.
+     */
+    public function testRefusingDoesNotAlsoLogAWarning(): void
+    {
+        $logger = new RecordingLogger();
+
+        try {
+            Hash::selectAlgorithm(false, false, $logger);
+        } catch (UtilsException) {
+            // expected
+        }
+
+        self::assertSame([], $logger->records);
+    }
+
+    /**
+     * The seam exposes the *decision*, not the weak algorithm — there is no route to hashing with
+     * bcrypt on a build that supports Argon2id.
+     */
+    public function testTheSeamCannotBeUsedToForceBcryptOnACapableBuild(): void
+    {
+        self::assertSame(PASSWORD_ARGON2ID, Hash::selectAlgorithm(true, true));
+        self::assertSame(PASSWORD_ARGON2ID, (new Hash(bcryptFallback: true))->algorithm());
     }
 }

--- a/src/test/php/d4np/utils/Security/RecordingLogger.php
+++ b/src/test/php/d4np/utils/Security/RecordingLogger.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Security;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * A PSR-3 logger that keeps what it was told, so a test can assert on it.
+ *
+ * Extends `Psr\Log\AbstractLogger` rather than implementing `LoggerInterface` directly: the
+ * abstract base already routes the eight level-named methods (`warning()`, `error()`, …) into
+ * `log()`, so this only has to implement the one that matters. A hand-written implementation of
+ * all nine would be nine more chances to get a test double wrong.
+ */
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var list<array{level: mixed, message: string, context: array<string, mixed>}> */
+    public array $records = [];
+
+    /**
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item 5.3 (spec FR-11). Probed before designing, and the first result shaped the whole class:

```
PASSWORD_DEFAULT === '2y'   // bcrypt, even where Argon2id is available
```

**`PASSWORD_DEFAULT` reads like "whatever PHP thinks is strongest" and is bcrypt on every release to date.** Code reaching for it expecting the strong algorithm silently gets the weaker one — no error, no warning, and a hash that looks perfectly fine. That's exactly why FR-11 names Argon2id rather than deferring, and it's pinned by a test asserting `PASSWORD_DEFAULT === PASSWORD_BCRYPT` so the day PHP changes it the suite says so.

Availability is `defined('PASSWORD_ARGON2ID')` — FR-11's mechanism — checked **before** use, because an unknown algorithm raises a bare `ValueError`, outside ADR-0004's family and invisible to a caller catching `UtilsThrowable`.

## Design decisions worth review

**An instance, not a static helper** like `Escaper`/`Sanitizer`. The inconsistency is deliberate: hashing carries a *policy* (what to do when Argon2id is missing) and a *collaborator* (the logger). Static means either global mutable configuration or repeating both at every call site — and security config that can change mid-request is the wrong shape either way.

**The fallback is decided once, at construction.** `bcryptFallback: false` refuses to construct, so a misconfigured deployment fails while being *wired* rather than at the first user registration. Failing at first `make()` would technically be "fail fast" and would find out at the worst possible moment. The default `true` logs **one** WARNING at construction, not one per hash — a warning on every password hash is one that gets filtered out.

**The fallback is a value, not only a log line.** `algorithm()` exposes the outcome, so a deployment without a PSR-3 logger can still detect the degradation.

## PHPStan deleted defensive code, and was right twice

- A guard on `password_hash()` returning `''` — always-false, since the function is typed `non-empty-string` and lost its `false` return in PHP 8.0. **Removed rather than suppressed:** dead defensive code implies a failure mode that doesn't exist.
- `assertTrue(defined('PASSWORD_ARGON2ID'))` → `markTestSkipped`, which it should have been anyway. A guard that is statically true is not a guard.

## ⚠️ A probe that **passed**, which is the finding

| planted | failures |
|---|---|
| `PASSWORD_DEFAULT` instead of Argon2id | 6 |
| `needsRehash()` always `false` | 4 |
| `verify()` doing raw string comparison | 5 |
| fallback logged at `info` instead of `warning` | **0 — passed** |

That pass isn't a weak probe, it's proof of a coverage gap: **the fallback branch is unreachable on any build with Argon2id, so the WARNING level is currently unasserted.** Roadmap item **5.5** explicitly owns the argon2id/bcrypt matrix. The alternative — adding a "please use bcrypt" option purely to make the branch reachable — would turn the weaker algorithm into a first-class supported choice for the sake of testability.

## Test plan

- [x] Upgrade-on-login asserted end to end (bcrypt hash verifies → flags rehash → replaced with Argon2id)
- [x] Weaker *parameters* under the same algorithm also trigger rehash
- [x] Malformed stored hash: `verify()` false, `needsRehash()` true (safe direction)
- [x] `vendor/bin/phpunit` — 701 tests, 1510 assertions, 7 skipped
- [x] PHPStan max clean · deptrac 0/0 (new `Psr` layer, verified by planting `Dto → LoggerInterface`) · consistency + action-pin lints OK
- [ ] CI

## Process notes

- Routed `frontier-reasoning / extra`; ran at standard tier. Flagged before starting rather than proceeding silently, since this is the most security-sensitive item so far and the model had just been switched twice. Accepted by you, recorded via `record_run.py`.
- `psr/log` gets a deptrac `Psr` layer granted to `Security` only. Unlike the sanitizer's *optional* dependency this one is **required** (RFC-0001 R-3), and `Errors`/`Container` will need it, so it's granted per group as each arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)