### PR TITLE
feat(http): typed Request/Response wrappers that refuse rather than coerce

### DIFF
--- a/.eados-core/learning/runs/2026-08-04-utils-7.yaml
+++ b/.eados-core/learning/runs/2026-08-04-utils-7.yaml
@@ -1,0 +1,36 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-04"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}
+route_mismatch:
+  routed: "fast/low"
+  session: "standard"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,26 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- `D4np\Utils\Http\Request` and `D4np\Utils\Http\Response` (**ADR-0025**) — opens Milestone 6.
+  Native lightweight wrappers **mirroring PSR-7's naming without its types**, per RFC-0001: the
+  optional `egl/utils-psr7-bridge` is the only sanctioned crossing point, and these never grow
+  middleware ambitions.
+  **The typed accessors refuse rather than coerce**, which is the security decision: `?email=x`
+  gives a string but `?email[]=x` gives an **array** — the same key, a different PHP type, chosen by
+  the client. A `(string)` cast yields the literal `"Array"` and `implode()` invents a value nobody
+  sent, so a scalar accessor handed a non-scalar returns its default instead.
+  `queryList()`/`postList()` are there for when a list is genuinely expected, and refuse scalars
+  rather than wrapping them. `queryInt()` uses `FILTER_VALIDATE_INT`, not a cast, because
+  `(int) "12abc"` is `12`.
+  Headers are derived from `$_SERVER` (`getallheaders()` does not exist outside Apache-like SAPIs),
+  including `CONTENT_TYPE`/`CONTENT_LENGTH` which CGI reports without the `HTTP_` prefix.
+  `isSecure()` ignores `X-Forwarded-Proto` — client-supplied absent a trusted proxy — but does
+  handle `$_SERVER['HTTPS']` being the string `'off'`.
+  `Response` is immutable, refuses CR/LF/NUL in header values (**response splitting**) at the point
+  they are *set* rather than at send time, and stores header names case-insensitively so a
+  duplicated `Content-Type` cannot smuggle a second interpretation past a proxy. `json()` encodes
+  through `Json::encode()` so an unencodable value raises instead of putting `false` in the body;
+  `html()` deliberately escapes nothing, since escaping is a render-time decision (ADR-0019).
 - Spec §7's **Hash matrix** and NFR-05's timing (**ADR-0024**) — closes Milestone 5. NFR-05 is a
   **range** (50–200 ms), unlike every other budget here, and the *lower* bound is the serious one:
   a hash completing in 5 ms means the work factor is inadequate. So it is split by what each half

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — A range, not a ceiling: measuring the wrong thing would have proved nothing](docs/journal/2026/08/2026-08-04-hash-matrix-nfr05.md).
+  [2026-08-04 — The client picks the type, not the application](docs/journal/2026/08/2026-08-04-http-wrappers.md).
 
 ## Model & effort routing (advisory)
 
