### PR TITLE
test(security): Hash matrix and NFR-05 timing, closing Milestone 5

### DIFF
--- a/.eados-core/learning/runs/2026-08-04-utils-6.yaml
+++ b/.eados-core/learning/runs/2026-08-04-utils-6.yaml
@@ -1,0 +1,36 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-04"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}
+route_mismatch:
+  routed: "frontier-reasoning/extra"
+  session: "standard"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,21 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- Spec §7's **Hash matrix** and NFR-05's timing (**ADR-0024**) — closes Milestone 5. NFR-05 is a
+  **range** (50–200 ms), unlike every other budget here, and the *lower* bound is the serious one:
+  a hash completing in 5 ms means the work factor is inadequate. So it is split by what each half
+  can prove. The **security** half is asserted as the **work factor** — `memory_cost`/`time_cost`
+  against OWASP's published Argon2id minimums — which is machine-independent and catches what a
+  stopwatch cannot: a duration cannot distinguish strong parameters on slow hardware from weak ones
+  on fast. The **capacity** half is a benchmark asserting nothing (`HashBench`).
+  Measured `Hash::make()` at **349 ms against the 50–200 ms range** — over, and deliberately **not**
+  fixed: the cost parameters are PHP's defaults and clear OWASP's floor by more than 3× on memory,
+  so lowering them to hit the range would trade security for latency. `verify()` is measured too
+  (~348 ms): NFR-05 does not budget it, but it runs on **every login** and is what actually caps
+  authentication throughput.
+  Documented PHP behaviour: `password_needs_rehash()` reports `true` for **stronger** parameters as
+  well as weaker ones, because it compares for equality with the current defaults — so a hash
+  hardened beyond them is silently downgraded on next login.
 - Spec §7's **OWASP XSS corpus snapshot suite** and **DOM-bypass corpus** for `richText()`
   (**ADR-0023**). Every payload is run through all four escaper contexts and recorded in a
   committed snapshot, so any change to escaping output becomes a reviewable diff rather than silent

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — A probe that passed, and the claim it disproved](docs/journal/2026/08/2026-08-04-xss-corpus.md).
+  [2026-08-04 — A range, not a ceiling: measuring the wrong thing would have proved nothing](docs/journal/2026/08/2026-08-04-hash-matrix-nfr05.md).
 
 ## Model & effort routing (advisory)
 