@@ -345,8 +345,19 @@ Explicit-mechanism security helpers (RFC-0001; every item carries the protected 
 
 The application-facing groups (RFC-0001).
 
-- [ ] 6.1 `Request`/`Response` typed wrappers, PSR-7-mirroring naming (RFC-0001)
-      (severity:medium) — route: standard / medium
+- [x] 6.1 `Request`/`Response` typed wrappers, PSR-7-mirroring naming (RFC-0001)
+      (severity:medium) — route: standard / medium · **ADR-0025**. *Opens Milestone 6. **The typed
+      accessors refuse rather than coerce**, which is the security decision here: `?email[]=x` gives
+      the same key a different PHP type, chosen by the client, and a `(string)` cast yields the
+      literal `"Array"` while `implode()` invents a value nobody sent — both turn attacker-chosen
+      *shape* into a trusted value. Scalar accessors return their default instead;
+      `queryList()`/`postList()` exist for when a list is genuinely expected. `FILTER_VALIDATE_INT`
+      not a cast (`(int) "12abc"` is 12). Headers from `$_SERVER` since `getallheaders()` is
+      Apache-only; `isSecure()` ignores `X-Forwarded-Proto` (client-supplied absent a trusted
+      proxy) but does handle the `'off'` string. `Response` refuses CR/LF/NUL in header values
+      (response splitting) **at set time, not send time**, and stores names case-insensitively so a
+      duplicate `Content-Type` cannot be smuggled past a proxy. PHPStan caught a type annotation
+      that was a lie: `?0=zero` yields an **integer** key, so superglobals are `array<array-key>`.*
 - [ ] 6.2 `Session` hardening + `regenerate()`; `CsrfToken` — CSPRNG, `hash_equals`, per-form
       scoping; Http placement per RFC-0001 R-1 (security) — route: frontier-reasoning / extra
 - [ ] 6.3 T-03 session/CSRF integration suite against a real `php -S` process (RFC-0001)

--- a/docs/adr/0025-typed-http-wrappers-that-refuse-rather-than-coerce.md
+++ b/docs/adr/0025-typed-http-wrappers-that-refuse-rather-than-coerce.md
@@ -1,0 +1,145 @@
+# ADR-0025: HTTP wrappers that mirror PSR-7's naming, and refuse rather than coerce
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 6.1 (opens Milestone 6) · spec FR-13, FR-14 · imported **ADR-002**
+  (HTTP / PSR-7) · [RFC-0001](../rfc/0001-egl-utils-library.md) §Alternatives 3 ·
+  [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md) ·
+  [ADR-0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md) (why the HTML
+  body is not escaped here) · item 6.2 (`Session`/`CsrfToken`, same group)
+
+## Context
+
+Spec FR-13 asks for a *"typed superglobal reader (`$_GET`/`$_POST`/`$_SERVER`/`$_FILES`)"* and
+FR-14 for *"headers/JSON/status helpers"*, both with an *"optional PSR-7 bridge per imported
+ADR-002"*.
+
+RFC-0001 §Alternatives 3 already settled the shape and its reasoning is worth restating, because it
+constrains everything below: implementing PSR-7 here was rejected (streams, immutability and
+uploaded files are a solved project, and re-doing them adds maintenance without differentiation),
+and exposing PSR-7 types *only* was rejected too (it forces factory wiring and stream handling on
+framework-less users who want `$request->postString('email')`). The chosen shape is **native
+lightweight wrappers mirroring PSR-7 naming**, with `egl/utils-psr7-bridge` as the only sanctioned
+crossing point — and the RFC adds that the wrappers **never grow middleware ambitions**.
+
+Four things were probed before writing anything:
+
+| probe | result |
+|---|---|
+| `?role[]=admin` | `$_GET['role']` is an **array** — the client chooses the PHP type |
+| `getallheaders()` | **not defined** outside Apache-like SAPIs |
+| `?0=zero` | produces an **integer** array key |
+| `filter_var('', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)` | **`false`**, not `null` |
+
+## Decision
+
+### 1. The typed accessors refuse rather than coerce
+
+This is the security decision in `Request`. `?email=x` yields a string; `?email[]=x` yields an
+array — **the same key, a different PHP type, chosen by whoever wrote the query string**. A
+`(string)` cast on that emits *"Array to string conversion"* and produces the literal `"Array"`;
+`implode()` invents a value nobody sent. Both convert attacker-controlled *shape* into a value the
+application then trusts, which is the parameter-pollution family.
+
+So a scalar accessor handed a non-scalar returns its **default**, exactly as if the key were
+absent — the honest answer, because a string is not what arrived.
+
+The same reasoning applies within scalars: `queryInt()` uses `FILTER_VALIDATE_INT`, not a cast,
+because `(int) "12abc"` is `12` — a value the client never sent. `queryBool()` uses
+`FILTER_VALIDATE_BOOLEAN` with `FILTER_NULL_ON_FAILURE`, the same coercion `Env::get()` uses, since
+an unchecked cast makes the *string* `"false"` true.
+
+**`queryList()`/`postList()` exist for the case where a list is genuinely expected.** A caller
+asking for a list has *decided* a list is acceptable here, which is a different decision from being
+handed one unexpectedly. They refuse scalars rather than wrapping them, because wrapping would
+erase the distinction they exist to preserve.
+
+### 2. Only `fromGlobals()` touches a superglobal
+
+Everything else is a pure function of the constructor arguments. That is what makes a request
+testable without a web server, and what lets the bridge construct one from a PSR-7 message.
+
+### 3. Headers come from `$_SERVER`, not `getallheaders()`
+
+`getallheaders()` does not exist outside Apache-like SAPIs — verified absent on this CLI build — so
+`$_SERVER` is the portable path. `HTTP_X_FORWARDED_FOR` → `x-forwarded-for`; `CONTENT_TYPE` and
+`CONTENT_LENGTH` are included despite carrying no `HTTP_` prefix, because CGI reports those two
+without one and a prefix-only rule silently loses them.
+
+**`isSecure()` deliberately ignores `X-Forwarded-Proto`.** That header is client-supplied unless a
+trusted proxy rewrote it, and this class cannot know whether one did — trusting it would let any
+client claim HTTPS. It does check for the string `'off'`, because `$_SERVER['HTTPS']` is present
+and set to `'off'` on some servers, so an `isset()` check reports every such request as secure.
+
+### 4. `Response` is immutable with `with*()`; `Request` is not
+
+A response is *built*, usually in stages and often across layers, and the alternative to
+immutability is an object a helper can change behind its caller's back. A request is only ever
+read. `Request` therefore has no withers — which also keeps it clear of the middleware ambitions
+RFC-0001 warned against.
+
+### 5. Header names are case-insensitive but remember their spelling
+
+RFC 9110 makes field names case-insensitive, so `Content-Type` and `content-type` must not become
+two headers — **a duplicated `Content-Type` is how a response smuggles a second interpretation past
+a proxy**. The original casing is kept for output because some clients are, in practice, less
+tolerant than the specification.
+
+### 6. CR, LF and NUL in a header value are refused, at the point they are *set*
+
+A CR or LF ends the header line early and lets everything after it be read as further headers or as
+the body — **response splitting**. Modern PHP's `header()` rejects these itself, but validating at
+`withHeader()` rather than at `send()` means a response assembled and inspected in a test fails the
+same way as one sent to a client. Refused rather than stripped, so the caller learns their value was
+not what they thought.
+
+### 7. `Response::html()` does not escape the body
+
+Escaping is a render-time decision that depends on where each value lands (ADR-0019's four
+contexts). A blanket `htmlspecialchars()` over an assembled document would corrupt the markup it
+exists to carry. `Response::json()` *does* go through `Json::encode()`, so an unencodable value
+raises rather than silently putting `false` in the body (RFC-0001 R-7).
+
+## Alternatives Considered
+
+- **Implementing PSR-7, or depending on an implementation** — settled by RFC-0001 §Alternatives 3
+  and imported ADR-002; restated in Context because it constrains the rest.
+- **Coercing arrays to strings** (`implode`, or `(string)`) — rejected in §1: it manufactures a
+  value the client did not send from a shape the client controls.
+- **Throwing on a type mismatch** instead of returning the default — rejected: absent input is
+  normal in HTTP, and a reader that throws on ordinary traffic would be wrapped in `try` at every
+  call site until someone caught `Throwable` around the lot.
+- **Wrapping a scalar into a one-element list** in `queryList()` — rejected in §1.
+- **Trusting `X-Forwarded-Proto`, or a `trustedProxies` option** — rejected for this item: the
+  option is real and belongs with a considered proxy story, not smuggled into a superglobal reader.
+- **`getallheaders()` with a `$_SERVER` fallback** — rejected: two code paths where one works
+  everywhere, and the rarely-taken branch is the one that rots.
+- **Escaping in `Response::html()`** — rejected in §7.
+- **A `Stream` body** — rejected: that is the PSR-7 surface this library declined to re-implement.
+
+## Consequences
+
+- 72 tests across the two classes; `--group T-07` runs them as a unit. Total 1109.
+- **Verified non-vacuous**, and one probe had to be redone: flattening arrays (6 failures), a cast
+  instead of `FILTER_VALIDATE_INT` (6), case-sensitive header storage (8), and removing the CR/LF
+  check (4). That last probe **initially reported a pass** because the string replacement had not
+  matched the source at all — a probe that does not apply is not evidence, and it was re-run
+  against the verified line before being believed.
+- **PHPStan at max rejected a type annotation that was a lie.** The superglobals were declared
+  `array<string, mixed>`; `?0=zero` produces an **integer** key, so the honest type is
+  `array<array-key, mixed>`. Corrected rather than cast away.
+- A PHP surprise is documented where it will be read: `filter_var('', FILTER_VALIDATE_BOOLEAN,
+  FILTER_NULL_ON_FAILURE)` is **`false`**, not `null` — so `?flag=` reads as false rather than as
+  absent. Following PHP rather than inventing a third answer keeps this consistent with `Env::get()`.
+- `file()` returns the raw `$_FILES` entry rather than an object. An uploaded-file abstraction
+  (moving, streaming, error codes) is exactly the surface RFC-0001 declined to re-implement, and
+  the bridge is where a PSR-7 `UploadedFileInterface` comes from.
+- No middleware, no `Stream`, no PSR-7 types. `Session` and `CsrfToken` join this group at item 6.2.
+
+## References
+
+- Spec FR-13, FR-14; RFC-0001 §Alternatives 3 and the imported ADR-002 commitment
+- ADR-0019 — why `Response::html()` escapes nothing
+- Verified directly on PHP 8.3.1: array-valued query parameters, `getallheaders()` absence,
+  integer array keys from `?0=`, and `filter_var`'s empty-string behaviour

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0022](0022-argon2id-by-default-with-a-fallback-decided-at-construction.md) | Argon2id by name, not by `PASSWORD_DEFAULT`, with the fallback decided at construction | Accepted |
 | [0023](0023-snapshot-for-drift-invariants-for-safety-idempotence-for-mxss.md) | Snapshots catch drift, invariants catch wrong, and idempotence catches mutation XSS | Accepted |
 | [0024](0024-assert-the-work-factor-not-the-wall-clock.md) | Assert the work factor, not the wall clock — NFR-05 split by what each half can actually prove | Accepted |
+| [0025](0025-typed-http-wrappers-that-refuse-rather-than-coerce.md) | HTTP wrappers that mirror PSR-7's naming, and refuse rather than coerce | Accepted |

--- a/docs/journal/2026/08/2026-08-04-http-wrappers.md
+++ b/docs/journal/2026/08/2026-08-04-http-wrappers.md
@@ -1,0 +1,105 @@
+# 2026-08-04 — The client picks the type, not the application
+
+Roadmap item **6.1**, opening Milestone 6. Route `fast / low`, session Opus 5 (standard) — *above*
+the route this time rather than below, which is over-resourced rather than under. Recorded.
+
+## The decision the whole item turns on
+
+`?email=x` gives you a string. `?email[]=x` gives you an **array**.
+
+Same key, different PHP type, and **the client chose which**. That's the whole parameter-pollution
+family in one line, and the two obvious ways to handle it are both wrong:
+
+- `(string) $_GET['email']` emits *"Array to string conversion"* and yields the literal `"Array"`
+- `implode(',', ...)` invents a value nobody sent
+
+Both convert attacker-controlled *shape* into a value the application then trusts. So a scalar
+accessor handed a non-scalar returns its **default** — the honest answer, because a string is not
+what arrived.
+
+The same reasoning one level down: `queryInt()` uses `FILTER_VALIDATE_INT`, not a cast, because
+`(int) "12abc"` is `12` — again, a value the client never sent.
+
+`queryList()`/`postList()` exist for when a list *is* expected. A caller asking for a list has
+decided a list is acceptable here, which is a different decision from being handed one
+unexpectedly. They refuse scalars rather than wrapping them, because wrapping erases the
+distinction they exist to preserve.
+
+## Probes that changed things
+
+| probe | result | consequence |
+|---|---|---|
+| `?role[]=admin` | array | the refusal above |
+| `getallheaders()` | **not defined** here | headers come from `$_SERVER`, one path not two |
+| `?0=zero` | **integer** array key | my type annotation was a lie (below) |
+| `filter_var('', BOOLEAN, NULL_ON_FAILURE)` | **`false`**, not `null` | `?flag=` is false, not absent |
+
+The last one caught me writing a test that asserted my *assumption* rather than PHP's behaviour. I
+expected `null` for an empty value; PHP says `false`. Fixed the test to match reality and
+documented it in the code, because it's surprising and someone will hit it. Following PHP rather
+than inventing a third answer also keeps this consistent with `Env::get()`, which uses the same
+filter.
+
+## PHPStan caught an annotation that was a lie
+
+I'd declared the superglobals `array<string, mixed>`. PHPStan max refused it, and it was right:
+`?0=zero` produces an **integer** key. The honest type is `array<array-key, mixed>`.
+
+Worth noting the shape of the error — not "this code is wrong" but "this *claim about the code* is
+wrong". Casting it away would have kept the lie and silenced the messenger.
+
+## A probe that passed for the wrong reason
+
+Four planted defects. Three caught immediately:
+
+| planted | failures |
+|---|---|
+| scalar accessors flatten arrays | 6 |
+| `queryInt` uses a cast | 6 |
+| header names stored case-sensitively | 8 |
+| **CR/LF check removed** | **0 — passed** |
+
+That fourth one should obviously have failed — the whole `splittingValues` provider exists for it.
+
+I flagged in item 5.4's journal that *"a probe that doesn't fail is evidence about the code or about
+the claim"*. This time it was neither: **the string replacement never matched the source**, so the
+probe never applied. A passing probe that didn't run is not a weak test, it's no test at all.
+
+Re-ran it by patching the verified line number instead of a fragile string match: 4 failures, as it
+should have been. The lesson is narrow and practical — **verify the probe actually landed before
+believing what it tells you**, especially when it tells you something reassuring.
+
+That's now twice this session that Python string-matching against PHP has misfired. The Edit tool,
+or a line-indexed patch, is the right instrument.
+
+## Smaller decisions, recorded
+
+- **`isSecure()` ignores `X-Forwarded-Proto`.** It's client-supplied unless a trusted proxy rewrote
+  it, and this class can't know whether one did — trusting it lets any client claim HTTPS. It *does*
+  check for the string `'off'`, because `$_SERVER['HTTPS']` is present-and-`'off'` on some servers,
+  where an `isset()` check would report every request as secure.
+- **Header values are validated at `withHeader()`, not at `send()`.** PHP's own `header()` rejects
+  CR/LF, but validating at set time means a response assembled and inspected in a test fails the
+  same way as one sent to a client.
+- **Header names are case-insensitive but keep their spelling.** RFC 9110 makes them
+  case-insensitive, so `Content-Type` and `content-type` must not become two headers — a duplicated
+  `Content-Type` is how a response smuggles a second interpretation past a proxy.
+- **`Response::html()` escapes nothing.** Escaping is a render-time decision that depends on where
+  each value lands (ADR-0019's four contexts); a blanket pass over an assembled document would
+  corrupt the markup it exists to carry. `json()` *does* go through `Json::encode()`, so an
+  unencodable value raises rather than putting `false` in the body.
+- **`Request` has no withers**, `Response` does. A response is built in stages across layers, where
+  the alternative to immutability is an object a helper changes behind its caller's back. A request
+  is only read — and withers would edge toward the middleware ambitions RFC-0001 explicitly warned
+  these wrappers against.
+
+## Bar
+
+1109 tests / 2475 assertions green (up from 1037). `--group T-07` runs 72. PHPStan max clean,
+deptrac 0/0, consistency lint OK.
+
+## Next
+
+**6.2** — `Session` hardening + `regenerate()`, and `CsrfToken`. Routed
+`frontier-reasoning / extra`, and genuinely security-critical: CSPRNG generation, `hash_equals`
+comparison, per-form scoping.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-04 — The client picks the type, not the application](2026/08/2026-08-04-http-wrappers.md)
 - [2026-08-04 — A range, not a ceiling: measuring the wrong thing would have proved nothing](2026/08/2026-08-04-hash-matrix-nfr05.md)
 - [2026-08-04 — A probe that passed, and the claim it disproved](2026/08/2026-08-04-xss-corpus.md)
 - [2026-08-04 — The constant that reads like "strongest" and means bcrypt](2026/08/2026-08-04-hash.md)