@@ -324,8 +324,20 @@ Explicit-mechanism security helpers (RFC-0001; every item carries the protected 
       since `return '';` passes every security check. **Corrects ADR-0021**: a probe allowing
       `javascript:` **passed** — symfony refuses it unconditionally — so the allowlist is the sole
       barrier only for `data:`, defence-in-depth for `javascript:`. 1010 tests, `--group T-06` 386.*
-- [ ] 5.5 Hash matrix tests (argon2id/bcrypt fallback, rehash triggers) + NFR-05 timing
-      (RFC-0001) (security) — route: frontier-reasoning / extra
+- [x] 5.5 Hash matrix tests (argon2id/bcrypt fallback, rehash triggers) + NFR-05 timing
+      (RFC-0001) (security) — route: frontier-reasoning / extra *(run at standard tier; mismatch
+      recorded)* · **ADR-0024**. ***Closes Milestone 5.*** *NFR-05 is a **range**, unlike every
+      other budget here — falling *below* 50ms would be the serious failure, since it means the work
+      factor is inadequate. So it is split by what each half can prove: the **security** half is
+      asserted as the **work factor** (`memory_cost`/`time_cost` vs OWASP's floor), which is
+      machine-independent and catches what a stopwatch cannot — a stopwatch cannot tell weak
+      parameters on fast hardware from strong ones on slow. The **capacity** half is a benchmark
+      asserting nothing. Measured `make()` **349ms vs the 50-200ms range** — over, and deliberately
+      **not** fixed: the parameters are PHP's defaults and clear OWASP's floor, so lowering them
+      would trade security for latency. Also measures `verify()` (~348ms), which NFR-05 does not
+      budget but which runs on **every login** and is what actually caps auth throughput.
+      Documented PHP quirk: `needsRehash()` is `true` for **stronger** parameters too, so a hardened
+      hash is silently downgraded on next login.*
 
 ---
 

--- a/docs/adr/0024-assert-the-work-factor-not-the-wall-clock.md
+++ b/docs/adr/0024-assert-the-work-factor-not-the-wall-clock.md
@@ -1,0 +1,134 @@
+# ADR-0024: Assert the work factor, not the wall clock — NFR-05 split by what each half can actually prove
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 5.5 (closes Milestone 5) · spec NFR-05, NFR-06, §7 · item 7.1 ·
+  [ADR-0022](0022-argon2id-by-default-with-a-fallback-decided-at-construction.md) (the class, and
+  the `selectAlgorithm()` seam this matrix depends on) ·
+  [ADR-0011](0011-benchmark-scope-and-the-measured-hydration-ratio.md) /
+  [ADR-0018](0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md) (the
+  measure-and-defer precedent) · **Benchmark record:**
+  [`docs/benchmarks/2026/08/nfr05-password-hashing-cost.md`](../benchmarks/2026/08/nfr05-password-hashing-cost.md)
+
+## Context
+
+Item 5.5 owes two things: spec §7's *"Hash matrix tests (argon2id/bcrypt fallback, rehash
+triggers)"* and NFR-05's timing — *"`Hash::make` (Argon2id defaults): 50–200 ms on the reference
+machine (deliberately slow; documented for capacity planning)."*
+
+**NFR-05 is a range, and that makes it structurally unlike every other budget in this project.** For
+NFR-01 and NFR-03 only the ceiling matters and faster is strictly better. Here, falling *below* the
+floor is the more serious failure: a password hash completing in 5 ms means the work factor is
+inadequate, and no amount of fast redeems it.
+
+Measured before deciding anything (PHP 8.3.1, i7-12700):
+
+| subject | mode | NFR-05 |
+|---|---|---|
+| `make()` Argon2id | **349.5 ms** ±1.82% | 50–200 ms — **over** |
+| `make()` bcrypt | 141.1 ms ±1.16% | within |
+| `verify()` Argon2id | 347.8 ms ±0.81% | not budgeted |
+
+Two facts about `needsRehash()` were also probed, and one was surprising:
+
+- A hash with **stronger** parameters than the current defaults also reports `true`. PHP compares
+  parameters for *equality*, not for "at least as strong", so a hardened hash is silently
+  **downgraded** on next login.
+- A malformed or empty stored hash reports `true`.
+
+## Decision
+
+### 1. Split NFR-05 by what each half can actually prove
+
+**The security half is asserted as the work factor, not as a duration.** Wall-clock time depends on
+CPU, memory bandwidth and ambient load; `memory_cost` and `time_cost` do not.
+`testTheArgon2idWorkFactorMeetsTheOwaspFloor()` checks them against OWASP's published Argon2id
+minimums (m ≥ 19456 KiB, t ≥ 2).
+
+This is the assertion that survives the case a timing test would miss: if a future PHP lowered its
+defaults, a fast machine could still produce a plausible-looking duration while the actual work
+factor had dropped. A stopwatch cannot distinguish "strong parameters on slow hardware" from "weak
+parameters on fast hardware"; the parameters can.
+
+A second assertion checks the library is not *overriding* PHP's defaults, since ADR-0022 decided
+those belong to PHP. Both were verified non-vacuous by planting weak cost parameters — 2 failures.
+
+**The capacity-planning half is a benchmark that asserts nothing**, per NFR-05's own stated purpose
+and the precedent of ADR-0011 and ADR-0018: the absolute range is tied to NFR-06's reference machine,
+and gating on it from arbitrary CI hardware fails for reasons unrelated to regressions. Item **7.1**
+owns baseline-tracked enforcement.
+
+### 2. The measured overshoot is recorded as a capacity finding, and the parameters are not touched
+
+`make()` at ~350 ms is roughly 1.75× NFR-05's ceiling. **The correct response is to leave the cost
+parameters alone.** They are PHP's defaults, they clear OWASP's floor by a wide margin (64 MiB
+against 19 MiB required), and the duration is what that work factor costs on this hardware. Lowering
+them to land inside 50–200 ms would trade security for latency — the exact inversion of what
+"deliberately slow" asks for.
+
+Two caveats are recorded with the number rather than left for a reader to infer: this is not the
+reference machine, and the bcrypt figure (141 ms at `cost=10`, commonly 50–80 ms) suggests this
+PHP build is slow at password hashing generally, so **both** figures are probably inflated. The
+ratio between them is the more portable observation.
+
+### 3. `verify()` is measured too, though NFR-05 does not budget it
+
+NFR-05 budgets `make`, which runs at registration and on upgrade. **`verify` runs on every login**,
+costs the same (~348 ms — symmetric by design in Argon2id), and is therefore what actually
+determines sustainable authentication throughput. A capacity plan built on the `make` figure alone
+would understate the load. Measuring it is within NFR-05's stated purpose even though it is outside
+its stated budget.
+
+### 4. The matrices are exhaustive cross-products, not examples
+
+The fallback matrix covers all four cells of *availability × policy*. Item 5.3 tested three of them
+incidentally; a policy tested at three of its four corners has an untested corner. Each cell is also
+asserted to behave identically with no logger attached — the logger records the decision, it must
+not influence it.
+
+The rehash matrix covers current defaults, weaker `memory_cost`, weaker `time_cost`, **stronger**
+parameters, a different algorithm, bcrypt at a raised cost, malformed, and empty. Every well-formed
+entry is additionally asserted to still *verify*, because upgrade-on-login depends on a login that
+must succeed first.
+
+## Alternatives Considered
+
+- **Asserting the 50–200 ms range in a unit test** — rejected: it would be flaky on CI and, worse,
+  it cannot distinguish a weak work factor on fast hardware from a strong one on slow hardware,
+  which is the only distinction that matters for the floor.
+- **Tuning the cost parameters down to land inside the range** — rejected in §2. It trades security
+  for latency and contradicts both "deliberately slow" and ADR-0022.
+- **Treating the ~350 ms overshoot as a defect to fix** — rejected: the work factor is correct, so
+  there is nothing to fix in the library. It is a fact about the hardware, recorded for planning.
+- **Omitting `verify()` because NFR-05 does not name it** — rejected in §3: it is the figure a
+  capacity plan actually needs.
+- **Asserting the exact PHP default values** (`memory_cost === 65536`) rather than a floor —
+  rejected: it would fail whenever PHP *raises* its defaults, which is the direction we want, and
+  would turn an improvement into a broken build.
+
+## Consequences
+
+- **Spec §7's Hash matrix is complete**, and NFR-05 has both an assertion (work factor) and a
+  measurement (timing), each doing the job it can actually do.
+- 1037 tests total; `--group T-06` covers the security suites.
+- **NFR-05's timing budget is not met on this machine** — ~350 ms against 50–200 ms — recorded with
+  its caveats rather than adjusted away. The third NFR in this project to miss its stated number on
+  development hardware, and the third deferred to item 7.1's reference-machine harness. That
+  accumulation is itself worth noticing: 7.1 now carries NFR-01's absolute half, NFR-03's residual,
+  and NFR-05's range.
+- **A PHP behaviour worth knowing is documented**: `needsRehash()` reports `true` for *stronger*
+  parameters, so a hash hardened beyond the defaults is downgraded on next login. This library
+  always uses PHP's defaults so it cannot produce such a hash itself, but a consumer migrating from
+  a hardened setup would silently lose that hardening.
+- The work-factor floor is OWASP's, an external standard, rather than a number chosen here — so
+  "deliberately slow" is checked against something with an owner outside this repository.
+
+## References
+
+- Spec NFR-05 (the range and its stated purpose), NFR-06 (reference machine), §7 (the matrix)
+- ADR-0022 — the class, the cost-parameter decision, and the `selectAlgorithm()` seam without which
+  half the fallback matrix could not be written
+- ADR-0011 / ADR-0018 — the measure-honestly-and-defer precedent this follows
+- OWASP Password Storage Cheat Sheet — the Argon2id minimums used as the floor
+- Benchmark record: `docs/benchmarks/2026/08/nfr05-password-hashing-cost.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0021](0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md) | Delegate rich-HTML sanitization, and escape LIKE wildcards with a portable character | Accepted |
 | [0022](0022-argon2id-by-default-with-a-fallback-decided-at-construction.md) | Argon2id by name, not by `PASSWORD_DEFAULT`, with the fallback decided at construction | Accepted |
 | [0023](0023-snapshot-for-drift-invariants-for-safety-idempotence-for-mxss.md) | Snapshots catch drift, invariants catch wrong, and idempotence catches mutation XSS | Accepted |
+| [0024](0024-assert-the-work-factor-not-the-wall-clock.md) | Assert the work factor, not the wall clock — NFR-05 split by what each half can actually prove | Accepted |

--- a/docs/benchmarks/2026/08/nfr05-password-hashing-cost.md
+++ b/docs/benchmarks/2026/08/nfr05-password-hashing-cost.md
@@ -1,0 +1,77 @@
+# Benchmark Report: NFR-05 password hashing cost
+
+- **Date:** 2026-08-04
+- **Version / commit:** v0.0.0 @ `4ad28dc`
+- **Environment:** 12th Gen Intel Core i7-12700, 31.7 GB RAM, Windows 11 Pro 10.0.26200,
+  PHP 8.3.1 CLI (NTS, VS16 x64), phpbench 1.4.3, OPcache **off**, JIT **off**, Xdebug **off**
+- **Command:** `vendor/bin/phpbench run src/bench/php/d4np/utils/HashBench.php --report=aggregate`
+
+## Scenario
+
+Spec **NFR-05**: *"`Hash::make` (Argon2id defaults): 50–200 ms on the reference machine
+(deliberately slow; documented for capacity planning)."*
+
+**This budget is a range, which makes it unlike every other NFR here.** For NFR-01 and NFR-03 only
+the ceiling matters and faster is better. For NFR-05, being *under* the floor is the more serious
+failure: a password hash completing in 5 ms means the work factor is inadequate.
+
+That asymmetry splits the requirement in two, and the split is the point:
+
+- **The security half is not measured here.** Wall-clock time depends on CPU, memory bandwidth and
+  ambient load; the **work factor** does not.
+  `HashMatrixTest::testTheArgon2idWorkFactorMeetsTheOwaspFloor()` asserts `memory_cost` and
+  `time_cost` against OWASP's published Argon2id minimums (m ≥ 19456 KiB, t ≥ 2) — machine-
+  independent, and the assertion that would still catch a future PHP lowering its defaults while a
+  fast machine made the timing look plausible.
+- **The capacity-planning half is this report.** Nothing is asserted; the absolute range is tied to
+  NFR-06's reference machine and gating on it from arbitrary hardware would fail for reasons
+  unrelated to any regression (the reasoning items 3.5 and 4.5 recorded; item **7.1** owns
+  baseline-tracked enforcement).
+
+## Results
+
+| subject | mode | rstdev | NFR-05 range |
+|---|---|---|---|
+| `benchMakeArgon2id` | **349.503 ms** | ±1.82% | 50–200 ms — **over** |
+| `benchMakeBcrypt` | 141.098 ms | ±1.16% | (fallback; within range) |
+| `benchVerifyArgon2id` | 347.849 ms | ±0.81% | not budgeted |
+
+Cost parameters in use are PHP 8.3's defaults, unmodified: Argon2id `memory_cost=65536` (64 MiB),
+`time_cost=4`, `threads=1`; bcrypt `cost=10`.
+
+## Interpretation
+
+**`make()` costs ~350 ms here — about 1.75× NFR-05's ceiling — and this is a capacity finding, not
+a security one.** The work factor is PHP's default and clears OWASP's floor by a wide margin
+(64 MiB vs 19 MiB required, t=4 vs t=2). The duration is simply what that work factor costs on this
+hardware. Lowering the cost parameters to land inside 50–200 ms would trade security for latency,
+which is the opposite of what "deliberately slow" asks for, and ADR-0022 already decided those
+parameters belong to PHP rather than to this library.
+
+**Two caveats on the absolute figures**, both pointing the same way:
+
+- This is not NFR-06's reference machine (a Ryzen 7 5800X). Argon2id at 64 MiB is memory-bound, so
+  it is sensitive to memory subsystem differences rather than raw clock.
+- The bcrypt figure is itself a signal: 141 ms at `cost=10` is high — that operation is commonly
+  50–80 ms — which suggests this Windows PHP build is slow at password hashing generally, and that
+  **both** numbers are likely inflated relative to the reference machine. The ratio between them
+  (Argon2id ≈ 2.5× bcrypt) is the more portable observation.
+
+**`verify()` costs the same as `make()` (~348 ms), and that is the number that scales.** NFR-05
+budgets only `make`, which runs at registration and on upgrade-on-login. `verify` runs on *every*
+login, so it — not `make` — is what determines how many concurrent authentications a deployment can
+sustain. This is symmetric by design in Argon2id (verification repeats the same derivation), and it
+is recorded here because NFR-05's stated purpose is capacity planning and a plan built on the
+`make` figure alone would understate the load.
+
+## Reproduce
+
+```bash
+composer install && vendor/bin/phpbench run src/bench/php/d4np/utils/HashBench.php --report=aggregate
+```
+
+The machine-independent security assertion:
+
+```bash
+vendor/bin/phpunit --filter testTheArgon2idWorkFactorMeetsTheOwaspFloor
+```

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -23,6 +23,7 @@ One report per measured scenario, from [`template.md`](template.md). Keep the in
 
 | Date | Scenario | Version | Headline result | Report |
 |------|----------|---------|-----------------|--------|
+| 2026-08-04 | NFR-05 password hashing cost (`Hash::make`, Argon2id defaults) | v0.0.0 | **349 ms** vs. the 50–200 ms range — over, but the *work factor* clears OWASP's floor; `verify()` costs the same and is the figure that scales | [report](2026/08/nfr05-password-hashing-cost.md) |
 | 2026-08-04 | NFR-03 QueryBuilder build time — **corrected workload** + 2 optimisations | v0.0.0 | literal 5-condition SELECT **14.43 → 12.98 µs**; still over ≤ 10 µs, but 1.3× not 2.3× | [report](2026/08/nfr03-querybuilder-build-time-corrected.md) |
 | 2026-08-04 | NFR-03 QueryBuilder build time (~~5-condition SELECT~~ — wrong workload) | v0.0.0 | ~23 µs — **superseded**, measured ~2× the work NFR-03 specifies | [report](2026/08/nfr03-querybuilder-build-time.md) |
 | 2026-08-04 | NFR-01 DTO hydration (10 scalar props), compiled closure vs. interpreter | v0.0.0 | **15.40× → 2.74×** manual construction (14.155 µs → 2.511 µs); NFR-01 met | [report](2026/08/nfr01-hydration-compiled-closure.md) |

--- a/docs/journal/2026/08/2026-08-04-hash-matrix-nfr05.md
+++ b/docs/journal/2026/08/2026-08-04-hash-matrix-nfr05.md
@@ -1,0 +1,95 @@
+# 2026-08-04 — A range, not a ceiling: measuring the wrong thing would have proved nothing
+
+Roadmap item **5.5**, closing Milestone 5. Route `frontier-reasoning / extra`, session Opus 5 —
+same mismatch as 5.3/5.4, recorded.
+
+## The thing that makes NFR-05 different
+
+Every other budget in this project is a ceiling: NFR-01's ≤5µs, NFR-03's ≤10µs, NFR-04's ≤16MiB.
+Faster and smaller are strictly better, and only one direction can fail.
+
+NFR-05 is a **range** — 50–200ms — and the *lower* bound is the serious one. A password hash that
+completes in 5ms means the work factor is inadequate. No amount of fast redeems that.
+
+That asymmetry decided the whole item. My first instinct was a benchmark asserting the range, which
+would have been useless in the direction that matters: **a stopwatch cannot distinguish strong
+parameters on slow hardware from weak parameters on fast hardware.** Both produce a number. Only one
+is safe.
+
+So the requirement splits by what each half can actually prove:
+
+- **Security → the work factor.** `memory_cost` and `time_cost` against OWASP's published Argon2id
+  minimums (m ≥ 19456 KiB, t ≥ 2). Machine-independent. If a future PHP lowered its defaults, a
+  fast machine could still produce a plausible duration while the work factor had quietly dropped —
+  this assertion catches that; a timing assertion cannot.
+- **Capacity → a benchmark that asserts nothing**, per NFR-05's own stated purpose ("documented for
+  capacity planning") and the ADR-0011/0018 precedent.
+
+The floor is OWASP's rather than a number I picked, so "deliberately slow" is checked against a
+standard with an owner outside this repository.
+
+## The measurement, and why I'm not fixing it
+
+| subject | measured | NFR-05 |
+|---|---|---|
+| `make()` argon2id | **349.5ms** ±1.82% | 50–200ms — **over** |
+| `make()` bcrypt | 141.1ms | within |
+| `verify()` argon2id | 347.8ms | not budgeted |
+
+~1.75× over the ceiling. **The correct response is to change nothing.** The parameters are PHP's
+defaults, they clear OWASP's floor by more than 3× on memory, and the duration is what that work
+factor costs on this hardware. Lowering them to land inside the range would trade security for
+latency — precisely the inversion of "deliberately slow", and against ADR-0022's decision that
+those parameters belong to PHP.
+
+Two caveats recorded with the number rather than left for a reader to infer: this isn't NFR-06's
+reference machine, and **bcrypt at 141ms for `cost=10` is itself a signal** — that operation is
+usually 50–80ms, so this Windows PHP build looks slow at password hashing generally and *both*
+figures are probably inflated. The ratio (argon2id ≈ 2.5× bcrypt) is the more portable observation.
+
+## The number NFR-05 doesn't ask for but a capacity plan needs
+
+`verify()` costs the same as `make()` — ~348ms, symmetric by design in Argon2id.
+
+NFR-05 budgets `make`, which runs at registration and on upgrade. **`verify` runs on every login.**
+It, not `make`, is what caps sustainable authentication throughput. A capacity plan built on the
+budgeted figure alone would understate the load, so I measured it even though it's outside the
+stated budget — measuring it serves NFR-05's stated *purpose* while being outside its stated scope.
+
+## A PHP behaviour worth knowing
+
+`needsRehash()` returns **`true` for stronger parameters too**. PHP compares for *equality* with the
+current defaults, not "at least as strong".
+
+So a hash hardened beyond the defaults is silently **downgraded** on next login. This library always
+uses PHP's defaults so it can't produce such a hash itself, but a consumer migrating from a hardened
+setup would lose that hardening without any signal. Documented rather than discovered later.
+
+## Matrices, not examples
+
+Item 5.3 tested three of the fallback policy's four corners incidentally. A policy tested at three
+of four corners has an untested corner, so the fallback matrix is now the full cross-product of
+*availability × policy*, plus an assertion that every cell behaves identically with **no logger** —
+the logger records the decision, it must not influence it.
+
+The rehash matrix covers current defaults, weaker memory, weaker time, stronger, a different
+algorithm, bcrypt at raised cost, malformed, empty. Every well-formed entry is also asserted to
+still **verify**, because upgrade-on-login depends on a login succeeding first.
+
+Both work-factor assertions verified non-vacuous by planting weak cost parameters: 2 failures.
+
+## Bar
+
+1037 tests / 2346 assertions green. PHPStan max clean, deptrac 0/0, consistency lint OK.
+
+## Milestone 5 is complete
+
+5.1–5.5 done. Worth noticing what has accumulated: **item 7.1 now carries three deferred
+measurements** — NFR-01's absolute half, NFR-03's residual, and NFR-05's range. All three were
+deferred for the same reason (hardware-dependent absolutes measured on a non-reference machine), and
+all three are recorded rather than waved through. That item is no longer just "a nightly harness";
+it's where three separate honest deferrals come due at once.
+
+## Next
+
+Milestone 6 (`v0.6.0`) — HTTP, container, errors.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — A range, not a ceiling: measuring the wrong thing would have proved nothing](2026/08/2026-08-04-hash-matrix-nfr05.md)
 - [2026-08-04 — A probe that passed, and the claim it disproved](2026/08/2026-08-04-xss-corpus.md)
 - [2026-08-04 — The constant that reads like "strongest" and means bcrypt](2026/08/2026-08-04-hash.md)
 - [2026-08-04 — Two sanitizers, and a wrong answer that only shows up on one driver](2026/08/2026-08-04-sanitizer.md)

--- a/src/bench/php/d4np/utils/HashBench.php
+++ b/src/bench/php/d4np/utils/HashBench.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench;
+
+use D4np\Utils\Security\Hash;
+use PhpBench\Attributes as Bench;
+
+/**
+ * NFR-05: `Hash::make` with Argon2id defaults, **50–200 ms** on the reference machine —
+ * *"deliberately slow; documented for capacity planning"*.
+ *
+ * **This budget is a range, and that makes it unlike every other NFR in this project.** For
+ * NFR-01 and NFR-03, faster is better and only the ceiling matters. Here, being *under* the floor
+ * is the more serious failure: a password hash that completes in 5 ms means the work factor is
+ * inadequate, and no amount of fast is good.
+ *
+ * That asymmetry is why the **security** half of NFR-05 is not asserted here at all. Wall-clock
+ * time depends on the CPU, the memory bandwidth and whatever else is running; the *work factor*
+ * does not. `HashMatrixTest::testTheArgon2idWorkFactorMeetsTheOwaspFloor()` asserts
+ * `memory_cost` and `time_cost` against OWASP's published minimums, which is the machine-
+ * independent statement of "deliberately slow" and the assertion that would still catch a future
+ * PHP lowering its defaults. What is left for this benchmark is NFR-05's *other* stated purpose:
+ * producing a number for **capacity planning**.
+ *
+ * Nothing is asserted here. The absolute range is tied to spec NFR-06's reference machine (a Ryzen
+ * 7 5800X), and gating on it from arbitrary CI hardware would fail for reasons unrelated to any
+ * regression — the same reasoning items 3.5 and 4.5 recorded, with roadmap item **7.1** owning
+ * baseline-tracked enforcement.
+ *
+ * `Revs(1)` is deliberate. One hash *is* the unit NFR-05 budgets, and at a few hundred
+ * milliseconds each, averaging many per iteration would only make the run slow without making the
+ * number better.
+ */
+#[Bench\Iterations(5)]
+#[Bench\Revs(1)]
+#[Bench\RetryThreshold(20)]
+final class HashBench
+{
+    private Hash $hash;
+
+    public function setUpHash(): void
+    {
+        $this->hash = new Hash();
+    }
+
+    /**
+     * The measured figure on the development machine is well **above** NFR-05's 200 ms ceiling —
+     * see `docs/benchmarks/` for the number and the analysis. That is a capacity-planning finding
+     * (login latency), not a security one: the cost parameters are PHP's defaults and clear
+     * OWASP's floor, so the work factor is right and the duration is what that work factor costs
+     * on this hardware.
+     */
+    #[Bench\BeforeMethods('setUpHash')]
+    public function benchMakeArgon2id(): void
+    {
+        $this->hash->make('correct horse battery staple');
+    }
+
+    /**
+     * The fallback algorithm, measured for the same capacity-planning reason: a deployment that
+     * lands on bcrypt should know what it costs, and the two differ enough to matter.
+     */
+    public function benchMakeBcrypt(): void
+    {
+        password_hash('correct horse battery staple', PASSWORD_BCRYPT);
+    }
+
+    /**
+     * Verification is on the login path for *every* user, where hashing is only on registration
+     * and upgrade — so its cost is the one that scales with traffic.
+     */
+    #[Bench\BeforeMethods('setUpVerify')]
+    public function benchVerifyArgon2id(): void
+    {
+        $this->hash->verify('correct horse battery staple', $this->stored);
+    }
+
+    private string $stored = '';
+
+    public function setUpVerify(): void
+    {
+        $this->hash = new Hash();
+        $this->stored = $this->hash->make('correct horse battery staple');
+    }
+}

--- a/src/test/php/d4np/utils/Security/HashMatrixTest.php
+++ b/src/test/php/d4np/utils/Security/HashMatrixTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Security;
+
+use D4np\Utils\Security\Hash;
+use D4np\Utils\Support\UtilsException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+
+/**
+ * Spec §7's *"Hash matrix tests (argon2id/bcrypt fallback, rehash triggers)"* — roadmap 5.5.
+ *
+ * `HashTest` (item 5.3) covers the behaviour of a correctly configured instance. This covers the
+ * two **cross-products** the spec names, exhaustively rather than by example, because a policy
+ * tested at three of its four corners is a policy with an untested corner.
+ *
+ * The fallback half is reachable at all only because item 5.3 extracted `selectAlgorithm()`:
+ * `defined('PASSWORD_ARGON2ID')` is a compile-time fact, so the availability has to arrive as an
+ * argument or half this matrix could not be written (ADR-0022).
+ */
+#[Group('T-06')]
+final class HashMatrixTest extends TestCase
+{
+    // ---- the fallback matrix: availability × policy, all four cells ----------------------------
+
+    /**
+     * @return iterable<string, array{bool, bool, string|null, bool}>
+     */
+    public static function fallbackMatrix(): iterable
+    {
+        //                                    available, fallback, expected algo,     warns
+        yield 'available + fallback allowed' => [true, true, PASSWORD_ARGON2ID, false];
+        yield 'available + fallback refused' => [true, false, PASSWORD_ARGON2ID, false];
+        yield 'missing + fallback allowed' => [false, true, PASSWORD_BCRYPT, true];
+        yield 'missing + fallback refused' => [false, false, null, false];
+    }
+
+    /**
+     * @param string|null $expected the algorithm, or `null` when construction must be refused
+     */
+    #[DataProvider('fallbackMatrix')]
+    public function testEveryCellOfTheFallbackMatrix(
+        bool $available,
+        bool $fallback,
+        ?string $expected,
+        bool $warns,
+    ): void {
+        $logger = new RecordingLogger();
+
+        if ($expected === null) {
+            $this->expectException(UtilsException::class);
+            Hash::selectAlgorithm($available, $fallback, $logger);
+
+            return;
+        }
+
+        self::assertSame($expected, Hash::selectAlgorithm($available, $fallback, $logger));
+        self::assertCount($warns ? 1 : 0, $logger->records);
+
+        if ($warns) {
+            self::assertSame(LogLevel::WARNING, $logger->records[0]['level']);
+        }
+    }
+
+    /**
+     * The refusing cell, asserted separately for the thing the matrix above cannot check once it
+     * has entered `expectException()`: that refusing does **not** also log. A hard failure is
+     * already loud, and a WARNING beside it would suggest the run continued in a degraded state.
+     */
+    public function testTheRefusingCellDoesNotAlsoLog(): void
+    {
+        $logger = new RecordingLogger();
+
+        try {
+            Hash::selectAlgorithm(false, false, $logger);
+        } catch (UtilsException) {
+            // expected
+        }
+
+        self::assertSame([], $logger->records);
+    }
+
+    /**
+     * Every cell must behave identically with no logger attached — the logger records the
+     * decision, it must not influence it.
+     */
+    #[DataProvider('fallbackMatrix')]
+    public function testTheDecisionIsTheSameWithoutALogger(
+        bool $available,
+        bool $fallback,
+        ?string $expected,
+        bool $warns,
+    ): void {
+        if ($expected === null) {
+            $this->expectException(UtilsException::class);
+            Hash::selectAlgorithm($available, $fallback);
+
+            return;
+        }
+
+        self::assertSame($expected, Hash::selectAlgorithm($available, $fallback));
+    }
+
+    // ---- the rehash-trigger matrix -------------------------------------------------------------
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function rehashMatrix(): iterable
+    {
+        if (!defined('PASSWORD_ARGON2ID')) {
+            return;
+        }
+
+        yield 'current defaults' => [password_hash('pw', PASSWORD_ARGON2ID), false];
+        yield 'weaker memory_cost' => [password_hash('pw', PASSWORD_ARGON2ID, ['memory_cost' => 8192]), true];
+        yield 'weaker time_cost' => [password_hash('pw', PASSWORD_ARGON2ID, ['time_cost' => 1]), true];
+        // Surprising, and real: PHP compares parameters for *equality* with the current defaults,
+        // not for "at least as strong". A hash hardened beyond the defaults is therefore also
+        // reported as needing a rehash — and would be silently *downgraded* on next login.
+        yield 'stronger parameters' => [password_hash('pw', PASSWORD_ARGON2ID, ['memory_cost' => 131072, 'time_cost' => 8]), true];
+        yield 'different algorithm (bcrypt)' => [password_hash('pw', PASSWORD_BCRYPT), true];
+        yield 'bcrypt at a high cost' => [password_hash('pw', PASSWORD_BCRYPT, ['cost' => 13]), true];
+        yield 'malformed' => ['not-a-hash', true];
+        yield 'empty' => ['', true];
+    }
+
+    #[DataProvider('rehashMatrix')]
+    public function testEveryRehashTrigger(string $stored, bool $expected): void
+    {
+        self::assertSame($expected, (new Hash())->needsRehash($stored));
+    }
+
+    /**
+     * Every hash in the matrix that was made from the same password must still *verify*, whatever
+     * its parameters — otherwise "upgrade on login" could never run, because the login it depends
+     * on would already have failed.
+     */
+    #[DataProvider('rehashMatrix')]
+    public function testEveryWellFormedHashInTheMatrixStillVerifies(string $stored, bool $expected): void
+    {
+        $hash = new Hash();
+
+        if ($stored === '' || $stored === 'not-a-hash') {
+            self::assertFalse($hash->verify('pw', $stored));
+
+            return;
+        }
+
+        self::assertTrue($hash->verify('pw', $stored));
+    }
+
+    // ---- the work factor: NFR-05's security property, without a stopwatch ----------------------
+
+    /**
+     * **NFR-05 says "deliberately slow", and the machine-independent way to assert that is the
+     * work factor, not the wall clock.**
+     *
+     * A duration depends on the CPU, the memory bandwidth, and what else is running; a cost
+     * parameter does not. If a future PHP lowered its Argon2id defaults, the timing on a fast
+     * machine might still look plausible while the actual work factor had dropped — this is the
+     * assertion that would catch it.
+     *
+     * The floor is OWASP's Password Storage recommendation for Argon2id (m ≥ 19456 KiB with
+     * t ≥ 2). PHP's current defaults (m = 65536, t = 4) clear it comfortably; the point is that
+     * they are *checked* against an external standard rather than trusted because they are the
+     * defaults.
+     */
+    public function testTheArgon2idWorkFactorMeetsTheOwaspFloor(): void
+    {
+        if (!defined('PASSWORD_ARGON2ID')) {
+            self::markTestSkipped('this PHP build has no Argon2id support');
+        }
+
+        $options = password_get_info((new Hash())->make('pw'))['options'];
+
+        self::assertIsArray($options);
+        self::assertArrayHasKey('memory_cost', $options);
+        self::assertArrayHasKey('time_cost', $options);
+
+        self::assertGreaterThanOrEqual(19456, $options['memory_cost'], 'below OWASP\'s Argon2id memory floor');
+        self::assertGreaterThanOrEqual(2, $options['time_cost'], 'below OWASP\'s Argon2id time floor');
+    }
+
+    /**
+     * The library must not be quietly overriding PHP's cost parameters — ADR-0022 decided those
+     * belong to PHP, so that this library does not own a number that has to keep moving.
+     */
+    public function testTheLibraryUsesPhpsOwnDefaultsRatherThanItsOwn(): void
+    {
+        if (!defined('PASSWORD_ARGON2ID')) {
+            self::markTestSkipped('this PHP build has no Argon2id support');
+        }
+
+        $ours = password_get_info((new Hash())->make('pw'))['options'];
+        $phps = password_get_info(password_hash('pw', PASSWORD_ARGON2ID))['options'];
+
+        self::assertSame($phps, $ours);
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item 5.5 (spec §7, NFR-05). **Closes Milestone 5.**

## The thing that makes NFR-05 different

Every other budget here is a **ceiling** — NFR-01's ≤5µs, NFR-03's ≤10µs, NFR-04's ≤16MiB — where faster/smaller is strictly better and only one direction can fail.

**NFR-05 is a range (50–200 ms), and the *lower* bound is the serious one.** A password hash completing in 5 ms means the work factor is inadequate; no amount of fast redeems it.

That asymmetry decided the item. The obvious approach — a benchmark asserting the range — would have been useless in exactly the direction that matters: **a stopwatch cannot distinguish strong parameters on slow hardware from weak parameters on fast hardware.** Both produce a number; only one is safe.

So the requirement splits by what each half can actually prove:

| half | mechanism | why |
|---|---|---|
| **security** | work factor (`memory_cost`/`time_cost`) vs **OWASP's** floor | machine-independent; catches a future PHP lowering its defaults while a fast machine still shows a plausible duration |
| **capacity** | `HashBench`, asserting nothing | NFR-05's own stated purpose; ADR-0011/0018 precedent |

The floor is OWASP's rather than a number I picked, so "deliberately slow" is checked against a standard owned outside this repo.

## Measured — and deliberately not fixed

| subject | measured | NFR-05 |
|---|---|---|
| `make()` argon2id | **349.5 ms** ±1.82% | 50–200 ms — **over** |
| `make()` bcrypt | 141.1 ms | within |
| `verify()` argon2id | 347.8 ms | not budgeted |

~1.75× over the ceiling, and **the correct response is to change nothing.** The parameters are PHP's defaults, they clear OWASP's floor by >3× on memory, and the duration is what that work factor costs here. Lowering them to hit the range would trade security for latency — the exact inversion of "deliberately slow", and against ADR-0022.

Two caveats recorded with the number: this isn't NFR-06's reference machine, and **bcrypt at 141 ms for `cost=10` is itself a signal** (usually 50–80 ms), so both figures are likely inflated. The ratio is the more portable observation.

## A number NFR-05 doesn't ask for, but a capacity plan needs

`verify()` costs the same as `make()` (~348 ms, symmetric by design in Argon2id). NFR-05 budgets `make`, which runs at registration and upgrade — **`verify` runs on every login** and is what actually caps authentication throughput. Measuring it serves NFR-05's stated *purpose* while being outside its stated scope.

## A PHP behaviour worth knowing

`password_needs_rehash()` returns **`true` for stronger parameters too** — it compares for *equality* with current defaults, not "at least as strong". A hash hardened beyond the defaults is silently **downgraded** on next login. This library always uses PHP's defaults so it can't produce one, but a consumer migrating from a hardened setup would lose that hardening with no signal.

## Test plan

- [x] **Exhaustive cross-products, not examples.** Item 5.3 tested 3 of the fallback policy's 4 corners incidentally; a policy tested at 3 of 4 corners has an untested corner. Full availability × policy matrix, plus every cell asserted identical with **no logger** (the logger records the decision, it must not influence it)
- [x] Rehash matrix: defaults, weaker memory, weaker time, **stronger**, different algorithm, bcrypt at raised cost, malformed, empty — every well-formed entry also asserted to still `verify()`, since upgrade-on-login needs a login that succeeds first
- [x] Work-factor assertions verified non-vacuous by planting weak cost parameters — 2 failures
- [x] `vendor/bin/phpunit` — 1037 tests, 2346 assertions, 7 skipped
- [x] PHPStan max clean · deptrac 0/0 · consistency + action-pin lints OK
- [ ] CI

## Milestone 5 complete — and something worth noticing

**Item 7.1 now carries three deferred measurements**: NFR-01's absolute half, NFR-03's residual, and NFR-05's range. All three deferred for the same reason (hardware-dependent absolutes on a non-reference machine), all three recorded rather than waved through. That item is no longer just "a nightly harness" — it's where three separate honest deferrals come due at once.

Route mismatch recorded (frontier-routed, standard session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)