--- a/src/main/php/d4np/utils/Http/Request.php
+++ b/src/main/php/d4np/utils/Http/Request.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+/**
+ * A typed reader over one request's input (spec FR-13, ADR-0025).
+ *
+ * **This is not PSR-7, and deliberately mirrors its naming rather than its types.** RFC-0001
+ * rejected both implementing PSR-7 here and depending on an implementation: doing it well is a
+ * solved project (streams, immutability, uploaded files), and exposing PSR-7 types only would
+ * force factory wiring and stream handling on framework-less users who want
+ * `$request->postString('email')`. The sanctioned crossing point is the optional
+ * `egl/utils-psr7-bridge`, and **these wrappers never grow middleware ambitions** — PSR-15 stacks
+ * belong on the other side of that bridge.
+ *
+ * **Nothing here reads a superglobal.** The constructor takes the four arrays and
+ * {@see fromGlobals()} is the only place `$_GET` and friends are touched, which is what makes a
+ * request testable without a web server and what lets the bridge construct one from a PSR-7
+ * message.
+ *
+ * **The typed accessors refuse rather than coerce, and that is the security decision in this
+ * class.** `?email=x` gives a string, but `?email[]=x` gives an **array** — the same key, a
+ * different PHP type, chosen by whoever wrote the query string. A `(string)` cast on that emits
+ * *"Array to string conversion"* and yields the literal `"Array"`; `implode()` invents a value
+ * nobody sent. Both turn attacker-controlled *shape* into a value the application then trusts,
+ * which is the parameter-pollution family. So a scalar accessor asked for a non-scalar returns its
+ * default, exactly as if the key were absent — the honest answer, because a string is not what
+ * arrived.
+ */
+final class Request
+{
+    /**
+     * Keys are `array-key`, not `string`, and that is not pedantry: `?0=zero` produces an
+     * **integer** key in `$_GET` — verified — so a `array<string, mixed>` annotation would be a
+     * lie PHPStan at max level correctly refuses to accept. The accessors take `string $key`
+     * because that is what callers write, and PHP's own array lookup handles the numeric-string
+     * equivalence.
+     *
+     * @param array<array-key, mixed> $query   `$_GET`
+     * @param array<array-key, mixed> $post    `$_POST`
+     * @param array<array-key, mixed> $server  `$_SERVER`
+     * @param array<array-key, mixed> $files   `$_FILES`
+     * @param array<array-key, mixed> $cookies `$_COOKIE`
+     */
+    public function __construct(
+        private readonly array $query = [],
+        private readonly array $post = [],
+        private readonly array $server = [],
+        private readonly array $files = [],
+        private readonly array $cookies = [],
+    ) {
+    }
+
+    /**
+     * The current request, read from the superglobals.
+     *
+     * The single point in this library that touches them, so everything else is a pure function of
+     * its constructor arguments.
+     */
+    public static function fromGlobals(): self
+    {
+        return new self($_GET, $_POST, $_SERVER, $_FILES, $_COOKIE);
+    }
+
+    // ---- typed readers -------------------------------------------------------------------------
+
+    public function queryString(string $key, ?string $default = null): ?string
+    {
+        return self::asString($this->query[$key] ?? null, $default);
+    }
+
+    public function queryInt(string $key, ?int $default = null): ?int
+    {
+        return self::asInt($this->query[$key] ?? null, $default);
+    }
+
+    public function queryBool(string $key, ?bool $default = null): ?bool
+    {
+        return self::asBool($this->query[$key] ?? null, $default);
+    }
+
+    public function postString(string $key, ?string $default = null): ?string
+    {
+        return self::asString($this->post[$key] ?? null, $default);
+    }
+
+    public function postInt(string $key, ?int $default = null): ?int
+    {
+        return self::asInt($this->post[$key] ?? null, $default);
+    }
+
+    public function postBool(string $key, ?bool $default = null): ?bool
+    {
+        return self::asBool($this->post[$key] ?? null, $default);
+    }
+
+    public function cookie(string $key, ?string $default = null): ?string
+    {
+        return self::asString($this->cookies[$key] ?? null, $default);
+    }
+
+    /**
+     * An input that genuinely *is* a list — `?tag[]=a&tag[]=b`.
+     *
+     * Separate from {@see queryString()} on purpose: a caller asking for a list has decided a list
+     * is acceptable here, which is a different decision from being handed one unexpectedly.
+     * Non-list values yield an empty array rather than being wrapped, because wrapping would erase
+     * the distinction this method exists to preserve.
+     *
+     * @return list<string>
+     */
+    public function queryList(string $key): array
+    {
+        return self::asStringList($this->query[$key] ?? null);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function postList(string $key): array
+    {
+        return self::asStringList($this->post[$key] ?? null);
+    }
+
+    // ---- request line and headers --------------------------------------------------------------
+
+    /**
+     * The HTTP method, upper-cased, defaulting to `GET` when absent.
+     */
+    public function method(): string
+    {
+        return strtoupper(self::asString($this->server['REQUEST_METHOD'] ?? null, 'GET') ?? 'GET');
+    }
+
+    /**
+     * The request target as the server reported it — path and query string, not a full URL.
+     */
+    public function uri(): string
+    {
+        return self::asString($this->server['REQUEST_URI'] ?? null, '') ?? '';
+    }
+
+    public function isSecure(): bool
+    {
+        $https = self::asString($this->server['HTTPS'] ?? null);
+
+        // `$_SERVER['HTTPS']` is 'off' on some servers rather than absent, which is why this is not
+        // an isset() check. Forwarded-proto headers are deliberately NOT consulted: they are
+        // client-supplied unless a trusted proxy has rewritten them, and this class cannot know
+        // whether one has.
+        return $https !== null && $https !== '' && strtolower($https) !== 'off';
+    }
+
+    /**
+     * One header, by case-insensitive name.
+     *
+     * Derived from `$_SERVER` rather than `getallheaders()`, which does not exist outside
+     * Apache-like SAPIs — verified absent on this CLI build. `HTTP_X_FORWARDED_FOR` becomes
+     * `x-forwarded-for`; `CONTENT_TYPE` and `CONTENT_LENGTH` are included despite carrying no
+     * `HTTP_` prefix, because CGI reports those two without one.
+     */
+    public function header(string $name, ?string $default = null): ?string
+    {
+        return $this->headers()[strtolower($name)] ?? $default;
+    }
+
+    /**
+     * Every header, keyed by lower-case name.
+     *
+     * @return array<string, string>
+     */
+    public function headers(): array
+    {
+        $headers = [];
+
+        foreach ($this->server as $key => $value) {
+            $name = self::headerNameOf((string) $key);
+
+            if ($name === null) {
+                continue;
+            }
+
+            $string = self::asString($value);
+
+            if ($string !== null) {
+                $headers[$name] = $string;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * One uploaded file's `$_FILES` entry, or `null`.
+     *
+     * Returned as the raw array rather than wrapped in an object: an uploaded-file abstraction
+     * (moving, streaming, error codes) is precisely the surface RFC-0001 declined to re-implement,
+     * and the bridge is where a PSR-7 `UploadedFileInterface` comes from.
+     *
+     * @return array<array-key, mixed>|null
+     */
+    public function file(string $key): ?array
+    {
+        $file = $this->files[$key] ?? null;
+
+        return is_array($file) ? $file : null;
+    }
+
+    // ---- coercion ------------------------------------------------------------------------------
+
+    private static function asString(mixed $value, ?string $default = null): ?string
+    {
+        // Arrays and objects are refused, not flattened — see the class docblock.
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        return $default;
+    }
+
+    private static function asInt(mixed $value, ?int $default = null): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (!is_string($value)) {
+            return $default;
+        }
+
+        // FILTER_VALIDATE_INT rather than a cast: `(int) "12abc"` is 12, which invents a value the
+        // client did not send. This returns the default for anything that is not wholly an integer.
+        $parsed = filter_var($value, FILTER_VALIDATE_INT);
+
+        return $parsed === false ? $default : $parsed;
+    }
+
+    private static function asBool(mixed $value, ?bool $default = null): ?bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (!is_string($value)) {
+            return $default;
+        }
+
+        // The same coercion `Env::get()` uses, and for the same reason: an unchecked cast makes the
+        // string "false" true. FILTER_NULL_ON_FAILURE distinguishes "not boolean-shaped" from
+        // "false".
+        //
+        // One surprise, verified rather than assumed and asserted in the tests: PHP's filter reads
+        // an **empty** (or whitespace-only) value as `false`, not as "not boolean-shaped". So
+        // `?flag=` is false, not absent. Following PHP here rather than inventing a third answer
+        // keeps this consistent with `Env::get()`, which uses the same filter.
+        $parsed = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        return $parsed ?? $default;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function asStringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $list = [];
+
+        foreach ($value as $item) {
+            $string = self::asString($item);
+
+            // A nested array (`?tag[a][b]=1`) is skipped rather than flattened: this method
+            // promises a list of strings, and inventing one from a deeper structure would be the
+            // same coercion the scalar accessors refuse.
+            if ($string !== null) {
+                $list[] = $string;
+            }
+        }
+
+        return $list;
+    }
+
+    /**
+     * The header name a `$_SERVER` key corresponds to, or `null` when it is not a header.
+     */
+    private static function headerNameOf(string $key): ?string
+    {
+        if (str_starts_with($key, 'HTTP_')) {
+            return strtolower(str_replace('_', '-', substr($key, 5)));
+        }
+
+        // CGI reports these two without the prefix. `HTTP_CONTENT_TYPE` maps to the same name, and
+        // whichever the server supplied wins — they cannot disagree in a well-formed request, and
+        // preferring one over the other would be inventing a rule no specification states.
+        if ($key === 'CONTENT_TYPE' || $key === 'CONTENT_LENGTH') {
+            return strtolower(str_replace('_', '-', $key));
+        }
+
+        return null;
+    }
+}

--- a/src/main/php/d4np/utils/Http/Response.php
+++ b/src/main/php/d4np/utils/Http/Response.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+use D4np\Utils\Support\HttpException;
+use D4np\Utils\Support\Json;
+
+/**
+ * A response to build and send (spec FR-14, ADR-0025).
+ *
+ * The counterpart to {@see Request}: PSR-7-mirroring naming, no PSR-7 types, and the optional
+ * `egl/utils-psr7-bridge` as the only sanctioned crossing point (RFC-0001).
+ *
+ * **Immutable, with `with*()` methods** — unlike `Request`, which is only ever read. A response is
+ * *built*, usually in stages and often across layers, and the alternative to immutability is a
+ * mutable object that a helper can change behind its caller's back. The naming follows PSR-7 so
+ * the shape is familiar and the bridge is mechanical.
+ *
+ * **Headers are stored case-insensitively but remember how they were spelled.** HTTP header names
+ * are case-insensitive per RFC 9110, so `Content-Type` and `content-type` must not become two
+ * headers — a duplicated `Content-Type` is how a response smuggles a second interpretation past a
+ * proxy. The original casing is preserved for output because some clients are, in practice, less
+ * tolerant than the specification.
+ */
+final class Response
+{
+    /**
+     * @param array<string, array{string, string}> $headers lower-case name => [original name, value]
+     */
+    private function __construct(
+        private readonly int $status,
+        private readonly array $headers,
+        private readonly string $body,
+    ) {
+    }
+
+    /**
+     * @throws HttpException if the status code is not a valid HTTP status
+     */
+    public static function create(int $status = 200, string $body = ''): self
+    {
+        return new self(self::validStatus($status), [], $body);
+    }
+
+    /**
+     * A `text/plain` response.
+     *
+     * @throws HttpException
+     */
+    public static function text(string $body, int $status = 200): self
+    {
+        return self::create($status, $body)->withHeader('Content-Type', 'text/plain; charset=utf-8');
+    }
+
+    /**
+     * A `text/html` response.
+     *
+     * The body is **not** escaped here. Escaping is a render-time decision that depends on where
+     * each value lands (ADR-0019's four contexts), and a response object cannot know that — a
+     * blanket `htmlspecialchars()` over an assembled document would corrupt the markup it is meant
+     * to carry.
+     *
+     * @throws HttpException
+     */
+    public static function html(string $body, int $status = 200): self
+    {
+        return self::create($status, $body)->withHeader('Content-Type', 'text/html; charset=utf-8');
+    }
+
+    /**
+     * A JSON response.
+     *
+     * Encoded through {@see Json::encode()} rather than `json_encode()` directly, so a value that
+     * cannot be encoded raises this library's own exception instead of silently becoming the
+     * string `false` in the body (RFC-0001 R-7 — `JSON_THROW_ON_ERROR` is always on).
+     *
+     * @throws HttpException
+     * @throws \D4np\Utils\Support\JsonException if `$data` cannot be encoded
+     */
+    public static function json(mixed $data, int $status = 200): self
+    {
+        return self::create($status, Json::encode($data))
+            ->withHeader('Content-Type', 'application/json; charset=utf-8');
+    }
+
+    /**
+     * A redirect.
+     *
+     * @throws HttpException if the status is not a 3xx redirect code
+     */
+    public static function redirect(string $location, int $status = 302): self
+    {
+        if ($status < 300 || $status > 399) {
+            throw new HttpException(sprintf(
+                'A redirect needs a 3xx status, got %d. Sending a Location header with a non-3xx '
+                . 'status produces a response most clients will not follow and some will render.',
+                $status,
+            ));
+        }
+
+        return self::create($status)->withHeader('Location', $location);
+    }
+
+    public function status(): int
+    {
+        return $this->status;
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    /**
+     * Every header, keyed by the name as it will be sent.
+     *
+     * @return array<string, string>
+     */
+    public function headers(): array
+    {
+        $out = [];
+
+        foreach ($this->headers as [$name, $value]) {
+            $out[$name] = $value;
+        }
+
+        return $out;
+    }
+
+    /**
+     * One header by case-insensitive name.
+     */
+    public function header(string $name, ?string $default = null): ?string
+    {
+        return $this->headers[strtolower($name)][1] ?? $default;
+    }
+
+    /**
+     * @throws HttpException if the name or value is not a legal header
+     */
+    public function withHeader(string $name, string $value): self
+    {
+        self::assertLegalHeader($name, $value);
+
+        $headers = $this->headers;
+        $headers[strtolower($name)] = [$name, $value];
+
+        return new self($this->status, $headers, $this->body);
+    }
+
+    public function withoutHeader(string $name): self
+    {
+        $headers = $this->headers;
+        unset($headers[strtolower($name)]);
+
+        return new self($this->status, $headers, $this->body);
+    }
+
+    /**
+     * @throws HttpException
+     */
+    public function withStatus(int $status): self
+    {
+        return new self(self::validStatus($status), $this->headers, $this->body);
+    }
+
+    public function withBody(string $body): self
+    {
+        return new self($this->status, $this->headers, $body);
+    }
+
+    /**
+     * Send the status line, headers and body.
+     *
+     * Refuses when output has already begun, because `header()` would emit a warning and be
+     * ignored — leaving a response whose body was sent with somebody else's headers. The check is
+     * `headers_sent()` rather than a `try`, since PHP does not raise here.
+     *
+     * @throws HttpException if headers have already been sent
+     */
+    public function send(): void
+    {
+        if (headers_sent($file, $line)) {
+            throw new HttpException(sprintf(
+                'Cannot send the response: output already started at %s:%d. Whatever was emitted '
+                . 'there has already committed the status and headers, so this response cannot '
+                . 'set them.',
+                $file,
+                $line,
+            ));
+        }
+
+        http_response_code($this->status);
+
+        foreach ($this->headers as [$name, $value]) {
+            header($name . ': ' . $value, true);
+        }
+
+        echo $this->body;
+    }
+
+    /**
+     * @throws HttpException
+     */
+    private static function validStatus(int $status): int
+    {
+        // The range HTTP defines. A three-digit code outside it is not "unusual", it is not a
+        // status code, and passing it through would produce a response no client can classify.
+        if ($status < 100 || $status > 599) {
+            throw new HttpException(sprintf('%d is not a valid HTTP status code (100-599).', $status));
+        }
+
+        return $status;
+    }
+
+    /**
+     * Refuse a header that could split the response.
+     *
+     * A CR or LF in a name or value ends the header line early and lets everything after it be
+     * read as a new header, or as the body — **response splitting**, and the reason a header value
+     * containing user input is dangerous. Modern PHP's `header()` rejects these itself, but this
+     * class validates at the point the value is *set* rather than at the point it is sent, so a
+     * response assembled and inspected in tests fails the same way as one sent to a client.
+     *
+     * A null byte is refused for the same reason: it truncates in C-level consumers that PHP's own
+     * check does not cover.
+     *
+     * @throws HttpException
+     */
+    private static function assertLegalHeader(string $name, string $value): void
+    {
+        if ($name === '' || preg_match('/^[!#$%&\'*+\-.^_`|~0-9A-Za-z]+$/', $name) !== 1) {
+            throw new HttpException(sprintf(
+                'Illegal header name %s. RFC 9110 allows only token characters in a field name.',
+                var_export($name, true),
+            ));
+        }
+
+        if (preg_match('/[\r\n\0]/', $value) === 1) {
+            throw new HttpException(sprintf(
+                'Header %s contains a carriage return, line feed or null byte. That would end the '
+                . 'header line early and let the remainder be read as further headers or as the '
+                . 'body — a response-splitting vector, refused rather than stripped so the caller '
+                . 'finds out their value was not what they thought.',
+                $name,
+            ));
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Http/RequestTest.php
+++ b/src/test/php/d4np/utils/Http/RequestTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http;
+
+use D4np\Utils\Http\Request;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-13's typed superglobal reader.
+ *
+ * The cases that matter most are the ones where an accessor is handed something that is not the
+ * type it names — because that shape is chosen by whoever wrote the query string, not by the
+ * application.
+ */
+#[Group('T-07')]
+final class RequestTest extends TestCase
+{
+    public function testTypedQueryReaders(): void
+    {
+        $request = new Request(query: ['name' => 'Ada', 'n' => '42', 'flag' => 'yes']);
+
+        self::assertSame('Ada', $request->queryString('name'));
+        self::assertSame(42, $request->queryInt('n'));
+        self::assertTrue($request->queryBool('flag'));
+    }
+
+    public function testTypedPostReaders(): void
+    {
+        $request = new Request(post: ['email' => 'a@b.com', 'age' => '30', 'subscribe' => 'off']);
+
+        self::assertSame('a@b.com', $request->postString('email'));
+        self::assertSame(30, $request->postInt('age'));
+        self::assertFalse($request->postBool('subscribe'));
+    }
+
+    public function testAbsentKeysReturnTheDefault(): void
+    {
+        $request = new Request();
+
+        self::assertNull($request->queryString('nope'));
+        self::assertSame('fallback', $request->queryString('nope', 'fallback'));
+        self::assertSame(7, $request->postInt('nope', 7));
+        self::assertTrue($request->queryBool('nope', true));
+    }
+
+    /**
+     * **The parameter-pollution case.** `?email[]=x` gives the same key a different PHP type,
+     * chosen by the client. A `(string)` cast yields the literal `"Array"`; `implode()` invents a
+     * value nobody sent. Both hand attacker-controlled shape to an application that then trusts
+     * it, so a scalar accessor returns its default instead — the honest answer, because a string
+     * is not what arrived.
+     *
+     * @return iterable<string, array{mixed}>
+     */
+    public static function nonScalarValues(): iterable
+    {
+        yield 'list' => [['admin']];
+        yield 'map' => [['role' => 'admin']];
+        yield 'nested' => [[['deep']]];
+        yield 'empty array' => [[]];
+    }
+
+    #[DataProvider('nonScalarValues')]
+    public function testScalarAccessorsRefuseNonScalarsRatherThanCoercingThem(mixed $value): void
+    {
+        $request = new Request(query: ['x' => $value], post: ['x' => $value]);
+
+        self::assertNull($request->queryString('x'));
+        self::assertNull($request->queryInt('x'));
+        self::assertNull($request->queryBool('x'));
+        self::assertNull($request->postString('x'));
+        self::assertSame('safe', $request->queryString('x', 'safe'));
+    }
+
+    /**
+     * `(int) "12abc"` is `12` — a value the client never sent. `FILTER_VALIDATE_INT` refuses
+     * anything that is not wholly an integer.
+     *
+     * @return iterable<string, array{string, int|null}>
+     */
+    public static function integerish(): iterable
+    {
+        yield 'plain' => ['42', 42];
+        yield 'negative' => ['-7', -7];
+        yield 'zero' => ['0', 0];
+        yield 'leading digits then letters' => ['12abc', null];
+        yield 'float string' => ['1.5', null];
+        yield 'empty' => ['', null];
+        yield 'whitespace' => ['  ', null];
+        yield 'hex-looking' => ['0x1A', null];
+        yield 'huge' => ['999999999999999999999999', null];
+    }
+
+    #[DataProvider('integerish')]
+    public function testIntegerReadingRefusesPartialNumbers(string $raw, ?int $expected): void
+    {
+        self::assertSame($expected, (new Request(query: ['n' => $raw]))->queryInt('n'));
+    }
+
+    /**
+     * The classic: an unchecked cast makes the *string* `"false"` true. Same coercion `Env::get()`
+     * uses, for the same reason.
+     *
+     * @return iterable<string, array{string, bool|null}>
+     */
+    public static function booleanish(): iterable
+    {
+        yield 'true' => ['true', true];
+        yield 'string false' => ['false', false];
+        yield '1' => ['1', true];
+        yield '0' => ['0', false];
+        yield 'on' => ['on', true];
+        yield 'off' => ['off', false];
+        yield 'yes' => ['yes', true];
+        yield 'no' => ['no', false];
+        yield 'not boolean-shaped' => ['maybe', null];
+        yield 'numeric but not 0/1' => ['2', null];
+        yield 'case-insensitive' => ['TRUE', true];
+        // PHP's filter treats an empty (and whitespace-only) value as FALSE rather than
+        // "not boolean-shaped" -- verified, and asserted here because it is surprising: `?flag=`
+        // reads as false, not as absent. Following PHP rather than inventing a third answer keeps
+        // this consistent with `Env::get()`, which uses the same filter.
+        yield 'empty is false, not null' => ['', false];
+        yield 'whitespace is false too' => ['  ', false];
+    }
+
+    #[DataProvider('booleanish')]
+    public function testBooleanReadingUsesFilterVarNotACast(string $raw, ?bool $expected): void
+    {
+        self::assertSame($expected, (new Request(query: ['b' => $raw]))->queryBool('b'));
+    }
+
+    /**
+     * A list is available when the caller has *decided* a list is acceptable — which is a
+     * different decision from being handed one unexpectedly.
+     */
+    public function testListReadersReturnListsAndRefuseScalars(): void
+    {
+        $request = new Request(query: ['tag' => ['a', 'b'], 'one' => 'x'], post: ['t' => ['p']]);
+
+        self::assertSame(['a', 'b'], $request->queryList('tag'));
+        self::assertSame(['p'], $request->postList('t'));
+        // A scalar is not silently wrapped into a one-element list: wrapping would erase the
+        // distinction the list readers exist to preserve.
+        self::assertSame([], $request->queryList('one'));
+        self::assertSame([], $request->queryList('absent'));
+    }
+
+    public function testNestedArraysAreSkippedRatherThanFlattenedInLists(): void
+    {
+        $request = new Request(query: ['t' => ['ok', ['deep'], 'also-ok']]);
+
+        self::assertSame(['ok', 'also-ok'], $request->queryList('t'));
+    }
+
+    // ---- request line ---------------------------------------------------------------------------
+
+    public function testMethodIsUpperCasedAndDefaultsToGet(): void
+    {
+        self::assertSame('POST', (new Request(server: ['REQUEST_METHOD' => 'post']))->method());
+        self::assertSame('GET', (new Request())->method());
+    }
+
+    public function testUriIsTheServerReportedTarget(): void
+    {
+        self::assertSame('/a/b?c=1', (new Request(server: ['REQUEST_URI' => '/a/b?c=1']))->uri());
+        self::assertSame('', (new Request())->uri());
+    }
+
+    /**
+     * `$_SERVER['HTTPS']` is the string `'off'` on some servers rather than being absent, so an
+     * `isset()` check reports every such request as secure.
+     */
+    public function testIsSecureHandlesTheOffString(): void
+    {
+        self::assertTrue((new Request(server: ['HTTPS' => 'on']))->isSecure());
+        self::assertTrue((new Request(server: ['HTTPS' => '1']))->isSecure());
+        self::assertFalse((new Request(server: ['HTTPS' => 'off']))->isSecure());
+        self::assertFalse((new Request(server: ['HTTPS' => '']))->isSecure());
+        self::assertFalse((new Request())->isSecure());
+    }
+
+    /**
+     * A forwarded-proto header is client-supplied unless a trusted proxy rewrote it, and this
+     * class cannot know whether one did. Trusting it would let any client claim HTTPS.
+     */
+    public function testIsSecureIgnoresClientSuppliedForwardedHeaders(): void
+    {
+        $request = new Request(server: ['HTTP_X_FORWARDED_PROTO' => 'https']);
+
+        self::assertFalse($request->isSecure());
+    }
+
+    // ---- headers --------------------------------------------------------------------------------
+
+    public function testHeadersComeFromServerAndAreLowerCased(): void
+    {
+        $request = new Request(server: [
+            'HTTP_USER_AGENT' => 'curl/8',
+            'HTTP_X_FORWARDED_FOR' => '203.0.113.1',
+            'REQUEST_METHOD' => 'GET',
+        ]);
+
+        self::assertSame([
+            'user-agent' => 'curl/8',
+            'x-forwarded-for' => '203.0.113.1',
+        ], $request->headers());
+    }
+
+    /**
+     * CGI reports these two without the `HTTP_` prefix, so a prefix-only rule loses them.
+     */
+    public function testContentTypeAndLengthAreFoundWithoutTheHttpPrefix(): void
+    {
+        $request = new Request(server: ['CONTENT_TYPE' => 'application/json', 'CONTENT_LENGTH' => '42']);
+
+        self::assertSame('application/json', $request->header('Content-Type'));
+        self::assertSame('42', $request->header('content-length'));
+    }
+
+    public function testHeaderLookupIsCaseInsensitive(): void
+    {
+        $request = new Request(server: ['HTTP_X_CUSTOM' => 'v']);
+
+        self::assertSame('v', $request->header('X-Custom'));
+        self::assertSame('v', $request->header('x-custom'));
+        self::assertSame('v', $request->header('X-CUSTOM'));
+        self::assertNull($request->header('X-Absent'));
+        self::assertSame('d', $request->header('X-Absent', 'd'));
+    }
+
+    public function testNonHeaderServerKeysAreNotReportedAsHeaders(): void
+    {
+        $request = new Request(server: ['DOCUMENT_ROOT' => '/var/www', 'PATH' => '/usr/bin']);
+
+        self::assertSame([], $request->headers());
+    }
+
+    // ---- files ----------------------------------------------------------------------------------
+
+    public function testFileReturnsTheRawEntryOrNull(): void
+    {
+        $entry = ['name' => 'a.txt', 'tmp_name' => '/tmp/x', 'error' => 0, 'size' => 3];
+        $request = new Request(files: ['doc' => $entry, 'bad' => 'not-an-array']);
+
+        self::assertSame($entry, $request->file('doc'));
+        self::assertNull($request->file('bad'));
+        self::assertNull($request->file('absent'));
+    }
+
+    public function testCookiesAreReadAsStrings(): void
+    {
+        $request = new Request(cookies: ['session' => 'abc', 'weird' => ['a']]);
+
+        self::assertSame('abc', $request->cookie('session'));
+        self::assertNull($request->cookie('weird'));
+    }
+
+    /**
+     * Nothing but `fromGlobals()` touches a superglobal, which is what makes every other method a
+     * pure function of the constructor arguments — and what lets the PSR-7 bridge build one.
+     */
+    public function testFromGlobalsReadsTheSuperglobals(): void
+    {
+        $_GET = ['q' => 'search'];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $request = Request::fromGlobals();
+
+        self::assertSame('search', $request->queryString('q'));
+        self::assertSame('GET', $request->method());
+
+        $_GET = [];
+    }
+}

--- a/src/test/php/d4np/utils/Http/ResponseTest.php
+++ b/src/test/php/d4np/utils/Http/ResponseTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http;
+
+use D4np\Utils\Http\Response;
+use D4np\Utils\Support\HttpException;
+use D4np\Utils\Support\JsonException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-14's response helpers.
+ *
+ * The load-bearing cases are header handling: case-insensitive names that must not become
+ * duplicates, and the CR/LF refusal that stops response splitting.
+ */
+#[Group('T-07')]
+final class ResponseTest extends TestCase
+{
+    public function testCreateCarriesStatusAndBody(): void
+    {
+        $response = Response::create(201, 'made');
+
+        self::assertSame(201, $response->status());
+        self::assertSame('made', $response->body());
+        self::assertSame([], $response->headers());
+    }
+
+    public function testTextSetsAPlainContentType(): void
+    {
+        $response = Response::text('hi');
+
+        self::assertSame(200, $response->status());
+        self::assertSame('hi', $response->body());
+        self::assertSame('text/plain; charset=utf-8', $response->header('Content-Type'));
+    }
+
+    public function testHtmlSetsAnHtmlContentType(): void
+    {
+        self::assertSame('text/html; charset=utf-8', Response::html('<p>x</p>')->header('content-type'));
+    }
+
+    /**
+     * The body is deliberately **not** escaped: escaping is a render-time decision that depends on
+     * where each value lands (ADR-0019's four contexts), and a blanket pass over an assembled
+     * document would corrupt the markup it is meant to carry.
+     */
+    public function testHtmlDoesNotEscapeTheBody(): void
+    {
+        self::assertSame('<p>kept</p>', Response::html('<p>kept</p>')->body());
+    }
+
+    public function testJsonEncodesAndSetsTheContentType(): void
+    {
+        $response = Response::json(['ok' => true, 'n' => 1]);
+
+        self::assertSame('{"ok":true,"n":1}', $response->body());
+        self::assertSame('application/json; charset=utf-8', $response->header('Content-Type'));
+    }
+
+    /**
+     * Encoded through `Json::encode()`, so an unencodable value raises rather than silently
+     * producing the string `false` in the body (RFC-0001 R-7).
+     */
+    public function testJsonRaisesRatherThanEmittingAFalsyBody(): void
+    {
+        $this->expectException(JsonException::class);
+
+        Response::json(NAN);
+    }
+
+    public function testRedirectSetsLocationAndDefaultsTo302(): void
+    {
+        $response = Response::redirect('/next');
+
+        self::assertSame(302, $response->status());
+        self::assertSame('/next', $response->header('Location'));
+    }
+
+    public function testRedirectRefusesANonRedirectStatus(): void
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/3xx/');
+
+        Response::redirect('/next', 200);
+    }
+
+    // ---- status validation -----------------------------------------------------------------------
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function illegalStatuses(): iterable
+    {
+        yield 'below the range' => [99];
+        yield 'above the range' => [600];
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
+        yield 'four digits' => [1000];
+    }
+
+    #[DataProvider('illegalStatuses')]
+    public function testAStatusOutsideTheHttpRangeIsRefused(int $status): void
+    {
+        $this->expectException(HttpException::class);
+
+        Response::create($status);
+    }
+
+    public function testTheStatusRangeBoundariesAreAccepted(): void
+    {
+        self::assertSame(100, Response::create(100)->status());
+        self::assertSame(599, Response::create(599)->status());
+    }
+
+    // ---- headers ---------------------------------------------------------------------------------
+
+    /**
+     * HTTP header names are case-insensitive (RFC 9110), so these must not become two headers — a
+     * duplicated `Content-Type` is how a response smuggles a second interpretation past a proxy.
+     */
+    public function testHeaderNamesAreCaseInsensitiveAndDoNotDuplicate(): void
+    {
+        $response = Response::create()
+            ->withHeader('Content-Type', 'text/plain')
+            ->withHeader('content-type', 'application/json');
+
+        self::assertCount(1, $response->headers());
+        self::assertSame('application/json', $response->header('CONTENT-TYPE'));
+    }
+
+    /**
+     * Some clients are, in practice, less tolerant than the specification, so the spelling the
+     * caller chose is what gets sent.
+     */
+    public function testTheOriginalHeaderCasingIsPreservedForOutput(): void
+    {
+        $headers = Response::create()->withHeader('X-Custom-Thing', 'v')->headers();
+
+        self::assertArrayHasKey('X-Custom-Thing', $headers);
+    }
+
+    public function testWithoutHeaderRemovesCaseInsensitively(): void
+    {
+        $response = Response::create()->withHeader('X-A', '1')->withoutHeader('x-a');
+
+        self::assertSame([], $response->headers());
+    }
+
+    /**
+     * **Response splitting.** A CR or LF in a header value ends the line early and lets the
+     * remainder be read as further headers or as the body. Refused rather than stripped, so a
+     * caller finds out their value was not what they thought.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function splittingValues(): iterable
+    {
+        yield 'CRLF then header' => ["v\r\nX-Injected: 1"];
+        yield 'LF only' => ["v\nX-Injected: 1"];
+        yield 'CR only' => ["v\rX-Injected: 1"];
+        yield 'null byte' => ["v\0truncated"];
+        yield 'CRLF CRLF into body' => ["v\r\n\r\n<script>alert(1)</script>"];
+    }
+
+    #[DataProvider('splittingValues')]
+    public function testHeaderValuesThatCouldSplitTheResponseAreRefused(string $value): void
+    {
+        $this->expectException(HttpException::class);
+
+        Response::create()->withHeader('X-Test', $value);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function illegalNames(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'with space' => ['X Custom'];
+        yield 'with colon' => ['X:Custom'];
+        yield 'with newline' => ["X\nCustom"];
+        yield 'with non-token char' => ['X-Cust(om)'];
+    }
+
+    #[DataProvider('illegalNames')]
+    public function testIllegalHeaderNamesAreRefused(string $name): void
+    {
+        $this->expectException(HttpException::class);
+
+        Response::create()->withHeader($name, 'v');
+    }
+
+    public function testTokenCharactersAreAcceptedInNames(): void
+    {
+        $response = Response::create()->withHeader('X-Custom_Thing.1', 'v');
+
+        self::assertSame('v', $response->header('x-custom_thing.1'));
+    }
+
+    // ---- immutability ------------------------------------------------------------------------------
+
+    /**
+     * A response is built in stages, often across layers. The alternative to immutability is an
+     * object a helper can change behind its caller's back.
+     */
+    public function testEveryWitherReturnsANewInstanceAndLeavesTheOriginalAlone(): void
+    {
+        $base = Response::create(200, 'body');
+
+        $withHeader = $base->withHeader('X-A', '1');
+        $withStatus = $base->withStatus(404);
+        $withBody = $base->withBody('other');
+        $without = $withHeader->withoutHeader('X-A');
+
+        self::assertNotSame($base, $withHeader);
+        self::assertSame([], $base->headers());
+        self::assertSame(200, $base->status());
+        self::assertSame('body', $base->body());
+
+        self::assertSame('1', $withHeader->header('X-A'));
+        self::assertSame(404, $withStatus->status());
+        self::assertSame('other', $withBody->body());
+        self::assertSame([], $without->headers());
+    }
+
+    public function testWithStatusValidatesToo(): void
+    {
+        $this->expectException(HttpException::class);
+
+        Response::create()->withStatus(700);
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item 6.1 (spec FR-13, FR-14), **opening Milestone 6**. Native lightweight wrappers mirroring PSR-7's naming **without its types**, per RFC-0001 §Alternatives 3 and imported ADR-002 — the optional `egl/utils-psr7-bridge` is the only sanctioned crossing point, and these never grow middleware ambitions.

## The decision the item turns on

`?email=x` gives a string. `?email[]=x` gives an **array**. Same key, different PHP type, and **the client chose which** — that's the parameter-pollution family in one line.

Both obvious handlings are wrong:
- `(string)` cast → emits *"Array to string conversion"*, yields the literal `"Array"`
- `implode()` → invents a value nobody sent

Each converts attacker-controlled **shape** into a value the application then trusts. So a scalar accessor handed a non-scalar returns its **default** — the honest answer, because a string is not what arrived.

Same reasoning one level down: `queryInt()` uses `FILTER_VALIDATE_INT`, not a cast, since `(int) "12abc"` is `12`. `queryList()`/`postList()` exist for when a list *is* expected, and refuse scalars rather than wrapping them.

## Probes that changed the design

| probe | result | consequence |
|---|---|---|
| `?role[]=admin` | array | the refusal above |
| `getallheaders()` | **not defined** here | headers from `$_SERVER`, one path not two |
| `?0=zero` | **integer** array key | my type annotation was a lie |
| `filter_var('', BOOLEAN, NULL_ON_FAILURE)` | **`false`**, not `null` | `?flag=` is false, not absent |

The last caught a test asserting my *assumption* rather than PHP's behaviour. Corrected and documented in the code — following PHP rather than inventing a third answer also keeps this consistent with `Env::get()`.

**PHPStan rejected an annotation that was a lie**: superglobals were declared `array<string, mixed>`, but `?0=zero` produces an integer key. The error wasn't "this code is wrong" but "this *claim about the code* is wrong" — casting it away would have kept the lie and silenced the messenger.

## ⚠️ A probe that passed for the wrong reason

| planted | failures |
|---|---|
| scalar accessors flatten arrays | 6 |
| `queryInt` uses a cast | 6 |
| header names stored case-sensitively | 8 |
| **CR/LF check removed** | **0 — passed** |

That should obviously have failed. It wasn't a weak test: **the string replacement never matched the source, so the probe never applied.** A passing probe that didn't run is not a weak test — it's no test at all. Re-ran against the verified line: 4 failures, as expected.

I'd noted in item 5.4 that "a probe that doesn't fail is evidence about the code *or* about the claim". This adds a third case, and the practical lesson is narrow: **verify the probe landed before believing it**, especially when it's reassuring.

## Smaller decisions

- **`isSecure()` ignores `X-Forwarded-Proto`** — client-supplied absent a trusted proxy, and this class can't know whether one exists. It *does* handle `$_SERVER['HTTPS']` being the string `'off'`, where `isset()` would report every request as secure.
- **Header values validated at `withHeader()`, not `send()`** — so a response assembled in a test fails the same way as one sent to a client. CR/LF/NUL refused, not stripped (response splitting).
- **Header names case-insensitive but keep their spelling** — a duplicated `Content-Type` is how a response smuggles a second interpretation past a proxy.
- **`Response::html()` escapes nothing** (render-time decision, ADR-0019); `json()` goes through `Json::encode()` so an unencodable value raises instead of putting `false` in the body.
- **`Request` has no withers, `Response` does** — a response is built in stages across layers; a request is only read, and withers would edge toward the middleware ambitions RFC-0001 warned against.

## Test plan

- [x] `vendor/bin/phpunit` — 1109 tests, 2475 assertions, 7 skipped
- [x] `--group T-07` runs 72
- [x] PHPStan max clean · deptrac 0/0 · consistency + action-pin lints OK
- [ ] CI

Route mismatch recorded (`fast/low` routed, standard session) — above the route rather than below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)