### PR TITLE
feat(http): hardened Session and CSPRNG CsrfToken with constant-time validation

### DIFF
--- a/.eados-core/learning/runs/2026-08-05-utils-2.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils-2.yaml
@@ -1,0 +1,38 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "failed"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures:
+  - gate: "coverage-floor"
+    message: "ADR-0007's 90% floor failed at 89.59%; Http\\Session 61.54%. start()/regenerate() had been written up in ADR-0026 as an acceptable gap owned by item 6.3, on the true premise that PHP returns false from every session function in CLI. The gate refused the writeup and was right to: the gap hid an unasserted correctness rule, not just uncovered lines — start() must apply the cookie parameters BEFORE session_start(), and both orderings yield a working session, so the wrong one ships a cookie without FR-15's three flags and no behavioural test can see it."
+rubric: {}
+route_mismatch:
+  routed: "frontier-reasoning/extra"
+  session: "standard"

--- a/.eados-core/learning/runs/2026-08-05-utils-3.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils-3.yaml
@@ -1,0 +1,36 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}
+route_mismatch:
+  routed: "frontier-reasoning/extra"
+  session: "standard"

--- a/.eados-core/learning/runs/2026-08-05-utils.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils.yaml
@@ -1,0 +1,36 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}
+route_mismatch:
+  routed: "frontier-reasoning/extra"
+  session: "standard"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,27 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- `D4np\Utils\Http\Session`, `CsrfToken`, `SameSite` and the `SessionStore` interface
+  (**ADR-0026**) — spec FR-12 and FR-15. `Session` applies `httponly`, `secure` and
+  `samesite=Lax` before starting, and `regenerate()` wraps `session_regenerate_id(true)` — the
+  `true` being the half that closes session fixation, since without it the old identifier keeps
+  working. `CsrfToken` issues 32 CSPRNG bytes per scope and compares with `hash_equals()`.
+  **The cookie policy is exposed as a value** (`cookieParams()`) and `CsrfToken` depends on a
+  three-method `SessionStore` rather than `$_SESSION`, because PHP will not run a session in CLI —
+  `session_start()`, `session_set_cookie_params()` and `session_regenerate_id()` all return
+  `false` — so without those seams FR-15's flags and all of CSRF validation would have had no unit
+  assertion at all.
+  `secure` defaults to `true` with an explicit named opt-out for local `http://` development,
+  rather than auto-detection from `$_SERVER['HTTPS']` which would silently disable the flag behind
+  a misconfigured proxy. `httponly` has **no** opt-out. `SameSite` is an enum, so an illegal value
+  is a compile-time impossibility; `None` without `Secure` is refused at construction, because
+  browsers drop that combination entirely.
+  A token is issued **once per scope and reused** — regenerating per render would invalidate the
+  token in another open tab — with `rotate()` as the explicit call for a privilege transition.
+  Scope names are validated: a scope becomes a session-storage key, so one taken from user input
+  would let a client grow the session record one key per request.
+  **Known gap:** `start()` and `regenerate()` have no unit coverage and cannot — roadmap item 6.3's
+  `php -S` integration suite owns their behaviour.
 - `D4np\Utils\Http\Request` and `D4np\Utils\Http\Response` (**ADR-0025**) — opens Milestone 6.
   Native lightweight wrappers **mirroring PSR-7's naming without its types**, per RFC-0001: the
   optional `egl/utils-psr7-bridge` is the only sanctioned crossing point, and these never grow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,8 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
-- `D4np\Utils\Http\Session`, `CsrfToken`, `SameSite` and the `SessionStore` interface
+- `D4np\Utils\Http\Session`, `CsrfToken`, `SameSite`, and the `SessionStore` / `SessionApi`
+  interfaces with `NativeSessionApi`
   (**ADR-0026**) — spec FR-12 and FR-15. `Session` applies `httponly`, `secure` and
   `samesite=Lax` before starting, and `regenerate()` wraps `session_regenerate_id(true)` — the
   `true` being the half that closes session fixation, since without it the old identifier keeps
@@ -166,8 +167,15 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   token in another open tab — with `rotate()` as the explicit call for a privilege transition.
   Scope names are validated: a scope becomes a session-storage key, so one taken from user input
   would let a client grow the session record one key per request.
-  **Known gap:** `start()` and `regenerate()` have no unit coverage and cannot — roadmap item 6.3's
-  `php -S` integration suite owns their behaviour.
+  PHP's session functions themselves sit behind a third seam, `SessionApi` (**ADR-0026 §8**), whose
+  `NativeSessionApi` default is five single-statement delegations. That exists for one property
+  behaviour cannot see: the cookie parameters must be applied **before** the session starts, since
+  `session_set_cookie_params()` has no effect afterwards. Get it wrong and the session still works
+  perfectly — with a cookie carrying none of FR-15's flags. Only the call sequence distinguishes the
+  two, so a fake asserts the sequence.
+  **Known gap:** that a real browser cookie carries the flags, and that a real identifier changes
+  across `regenerate()`, remain behavioural — roadmap item 6.3's `php -S` integration suite owns
+  them.
 - `D4np\Utils\Http\Request` and `D4np\Utils\Http\Response` (**ADR-0025**) — opens Milestone 6.
   Native lightweight wrappers **mirroring PSR-7's naming without its types**, per RFC-0001: the
   optional `egl/utils-psr7-bridge` is the only sanctioned crossing point, and these never grow

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-04 — The client picks the type, not the application](docs/journal/2026/08/2026-08-04-http-wrappers.md).
+  [2026-08-05 — A probe that passed, and this time it was the code](docs/journal/2026/08/2026-08-05-session-csrf.md).
 
 ## Model & effort routing (advisory)
 
@@ -358,8 +358,18 @@ The application-facing groups (RFC-0001).
       (response splitting) **at set time, not send time**, and stores names case-insensitively so a
       duplicate `Content-Type` cannot be smuggled past a proxy. PHPStan caught a type annotation
       that was a lie: `?0=zero` yields an **integer** key, so superglobals are `array<array-key>`.*
-- [ ] 6.2 `Session` hardening + `regenerate()`; `CsrfToken` — CSPRNG, `hash_equals`, per-form
+- [x] 6.2 `Session` hardening + `regenerate()`; `CsrfToken` — CSPRNG, `hash_equals`, per-form
       scoping; Http placement per RFC-0001 R-1 (security) — route: frontier-reasoning / extra
+      *(run at standard tier; mismatch recorded)* · **ADR-0026**. *One probe shaped the item: PHP
+      will not run a session in CLI — `session_start()`, `session_set_cookie_params()` and
+      `session_regenerate_id()` **all return `false`** — so the cookie policy is exposed as a pure
+      **value** (`cookieParams()`) and `CsrfToken` takes a `SessionStore` seam, or FR-15's flags
+      and all of CSRF validation would have had no unit assertion at all. **The finding:** replacing
+      `hash_equals()` with `===` **passed the entire suite** — they return identical values and
+      differ only in timing, so no behavioural test can see it. Now asserted as a **mechanism**
+      (item 4.6's pattern). `SameSite` became an enum after PHPStan rejected a validated string —
+      ADR-0015's reasoning, reached from the other direction. Honest gap: `start()`/`regenerate()`
+      remain uncoverable here; item 6.3's `php -S` suite owns them.*
 - [ ] 6.3 T-03 session/CSRF integration suite against a real `php -S` process (RFC-0001)
       (security) — route: frontier-reasoning / extra
 - [ ] 6.4 `Container` (PSR-11) + `ServiceProvider`; NFR-02 benchmarks (RFC-0001, imported

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -368,8 +368,12 @@ The application-facing groups (RFC-0001).
       `hash_equals()` with `===` **passed the entire suite** — they return identical values and
       differ only in timing, so no behavioural test can see it. Now asserted as a **mechanism**
       (item 4.6's pattern). `SameSite` became an enum after PHPStan rejected a validated string —
-      ADR-0015's reasoning, reached from the other direction. Honest gap: `start()`/`regenerate()`
-      remain uncoverable here; item 6.3's `php -S` suite owns them.*
+      ADR-0015's reasoning, reached from the other direction. **Then the coverage gate found the
+      same shape a second time:** `start()` must apply the cookie parameters **before** starting,
+      and both orderings produce a working session — the wrong one just ships a cookie with none of
+      FR-15's flags. Nothing observable separates them, so the session functions moved behind a
+      `SessionApi` seam and a fake asserts the call sequence (**§8**). Honest gap remaining is
+      genuinely behavioural — a real cookie, a real identifier — and item 6.3 owns it.*
 - [ ] 6.3 T-03 session/CSRF integration suite against a real `php -S` process (RFC-0001)
       (security) — route: frontier-reasoning / extra
 - [ ] 6.4 `Container` (PSR-11) + `ServiceProvider`; NFR-02 benchmarks (RFC-0001, imported

--- a/docs/adr/0026-session-hardening-as-a-value-and-csrf-through-a-seam.md
+++ b/docs/adr/0026-session-hardening-as-a-value-and-csrf-through-a-seam.md
@@ -102,6 +102,36 @@ method's own source. That is the pattern roadmap item **4.6** settled when a sav
 measurement noise floor: *when a property cannot be observed in behaviour, assert the thing that
 produces it rather than pretending a behavioural test covers it.* Re-running the probe now fails.
 
+### 8. The session functions come through a `SessionApi` seam — which the coverage gate forced, and was right to
+
+§1 stopped half way. Making the cookie policy a value covered the *policy* and left `start()`,
+`regenerate()` and `destroy()` — every guard, every error path, and the ordering rule — with no
+unit coverage at all. That was written up in this ADR's first revision as an acceptable gap owned by
+item 6.3. The coverage gate then failed the branch at **89.59%**, and re-reading the gap showed it
+was not only a coverage hole:
+
+> `session_set_cookie_params()` has no effect once the session has started.
+
+Apply the parameters after starting and **everything still works**. A session is created, values
+round-trip, every existing assertion passes — and the cookie went out with none of the three flags
+FR-15 exists to pin. Both orderings produce a working session, so no assertion on the *outcome* can
+tell them apart. This is §7's situation exactly, in a second place: a load-bearing property that
+behaviour cannot see. The ADR called the ordering *"not optional"* and nothing tested it.
+
+So `SessionApi` — five methods, no behaviour — with `NativeSessionApi` delegating to PHP and
+nothing else. `Session` keeps the guards, the ordering and the error mapping, and a fake records the
+call sequence. The interface is justified the same way §2 justifies `SessionStore`, and passes
+ADR-0006's test that an interface waits for a consumer to need it: the consumer arrived.
+
+What stays uncovered is `NativeSessionApi` itself, and that is the point of the split — five
+single-statement delegations with no branch, ordering or error handling, small enough that there is
+nothing in them to get wrong. Item 6.3 exercises them against a real server.
+
+**Two probes, both caught.** Swapping the order in `start()` fails 3 tests where it previously
+failed none. Weakening `session_regenerate_id(true)` to `session_regenerate_id()` — which renames
+the session while leaving the old identifier valid, the half of session fixation that matters —
+fails 1.
+
 ## Alternatives Considered
 
 - **`CsrfToken` reading `$_SESSION` directly** — rejected: it makes the security-critical logic
@@ -119,20 +149,34 @@ produces it rather than pretending a behavioural test covers it.* Re-running the
 - **Accepting that `hash_equals` is untestable and documenting the gap** — rejected. That was the
   first instinct, and item 5.3 already showed where it leads: a gap written up as acceptable is a
   gap nobody closes. The mechanism assertion is crude but deterministic.
+- **Leaving `start()`/`regenerate()` uncovered and lowering the 90% floor, or marking them
+  `@codeCoverageIgnore`** — rejected in §8, and this is the third time the same pair of easy exits
+  has presented itself. Lowering the floor is the precise failure this project's discipline exists
+  to prevent; an ignore annotation would have hidden the session-fixation defence from measurement
+  altogether. Both would also have left the ordering rule unasserted, which turned out to be the
+  real cost.
+- **`Session` made non-final so a test double could override the session calls** — rejected: it
+  opens the class to subclassing everywhere to serve one test, where an injected seam is visible in
+  the signature and costs nothing at runtime.
+- **Testing only `start()`'s CLI failure path**, which *is* reachable (`session_set_cookie_params()`
+  returns `false`, so it throws) — rejected as a coverage fix dressed as a test. It would have
+  cleared the floor by 0.03% and asserted nothing about the ordering.
 - **Capping the number of stored per-scope tokens** — rejected in favour of validating the scope
   name: a cap would silently invalidate live tokens, where a refusal names the actual mistake.
 
 ## Consequences
 
-- 51 tests across the three classes; `--group T-03` runs 48. Total 1157.
+- 69 tests across the six classes; `--group T-03` runs 66. Total 1175.
 - **Verified non-vacuous**: a predictable token (5 failures), scope validation removed (14),
-  `httponly` off (2), and — after §7 — `hash_equals` → `===` (1, where it previously caught
-  nothing).
-- **`Session::start()` and `regenerate()` have no unit coverage**, and cannot: PHP refuses to run a
-  session in CLI. The cookie *policy* is covered; the *behaviour* — that the cookie really carries
-  the flags, that the identifier really changes across `regenerate()` — belongs to item **6.3**'s
-  `php -S` suite. Named here, in the class docblock, and in the test file rather than left as a
-  silent hole.
+  `httponly` off (2), `hash_equals` → `===` (1, where it previously caught nothing, §7), the
+  `start()` ordering swapped (3, likewise, §8) and `session_regenerate_id(true)` weakened to
+  `session_regenerate_id()` (1, §8).
+- **`Session` is now fully covered**, including the ordering rule, both `start()` failure paths and
+  the session-fixation guard. What remains uncovered is `NativeSessionApi`'s five delegations,
+  which contain no logic by construction.
+- Still outside the unit suite, and genuinely behavioural: that a real browser cookie carries the
+  flags, and that a real identifier changes across `regenerate()`. That is item **6.3**'s `php -S`
+  suite. Named here, in the class docblock and in the test file rather than left silent.
 - `Session` implements `SessionStore`, so the production wiring is `new CsrfToken(new Session())`
   with no adapter.
 - `destroy()` deliberately does not expire the cookie: writing headers is a `Response` concern, and

--- a/docs/adr/0026-session-hardening-as-a-value-and-csrf-through-a-seam.md
+++ b/docs/adr/0026-session-hardening-as-a-value-and-csrf-through-a-seam.md
@@ -1,0 +1,149 @@
+# ADR-0026: Session hardening as a value, CSRF through a seam, and a mechanism asserted because behaviour cannot see it
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 6.2 · spec FR-12, FR-15, §7 T-03 · item **6.3** (the `php -S`
+  integration suite this item depends on) · [RFC-0001](../rfc/0001-egl-utils-library.md) R-1
+  (placement) · [ADR-0022](0022-argon2id-by-default-with-a-fallback-decided-at-construction.md)
+  (the same "make the policy a value" move) ·
+  [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) (closed keyword
+  types) · [ADR-0025](0025-typed-http-wrappers-that-refuse-rather-than-coerce.md) ·
+  [ADR-0006](0006-shared-reflection-metadata-cache.md) (which refused an interface until a
+  consumer needed one)
+
+## Context
+
+Spec FR-15 asks for *"cookie_httponly, cookie_secure, cookie_samesite=Lax at start; regenerate()
+wraps session_regenerate_id(true)"*, and FR-12 for *"CSPRNG token generation + constant-time
+validation (hash_equals), per-session storage, optional per-form scoping"* — the latter placed in
+`Http` by RFC-0001's R-1 note.
+
+One probe determined the entire shape of this item:
+
+| probe | result |
+|---|---|
+| `session_start()` in CLI | **`false`** |
+| `session_set_cookie_params()` in CLI | **`false`** |
+| `session_regenerate_id(true)` in CLI | **`false`** |
+
+**Nothing about a live session can be exercised in the unit suite.** Left alone, that would mean
+FR-15's three flags and the whole of CSRF validation had no unit assertion at all — everything
+resting on item 6.3's integration suite. For CSRF validation in particular that is the wrong place
+for the only coverage to live.
+
+## Decision
+
+### 1. The cookie policy is a **value**, not a side effect
+
+`Session::cookieParams()` returns exactly what `start()` will apply and is a pure function of the
+constructor arguments. FR-15's three flags become assertable without a live session.
+
+This is the same move ADR-0022 made when `defined('PASSWORD_ARGON2ID')` put the bcrypt-fallback
+branch out of reach: separate the **decision** from the **I/O**, test the decision, keep the I/O
+thin enough to be covered by an integration suite.
+
+### 2. `CsrfToken` depends on a three-method `SessionStore`, not on `$_SESSION`
+
+The seam exists for one reason — testability of security-critical logic that PHP otherwise makes
+untestable. ADR-0006 refused an interface for the reflection cache because no consumer needed one;
+here a consumer does, and the interface is kept no wider than that need.
+
+### 3. `secure` defaults to `true`; the opt-out is explicit and narrow
+
+A `Secure` cookie over plain HTTP is never sent, so local development on `http://localhost` would
+appear to have no session at all. That is a real need, and the honest answer is a named constructor
+argument — **not** auto-detection from `$_SERVER['HTTPS']`, which would silently disable the flag
+on any deployment behind a misconfigured proxy. Same shape as `Hash`'s `bcryptFallback`: safe by
+default, opt out on purpose, visible in the wiring.
+
+`httponly` has **no** opt-out. No legitimate caller needs the session identifier readable from
+JavaScript, and offering the switch would be offering the vulnerability.
+
+`SameSite` defaults to `Lax` rather than `Strict` because `Strict` also withholds the cookie from
+ordinary inbound links — a logged-in user following one from an email arrives logged out, which is
+the kind of breakage that gets a security control switched off entirely.
+
+### 4. `SameSite` is an enum, which PHPStan pushed us toward and ADR-0015 had already argued for
+
+It began as a validated `string`. PHPStan at max rejected it: `session_set_cookie_params()` is
+itself typed against a literal union. A closed keyword set reaching a security-relevant output is
+exactly what ADR-0015 made `Sort` and `Operator` enums for, so the same answer applies —
+an illegal value becomes a compile-time impossibility instead of a runtime check.
+
+The one constraint the type system *cannot* express spans two arguments: browsers **drop** a
+`SameSite=None` cookie that is not `Secure`. That stays a constructor check, so the
+misconfiguration surfaces at wiring time rather than as "sessions do not work".
+
+### 5. A token is issued **once per scope** and reused
+
+Regenerating on every render would invalidate the token already sitting in another open tab, and
+the usual response to that — users retrying until it works — trains people to ignore the failure
+this protects them with. `rotate()` is the explicit call for a privilege transition, where any
+token issued to the previous identity *should* stop working.
+
+### 6. Scope names are validated, which is a storage decision as much as a security one
+
+A scope becomes a session-storage key, so a scope taken from user input would let a client grow the
+session record one key per request. Scopes are application-chosen labels; anything that does not
+look like one is refused rather than trusting every caller to have remembered.
+
+### 7. Constant-time comparison is asserted **as a mechanism**, because behaviour cannot see it
+
+`hash_equals($a, $b)` and `$a === $b` return **identical values for every input**. They differ only
+in timing, so no functional assertion can distinguish them — and a PHP-level timing assertion is
+too noisy to be anything but flaky.
+
+This is not a theory. Replacing `hash_equals()` with `===` was planted as a probe and **the whole
+suite passed**. The single most important line in CSRF validation was unasserted.
+
+So `testValidationComparesInConstantTime()` asserts the mechanism directly, via reflection over the
+method's own source. That is the pattern roadmap item **4.6** settled when a saving sat under the
+measurement noise floor: *when a property cannot be observed in behaviour, assert the thing that
+produces it rather than pretending a behavioural test covers it.* Re-running the probe now fails.
+
+## Alternatives Considered
+
+- **`CsrfToken` reading `$_SESSION` directly** — rejected: it makes the security-critical logic
+  untestable outside an integration suite, for no gain.
+- **Auto-detecting `secure` from `$_SERVER['HTTPS']`** — rejected in §3: it silently disables the
+  flag exactly where a proxy is misconfigured, which is where it is most needed.
+- **An `httponly` option** — rejected in §3.
+- **`SameSite=Strict` as the default** — rejected in §3; a control that breaks email links gets
+  switched off.
+- **Accepting lower-case `lax`/`strict`/`none`** (PHP allows them) — rejected: two spellings of one
+  policy is a distinction with no meaning.
+- **Rotating the token on every successful `validate()`** — rejected in §5: it breaks the second of
+  two open tabs.
+- **A timing-based test for constant-time comparison** — rejected in §7 as inherently flaky.
+- **Accepting that `hash_equals` is untestable and documenting the gap** — rejected. That was the
+  first instinct, and item 5.3 already showed where it leads: a gap written up as acceptable is a
+  gap nobody closes. The mechanism assertion is crude but deterministic.
+- **Capping the number of stored per-scope tokens** — rejected in favour of validating the scope
+  name: a cap would silently invalidate live tokens, where a refusal names the actual mistake.
+
+## Consequences
+
+- 51 tests across the three classes; `--group T-03` runs 48. Total 1157.
+- **Verified non-vacuous**: a predictable token (5 failures), scope validation removed (14),
+  `httponly` off (2), and — after §7 — `hash_equals` → `===` (1, where it previously caught
+  nothing).
+- **`Session::start()` and `regenerate()` have no unit coverage**, and cannot: PHP refuses to run a
+  session in CLI. The cookie *policy* is covered; the *behaviour* — that the cookie really carries
+  the flags, that the identifier really changes across `regenerate()` — belongs to item **6.3**'s
+  `php -S` suite. Named here, in the class docblock, and in the test file rather than left as a
+  silent hole.
+- `Session` implements `SessionStore`, so the production wiring is `new CsrfToken(new Session())`
+  with no adapter.
+- `destroy()` deliberately does not expire the cookie: writing headers is a `Response` concern, and
+  this class does not write headers.
+
+## References
+
+- Spec FR-12, FR-15, §7 T-03; RFC-0001 R-1 (why CSRF lives in `Http`)
+- ADR-0022 — separating a policy from its I/O so the policy can be tested
+- ADR-0015 — closed keyword types instead of validated strings
+- ADR-0006 — the interface deferred until a consumer needed it; this is that consumer
+- Item 4.6 — assert the mechanism when the property is invisible to behaviour
+- Verified directly on PHP 8.3.1: `session_start()`, `session_set_cookie_params()` and
+  `session_regenerate_id()` all returning `false` in CLI

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0023](0023-snapshot-for-drift-invariants-for-safety-idempotence-for-mxss.md) | Snapshots catch drift, invariants catch wrong, and idempotence catches mutation XSS | Accepted |
 | [0024](0024-assert-the-work-factor-not-the-wall-clock.md) | Assert the work factor, not the wall clock — NFR-05 split by what each half can actually prove | Accepted |
 | [0025](0025-typed-http-wrappers-that-refuse-rather-than-coerce.md) | HTTP wrappers that mirror PSR-7's naming, and refuse rather than coerce | Accepted |
+| [0026](0026-session-hardening-as-a-value-and-csrf-through-a-seam.md) | Session hardening as a value, CSRF through a seam, and a mechanism asserted because behaviour cannot see it | Accepted |

--- a/docs/journal/2026/08/2026-08-05-session-csrf.md
+++ b/docs/journal/2026/08/2026-08-05-session-csrf.md
@@ -1,0 +1,112 @@
+# 2026-08-05 — A probe that passed, and this time it was the code
+
+Roadmap item **6.2**. Route `frontier-reasoning / extra`, session Opus 5 (standard) — the same
+mismatch the maintainer accepted at 5.3 and which 5.4/5.5 ran under. Recorded, proceeded on that
+precedent rather than asking a fourth time.
+
+## One probe shaped the whole item
+
+```
+session_start()             -> false
+session_set_cookie_params() -> false
+session_regenerate_id(true) -> false
+```
+
+PHP will not run a session in CLI. **Nothing about a live session is testable in the unit suite.**
+
+Left alone that means FR-15's three cookie flags and the entirety of CSRF validation have no unit
+assertion — all of it resting on item 6.3's `php -S` integration suite. For CSRF validation
+especially, that's the wrong place for the only coverage to live.
+
+So, two structural moves, both borrowed from decisions this project already made:
+
+- **The cookie policy is a value.** `cookieParams()` returns exactly what `start()` will apply and
+  is pure. FR-15's flags become assertable without a session. Same move as ADR-0022's
+  `selectAlgorithm()` when `defined()` put a branch out of reach: separate the *decision* from the
+  *I/O*, test the decision, keep the I/O thin.
+- **`CsrfToken` takes a `SessionStore`**, not `$_SESSION`. ADR-0006 refused an interface for the
+  reflection cache because no consumer needed one. Here one does.
+
+## The finding
+
+Four planted defects:
+
+| planted | failures |
+|---|---|
+| predictable token (constant) | 5 |
+| scope validation removed | 14 |
+| `httponly` turned off | 2 |
+| **`hash_equals()` → `===`** | **0 — passed** |
+
+The last one is the single most important line in CSRF validation, and the whole suite passed
+without it.
+
+Not a probe that failed to apply this time — I checked, the marker was present and the edit landed.
+It passed because **`hash_equals($a, $b)` and `$a === $b` return identical values for every input.**
+They differ only in *how long they take*. No functional assertion can distinguish them, and a
+PHP-level timing assertion is too noisy to be anything but flaky.
+
+I nearly wrote this up as an accepted gap. Item 5.3 is why I didn't: there I documented an
+untestable branch as acceptable, moved on, and the coverage gate dragged me back to actually solve
+it. A gap written up as acceptable is a gap nobody closes.
+
+So the mechanism is asserted directly — reflection over `validate()`'s own source, checking it
+calls `hash_equals` and doesn't compare the tokens with `===`. Crude, and deterministic. It's
+item **4.6**'s pattern restated: *when a property can't be observed in behaviour, assert the thing
+that produces it.* There I counted driver lookups because the timing was under the noise floor;
+here the timing difference is the entire point and still unobservable. Re-ran the probe: it fails
+now.
+
+Three occurrences of this shape in three items — 4.6 (sub-noise saving), 5.3 (unreachable branch),
+6.2 (timing-only property) — is enough that it's a pattern rather than three coincidences.
+
+## PHPStan pushed me to a decision I'd already made elsewhere
+
+`SameSite` started as a validated `string`. PHPStan max rejected it: `session_set_cookie_params()`
+is itself typed against a literal union.
+
+The right fix wasn't a narrower docblock — it was an **enum**, which is precisely what ADR-0015
+decided for `Sort` and `Operator`: a closed keyword set reaching a security-relevant output should
+be a closed *type*, not a runtime check. Reaching the same conclusion from a static-analysis
+complaint rather than from first principles was a good sign the earlier decision generalises.
+
+It also deleted a test. The "illegal SameSite is refused" cases became compile-time
+impossibilities, replaced by one assertion that the set is exactly the three the spec defines — so
+widening it stays deliberate.
+
+The one constraint the type system *can't* express spans two arguments: browsers **drop** a
+`SameSite=None` cookie that isn't `Secure`. That stays a constructor check, so it surfaces at
+wiring time instead of as "sessions don't work".
+
+## Defaults, and which ones have no opt-out
+
+- **`secure: true`**, with an explicit named opt-out for local `http://` development — *not*
+  auto-detection from `$_SERVER['HTTPS']`, which would silently disable the flag on exactly the
+  misconfigured-proxy deployment that needs it most. Same shape as `Hash`'s `bcryptFallback`.
+- **`httponly` has no opt-out at all.** No legitimate caller needs the session id readable from
+  JavaScript; offering the switch would be offering the vulnerability.
+- **`SameSite=Lax`, not `Strict`.** `Strict` also withholds the cookie from ordinary inbound links,
+  so a logged-in user following one from an email arrives logged out — the kind of breakage that
+  gets a security control switched off entirely.
+- **A token is issued once per scope and reused.** Regenerating per render invalidates the token in
+  another open tab, and users retrying until it works is exactly how people learn to ignore this
+  failure. `rotate()` is the explicit call for a privilege transition.
+- **Scope names are validated** — a scope becomes a session-storage key, so a scope from user input
+  would let a client grow the session record one key per request.
+
+## Honest gap
+
+`start()` and `regenerate()` have **no unit coverage and cannot**. The cookie *policy* is covered;
+the *behaviour* — that the cookie really carries the flags, that the session id really changes —
+belongs to item **6.3**. Named in the ADR, the class docblock and the test file rather than left
+silent.
+
+## Bar
+
+1157 tests / 2553 assertions green (up from 1109). `--group T-03` runs 48. PHPStan max clean,
+deptrac 0/0, consistency lint OK.
+
+## Next
+
+**6.3** — T-03 session/CSRF integration against a real `php -S` process, which is where everything
+this item couldn't reach gets exercised.

--- a/docs/journal/2026/08/2026-08-05-session-csrf.md
+++ b/docs/journal/2026/08/2026-08-05-session-csrf.md
@@ -60,6 +60,9 @@ now.
 Three occurrences of this shape in three items — 4.6 (sub-noise saving), 5.3 (unreachable branch),
 6.2 (timing-only property) — is enough that it's a pattern rather than three coincidences.
 
+*(It turned out to be four. See the last section: the same class had a second one, and I walked
+straight past it while writing this paragraph.)*
+
 ## PHPStan pushed me to a decision I'd already made elsewhere
 
 `SameSite` started as a validated `string`. PHPStan max rejected it: `session_set_cookie_params()`
@@ -94,16 +97,56 @@ wiring time instead of as "sessions don't work".
 - **Scope names are validated** — a scope becomes a session-storage key, so a scope from user input
   would let a client grow the session record one key per request.
 
-## Honest gap
+## The gap I wrote up as honest, and the gate that disagreed
 
-`start()` and `regenerate()` have **no unit coverage and cannot**. The cookie *policy* is covered;
-the *behaviour* — that the cookie really carries the flags, that the session id really changes —
-belongs to item **6.3**. Named in the ADR, the class docblock and the test file rather than left
-silent.
+I finished the item with this in the ADR, the class docblock and the test file:
+
+> `start()` and `regenerate()` have no unit coverage and cannot.
+
+Then CI failed the coverage floor at **89.59%**, `Session` sitting at 61.54%.
+
+Two exits were available and both were familiar: lower the floor, or `@codeCoverageIgnore`. A third
+had turned up while probing — `start()`'s cookie-params failure *is* reachable in CLI, because
+`session_set_cookie_params()` returns `false` and the guard throws. One small test, +4 lines,
+90.03%. Clears the gate by 0.03%.
+
+That third option is the one worth naming, because it was the tempting one. It is a coverage fix
+wearing a test's clothes: the number goes green, nothing anyone cares about gets asserted, and I
+ship it as though the problem were solved.
+
+Re-reading the gap instead of routing around it turned up something I had written down myself and
+not followed through on. From the docblock:
+
+> The order is not optional: `session_set_cookie_params()` has no effect once the session has
+> started.
+
+Get that order wrong and **everything still works**. Session created, values round-trip, all 1157
+tests green — and the cookie went out with none of `httponly`, `secure`, `samesite`. Both orderings
+produce a working session. Nothing about the outcome distinguishes them.
+
+Which is §7 again, in a second place in the same class. `hash_equals` vs `===` is invisible because
+the values match and only the timing differs; params-before-start is invisible because the session
+works either way and only the sequence differs. I found that shape once this item, wrote an ADR
+section about it, and still walked past the second instance — because the first announced itself as
+a failed probe, and this one was sitting quietly in a comment I had written myself.
+
+So: `SessionApi`, five methods, no behaviour. `NativeSessionApi` delegates and does nothing else.
+`Session` keeps the guards, the ordering and the error mapping, and a fake records the call order.
+Same justification as `CsrfToken`'s `SessionStore` two sections up — and it satisfies ADR-0006's
+rule that an interface waits for a consumer to need one, because the consumer showed up.
+
+Probes: swapping the order in `start()` fails 3 tests where it previously failed **none**. Weakening
+`session_regenerate_id(true)` to `session_regenerate_id()` — which renames the session while leaving
+the old identifier valid, the half of fixation that matters — fails 1.
+
+The 5.3 journal said *"a gap written up as acceptable is a gap nobody closes."* I quoted that line
+in this item's own ADR, in the section explaining why I would not accept the `hash_equals` gap, and
+then accepted a different one four paragraphs later. The gate caught it. That is twice the coverage
+floor has done work no reviewer asked it to.
 
 ## Bar
 
-1157 tests / 2553 assertions green (up from 1109). `--group T-03` runs 48. PHPStan max clean,
+1175 tests / 2576 assertions green (up from 1109). `--group T-03` runs 66. PHPStan max clean,
 deptrac 0/0, consistency lint OK.
 
 ## Next

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-05 — A probe that passed, and this time it was the code](2026/08/2026-08-05-session-csrf.md)
 - [2026-08-04 — The client picks the type, not the application](2026/08/2026-08-04-http-wrappers.md)
 - [2026-08-04 — A range, not a ceiling: measuring the wrong thing would have proved nothing](2026/08/2026-08-04-hash-matrix-nfr05.md)
 - [2026-08-04 — A probe that passed, and the claim it disproved](2026/08/2026-08-04-xss-corpus.md)

--- a/src/main/php/d4np/utils/Http/CsrfToken.php
+++ b/src/main/php/d4np/utils/Http/CsrfToken.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+use D4np\Utils\Support\HttpException;
+
+/**
+ * Synchroniser-pattern CSRF tokens (spec FR-12, ADR-0026).
+ *
+ * Lives in `Http` rather than `Security` per RFC-0001's R-1 placement note: a CSRF token is
+ * meaningless without the session and the request that carry it, and putting it beside them keeps
+ * the dependency pointing the way the layering rule allows.
+ *
+ * ```php
+ * $csrf = new CsrfToken($session);
+ * $token = $csrf->issue('login');                 // render into the form
+ * if (!$csrf->validate($request->postString('_token') ?? '', 'login')) { … }
+ * ```
+ *
+ * **Three properties carry the whole defence, and each is a decision rather than a detail:**
+ *
+ * 1. **The token is CSPRNG output**, 32 bytes from `random_bytes()` rendered as 64 hex characters.
+ *    Not `uniqid()`, not `mt_rand()`, not a hash of session data — a token an attacker can predict
+ *    is not a token, and the predictable-source mistakes are the ones that keep recurring.
+ * 2. **Comparison is `hash_equals()`**, which takes the same time whichever byte differs first. A
+ *    `===` leaks the length of the matching prefix through timing, which is enough to reconstruct
+ *    a token byte by byte given enough attempts.
+ * 3. **A token is issued once per scope and reused**, not regenerated per call. Re-issuing on
+ *    every render would invalidate the token already sitting in another open tab, and the usual
+ *    response to that — users retrying until it works — trains people to ignore the failure this
+ *    protects them with.
+ *
+ * **Scope names are validated, and that is a storage decision as much as a security one.** A scope
+ * becomes a session-storage key, so a scope taken from user input would let a client grow the
+ * session record without bound, one key per request. Scope names are application-chosen labels
+ * (`'login'`, `'checkout'`), and this refuses anything that does not look like one rather than
+ * trusting that every caller remembered.
+ */
+final class CsrfToken
+{
+    /**
+     * 32 bytes — 256 bits — rendered as 64 hex characters.
+     *
+     * Well beyond what a CSRF token needs to resist guessing, and cheap: this is generated once
+     * per scope per session, not per request.
+     */
+    private const TOKEN_BYTES = 32;
+
+    private const STORAGE_PREFIX = '_csrf.';
+
+    /**
+     * The shape an application-chosen scope label may take. Deliberately narrow — see the class
+     * docblock on why a scope is not a place for user input.
+     */
+    private const SCOPE = '/^[A-Za-z0-9_.-]{1,64}\z/';
+
+    public function __construct(
+        private readonly SessionStore $store,
+    ) {
+    }
+
+    /**
+     * The token for `$scope`, generating and storing one on first use.
+     *
+     * Stable across calls within a session so that concurrently open forms all carry a token that
+     * still validates. {@see rotate()} is the explicit way to get a new one.
+     *
+     * @throws HttpException if the scope name is not a legal label
+     */
+    public function issue(string $scope = 'default'): string
+    {
+        $key = self::keyFor($scope);
+        $existing = $this->store->get($key);
+
+        if ($existing !== null && $existing !== '') {
+            return $existing;
+        }
+
+        $token = bin2hex(random_bytes(self::TOKEN_BYTES));
+        $this->store->set($key, $token);
+
+        return $token;
+    }
+
+    /**
+     * Whether `$token` matches the one issued for `$scope`.
+     *
+     * Returns `false` — never throws — for a missing, empty or mismatched token, because every one
+     * of those is the same answer to the caller: this request is not authorised. Throwing would
+     * push callers into a `try` around a routine branch.
+     *
+     * The comparison is `hash_equals()`, constant-time in the length of the *stored* token. The
+     * absent-token case returns early, which is a timing difference — and a harmless one, because
+     * it distinguishes "you have no session" from "your token is wrong", neither of which helps an
+     * attacker who has neither.
+     *
+     * @throws HttpException if the scope name is not a legal label
+     */
+    public function validate(string $token, string $scope = 'default'): bool
+    {
+        $stored = $this->store->get(self::keyFor($scope));
+
+        if ($stored === null || $stored === '' || $token === '') {
+            return false;
+        }
+
+        return hash_equals($stored, $token);
+    }
+
+    /**
+     * Replace the token for `$scope` and return the new one.
+     *
+     * The right thing to call on a privilege transition — a login, a password change — where the
+     * session identity itself changes and any token issued to the previous identity should stop
+     * working. Deliberately *not* what {@see validate()} does: rotating on every successful
+     * validation would break the second of two open tabs.
+     *
+     * @throws HttpException if the scope name is not a legal label
+     */
+    public function rotate(string $scope = 'default'): string
+    {
+        $this->store->remove(self::keyFor($scope));
+
+        return $this->issue($scope);
+    }
+
+    /**
+     * Forget the token for `$scope`.
+     *
+     * @throws HttpException if the scope name is not a legal label
+     */
+    public function clear(string $scope = 'default'): void
+    {
+        $this->store->remove(self::keyFor($scope));
+    }
+
+    /**
+     * @throws HttpException
+     */
+    private static function keyFor(string $scope): string
+    {
+        if (preg_match(self::SCOPE, $scope) !== 1) {
+            throw new HttpException(sprintf(
+                'CSRF scope %s is not a legal label. A scope becomes a session-storage key, so it '
+                . 'must be an application-chosen name such as "login" or "checkout" — matching %s '
+                . '— and never a value taken from the request, which would let a client grow the '
+                . 'session record one key at a time.',
+                var_export($scope, true),
+                self::SCOPE,
+            ));
+        }
+
+        return self::STORAGE_PREFIX . $scope;
+    }
+}

--- a/src/main/php/d4np/utils/Http/NativeSessionApi.php
+++ b/src/main/php/d4np/utils/Http/NativeSessionApi.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+/**
+ * {@see SessionApi} over PHP's global session functions.
+ *
+ * Every method is a single delegation with no branch, no ordering and no error handling — all of
+ * that lives in {@see Session}, where it can be tested. That split is the whole point of the seam
+ * (ADR-0026 §8): what remains here cannot be exercised in CLI, so what remains here is made small
+ * enough that there is nothing in it to get wrong. Its behaviour against a real server is roadmap
+ * item 6.3's integration suite.
+ */
+final class NativeSessionApi implements SessionApi
+{
+    public function status(): int
+    {
+        return session_status();
+    }
+
+    public function setCookieParams(array $params): bool
+    {
+        return session_set_cookie_params($params);
+    }
+
+    public function start(): bool
+    {
+        return session_start();
+    }
+
+    public function regenerateId(): bool
+    {
+        return session_regenerate_id(true);
+    }
+
+    public function destroy(): bool
+    {
+        return session_destroy();
+    }
+}

--- a/src/main/php/d4np/utils/Http/SameSite.php
+++ b/src/main/php/d4np/utils/Http/SameSite.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+/**
+ * A cookie's `SameSite` policy.
+ *
+ * An enum for the same reason {@see \D4np\Utils\Database\Sort} and
+ * {@see \D4np\Utils\Database\Operator} are (ADR-0015): a closed set of keywords that reaches a
+ * security-relevant output, where a `string` parameter means validating at run time what the type
+ * system can decide outright. PHPStan at max is what surfaced it here — `session_set_cookie_params()`
+ * is itself typed against a literal union, and a plain `string` could not satisfy it.
+ *
+ * `lax`/`strict`/`none` in lower case are legal for PHP but omitted deliberately: two spellings of
+ * one policy is a distinction with no meaning and one more thing for a reader to wonder about.
+ */
+enum SameSite: string
+{
+    /**
+     * FR-15's default. The cookie is withheld from cross-site POSTs — a second, independent line
+     * against CSRF — but still sent when a user follows an ordinary inbound link.
+     */
+    case Lax = 'Lax';
+
+    /**
+     * Withheld from *every* cross-site request, including ordinary inbound links. A logged-in user
+     * following a link from an email arrives logged out, which is the kind of breakage that gets a
+     * security control switched off entirely — hence `Lax` as the default rather than this.
+     */
+    case Strict = 'Strict';
+
+    /**
+     * Sent on every cross-site request. Browsers **reject this unless the cookie is also
+     * `Secure`** and drop it entirely, which {@see Session} refuses at construction rather than
+     * letting it surface as "sessions do not work".
+     */
+    case None = 'None';
+}

--- a/src/main/php/d4np/utils/Http/Session.php
+++ b/src/main/php/d4np/utils/Http/Session.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+use D4np\Utils\Support\HttpException;
+
+/**
+ * A session with hardened cookie flags and a real `regenerate()` (spec FR-15, ADR-0026).
+ *
+ * **The cookie policy is a value, not a side effect.** {@see cookieParams()} returns exactly what
+ * {@see start()} will apply, and is a pure function of the constructor arguments. That is not
+ * tidiness: PHP makes a live session impossible to exercise in process — verified, `session_start()`,
+ * `session_set_cookie_params()` and `session_regenerate_id()` all return `false` in CLI — so
+ * without this the three flags FR-15 exists to pin would have no unit assertion at all, only
+ * roadmap item 6.3's integration suite. The same move ADR-0022 made for the hashing policy.
+ *
+ * The three flags, and what each one actually stops:
+ *
+ * - **`httponly`** — JavaScript cannot read the cookie, so an XSS that gets as far as running
+ *   script still cannot exfiltrate the session identifier.
+ * - **`secure`** — the cookie is never sent over plain HTTP, so a network attacker cannot harvest
+ *   it from an accidental `http://` request.
+ * - **`samesite=Lax`** — the browser does not attach it to cross-site POSTs, which is a second,
+ *   independent line against CSRF. `Lax` rather than `Strict` because `Strict` also withholds the
+ *   cookie from ordinary inbound links, so a logged-in user following one from an email arrives
+ *   logged out — the kind of breakage that gets a security control switched off entirely.
+ *
+ * **`secure` defaults to `true` and the opt-out is explicit and narrow.** A `secure` cookie over
+ * plain HTTP is never sent, so local development on `http://localhost` would appear to have no
+ * session at all. That is a real need, and the honest response is a named constructor argument
+ * whose only correct use is documented — not a silent auto-detection from
+ * `$_SERVER['HTTPS']`, which would quietly disable the flag on any deployment sitting behind a
+ * misconfigured proxy. Same shape as `Hash`'s `bcryptFallback`: safe by default, opt out on
+ * purpose, visible in the wiring.
+ */
+final class Session implements SessionStore
+{
+    /**
+     * @param bool $secure whether the cookie is HTTPS-only. **Leave this `true` in anything a
+     *                     browser will reach.** Setting it `false` is for local `http://`
+     *                     development, and means the session identifier travels in clear text
+     * @param SameSite $sameSite `Lax` per FR-15. A closed type rather than a string, so an illegal
+     *                            value is a compile-time impossibility instead of a runtime check
+     *                            (ADR-0015's reasoning, applied again)
+     * @param string $path the cookie path
+     *
+     * @throws HttpException if `None` is paired with an insecure cookie
+     */
+    public function __construct(
+        private readonly bool $secure = true,
+        private readonly SameSite $sameSite = SameSite::Lax,
+        private readonly string $path = '/',
+    ) {
+        // The one constraint the type system cannot express, because it spans two arguments:
+        // browsers reject `SameSite=None` without `Secure` and drop the cookie entirely. Failing
+        // here means the misconfiguration surfaces at wiring time rather than as "sessions do not
+        // work" in production.
+        if ($this->sameSite === SameSite::None && !$this->secure) {
+            throw new HttpException(
+                'SameSite=None requires a Secure cookie; browsers reject the combination and drop '
+                . 'the cookie entirely, so this refuses rather than producing a session that '
+                . 'silently never persists.',
+            );
+        }
+    }
+
+    /**
+     * Exactly the cookie parameters {@see start()} will apply.
+     *
+     * Pure, so FR-15's flags can be asserted without a live session.
+     *
+     * @return array{lifetime: int, path: string, domain: string, secure: bool, httponly: bool, samesite: 'Lax'|'Strict'|'None'}
+     */
+    public function cookieParams(): array
+    {
+        return [
+            // A session cookie: it dies with the browser session rather than persisting on disk
+            // with an expiry the server cannot revoke.
+            'lifetime' => 0,
+            'path' => $this->path,
+            'domain' => '',
+            'secure' => $this->secure,
+            // Never configurable. A session identifier readable from JavaScript defeats the
+            // purpose of having one, and no legitimate caller needs it.
+            'httponly' => true,
+            'samesite' => $this->sameSite->value,
+        ];
+    }
+
+    /**
+     * Start the session, applying {@see cookieParams()} first.
+     *
+     * The order is not optional: `session_set_cookie_params()` has no effect once the session has
+     * started, so setting the flags afterwards would leave the cookie already sent without them.
+     *
+     * Starting an already-active session is a no-op rather than an error — a request that reaches
+     * two entry points should not fail on the second.
+     *
+     * @throws HttpException if sessions are disabled, or the session cannot be started
+     */
+    public function start(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            return;
+        }
+
+        if (session_status() === PHP_SESSION_DISABLED) {
+            throw new HttpException('Sessions are disabled in this PHP build.');
+        }
+
+        if (!session_set_cookie_params($this->cookieParams())) {
+            throw new HttpException(
+                'Could not apply the session cookie parameters. They must be set before the '
+                . 'session starts and before any output; this refuses rather than starting a '
+                . 'session whose cookie lacks the flags FR-15 requires.',
+            );
+        }
+
+        if (!session_start()) {
+            throw new HttpException('Could not start the session.');
+        }
+    }
+
+    /**
+     * Give the session a new identifier, discarding the old one.
+     *
+     * **Call this on every privilege transition — login above all.** Without it, an attacker who
+     * can fix a victim's session identifier before login (a link carrying one, an XSS writing the
+     * cookie) still holds a valid identifier *after* the victim authenticates: session fixation.
+     *
+     * `session_regenerate_id(true)` — the `true` deletes the old session record rather than
+     * leaving it valid, which is the half that actually closes the attack. Leaving it `false`
+     * renames the session while the old identifier keeps working.
+     *
+     * @throws HttpException if there is no active session, or regeneration fails
+     */
+    public function regenerate(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            throw new HttpException(
+                'Cannot regenerate a session identifier before the session has started.',
+            );
+        }
+
+        if (!session_regenerate_id(true)) {
+            throw new HttpException('Could not regenerate the session identifier.');
+        }
+    }
+
+    public function get(string $key): ?string
+    {
+        $value = $_SESSION[$key] ?? null;
+
+        // Only strings come back. A session written by other code can hold anything, and quietly
+        // casting an array or object here would be the coercion `Request` refuses for the same
+        // reason (ADR-0025).
+        return is_string($value) ? $value : null;
+    }
+
+    public function set(string $key, string $value): void
+    {
+        $_SESSION[$key] = $value;
+    }
+
+    public function remove(string $key): void
+    {
+        unset($_SESSION[$key]);
+    }
+
+    /**
+     * Empty the session data and destroy the server-side record.
+     *
+     * The cookie itself is left alone: expiring it is a response concern, and this class does not
+     * write headers.
+     */
+    public function destroy(): void
+    {
+        $_SESSION = [];
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+    }
+}

--- a/src/main/php/d4np/utils/Http/Session.php
+++ b/src/main/php/d4np/utils/Http/Session.php
@@ -34,6 +34,14 @@ use D4np\Utils\Support\HttpException;
  * `$_SERVER['HTTPS']`, which would quietly disable the flag on any deployment sitting behind a
  * misconfigured proxy. Same shape as `Hash`'s `bcryptFallback`: safe by default, opt out on
  * purpose, visible in the wiring.
+ *
+ * **The session functions themselves come through {@see SessionApi}** (ADR-0026 §8), for the same
+ * reason and by the same route. Because PHP returns `false` from all of them in CLI, the guards
+ * below, the error paths, and above all the *ordering* in {@see start()} were unreachable by any
+ * test. The ordering is the one worth naming: applied after the session has started, the cookie
+ * parameters have no effect and the session cookie goes out without FR-15's flags — a session that
+ * works perfectly and is unprotected. Both orderings "work", so only an assertion on the call
+ * sequence can tell them apart.
  */
 final class Session implements SessionStore
 {
@@ -45,6 +53,10 @@ final class Session implements SessionStore
      *                            value is a compile-time impossibility instead of a runtime check
      *                            (ADR-0015's reasoning, applied again)
      * @param string $path the cookie path
+     * @param SessionApi $api PHP's session functions, behind a seam so this class's guards,
+     *                        ordering and error paths can be tested at all (ADR-0026 §8). The
+     *                        default is the real thing; nothing but the test suite passes anything
+     *                        else
      *
      * @throws HttpException if `None` is paired with an insecure cookie
      */
@@ -52,6 +64,7 @@ final class Session implements SessionStore
         private readonly bool $secure = true,
         private readonly SameSite $sameSite = SameSite::Lax,
         private readonly string $path = '/',
+        private readonly SessionApi $api = new NativeSessionApi(),
     ) {
         // The one constraint the type system cannot express, because it spans two arguments:
         // browsers reject `SameSite=None` without `Secure` and drop the cookie entirely. Failing
@@ -102,15 +115,15 @@ final class Session implements SessionStore
      */
     public function start(): void
     {
-        if (session_status() === PHP_SESSION_ACTIVE) {
+        if ($this->api->status() === PHP_SESSION_ACTIVE) {
             return;
         }
 
-        if (session_status() === PHP_SESSION_DISABLED) {
+        if ($this->api->status() === PHP_SESSION_DISABLED) {
             throw new HttpException('Sessions are disabled in this PHP build.');
         }
 
-        if (!session_set_cookie_params($this->cookieParams())) {
+        if (!$this->api->setCookieParams($this->cookieParams())) {
             throw new HttpException(
                 'Could not apply the session cookie parameters. They must be set before the '
                 . 'session starts and before any output; this refuses rather than starting a '
@@ -118,7 +131,7 @@ final class Session implements SessionStore
             );
         }
 
-        if (!session_start()) {
+        if (!$this->api->start()) {
             throw new HttpException('Could not start the session.');
         }
     }
@@ -138,13 +151,13 @@ final class Session implements SessionStore
      */
     public function regenerate(): void
     {
-        if (session_status() !== PHP_SESSION_ACTIVE) {
+        if ($this->api->status() !== PHP_SESSION_ACTIVE) {
             throw new HttpException(
                 'Cannot regenerate a session identifier before the session has started.',
             );
         }
 
-        if (!session_regenerate_id(true)) {
+        if (!$this->api->regenerateId()) {
             throw new HttpException('Could not regenerate the session identifier.');
         }
     }
@@ -179,8 +192,8 @@ final class Session implements SessionStore
     {
         $_SESSION = [];
 
-        if (session_status() === PHP_SESSION_ACTIVE) {
-            session_destroy();
+        if ($this->api->status() === PHP_SESSION_ACTIVE) {
+            $this->api->destroy();
         }
     }
 }

--- a/src/main/php/d4np/utils/Http/SessionApi.php
+++ b/src/main/php/d4np/utils/Http/SessionApi.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+/**
+ * PHP's own session functions, behind a seam (ADR-0026 §8).
+ *
+ * This interface adds no behaviour. It exists because `session_start()`,
+ * `session_set_cookie_params()` and `session_regenerate_id()` all return `false` in CLI — verified
+ * — which puts every guard, every ordering rule and every error path in {@see Session} beyond the
+ * reach of the unit suite.
+ *
+ * The property that matters most is one no functional test could otherwise reach: **the cookie
+ * parameters must be applied before the session starts.** Applied afterwards they have no effect,
+ * and the session cookie goes out without the flags FR-15 exists to pin — a session that works
+ * perfectly and is unprotected. Both orderings "work"; only one is correct. With this seam a fake
+ * records the call order and the rule is asserted directly.
+ *
+ * The same reasoning that gave `CsrfToken` its {@see SessionStore} (ADR-0026 §2): a seam introduced
+ * for exactly one reason, kept no wider than that reason, over logic too security-relevant to leave
+ * resting on an integration suite alone.
+ *
+ * @see NativeSessionApi the production implementation, which is delegation and nothing else
+ */
+interface SessionApi
+{
+    /**
+     * @return int one of `PHP_SESSION_DISABLED`, `PHP_SESSION_NONE`, `PHP_SESSION_ACTIVE`
+     */
+    public function status(): int;
+
+    /**
+     * @param array{lifetime: int, path: string, domain: string, secure: bool, httponly: bool, samesite: 'Lax'|'Strict'|'None'} $params
+     */
+    public function setCookieParams(array $params): bool;
+
+    public function start(): bool;
+
+    /**
+     * Regenerate the identifier, **deleting the old session record**.
+     *
+     * The deletion is not a detail: keeping the old record leaves the previous identifier valid,
+     * which is the half of session fixation that actually matters. It is fixed here rather than
+     * exposed as a parameter so no caller can turn it off.
+     */
+    public function regenerateId(): bool;
+
+    public function destroy(): bool;
+}

--- a/src/main/php/d4np/utils/Http/SessionStore.php
+++ b/src/main/php/d4np/utils/Http/SessionStore.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+/**
+ * The slice of session storage {@see CsrfToken} needs.
+ *
+ * **This interface exists for one reason: PHP makes a live session impossible to test in
+ * process.** Verified — in CLI, `session_start()`, `session_set_cookie_params()` and
+ * `session_regenerate_id()` all return `false`. A `CsrfToken` reading `$_SESSION` directly would
+ * therefore be untestable in the unit suite, and CSRF validation is the last thing that should
+ * rest on an integration suite alone.
+ *
+ * It is deliberately three methods wide. ADR-0006 refused an interface for the reflection cache
+ * because no consumer needed one yet; here a consumer does, and the justification is the same
+ * shape as ADR-0022's `selectAlgorithm()` seam — introduce the seam when there is a real need, and
+ * keep it no wider than that need.
+ *
+ * {@see Session} implements it over `$_SESSION`. Item 6.3's integration suite is what exercises
+ * that implementation against a real `php -S` process.
+ */
+interface SessionStore
+{
+    public function get(string $key): ?string;
+
+    public function set(string $key, string $value): void;
+
+    public function remove(string $key): void;
+}

--- a/src/test/php/d4np/utils/Http/CsrfTokenTest.php
+++ b/src/test/php/d4np/utils/Http/CsrfTokenTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http;
+
+use D4np\Utils\Http\CsrfToken;
+use D4np\Utils\Support\HttpException;
+use D4np\Utils\Tests\Http\Fixture\ArraySessionStore;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-12's CSRF tokens.
+ *
+ * Testable at all only because `CsrfToken` takes a {@see \D4np\Utils\Http\SessionStore} rather
+ * than reaching for `$_SESSION`: PHP will not start a session in CLI, so the alternative was
+ * leaving CSRF validation to item 6.3's integration suite alone — the last thing that should rest
+ * on an integration suite alone.
+ */
+#[Group('T-03')]
+final class CsrfTokenTest extends TestCase
+{
+    private ArraySessionStore $store;
+
+    private CsrfToken $csrf;
+
+    protected function setUp(): void
+    {
+        $this->store = new ArraySessionStore();
+        $this->csrf = new CsrfToken($this->store);
+    }
+
+    public function testAnIssuedTokenValidates(): void
+    {
+        self::assertTrue($this->csrf->validate($this->csrf->issue()));
+    }
+
+    /**
+     * 32 CSPRNG bytes as 64 hex characters. The predictable-source mistakes — `uniqid()`,
+     * `mt_rand()`, a hash of session data — are the ones that keep recurring, so the shape is
+     * pinned.
+     */
+    public function testTheTokenIsSixtyFourHexCharacters(): void
+    {
+        self::assertSame(1, preg_match('/^[0-9a-f]{64}\z/', $this->csrf->issue()));
+    }
+
+    /**
+     * Two sessions must not receive the same token. A collision here would mean the generator is
+     * not what it claims to be.
+     */
+    public function testTokensDifferBetweenSessions(): void
+    {
+        $tokens = [];
+
+        for ($i = 0; $i < 50; $i++) {
+            $tokens[] = (new CsrfToken(new ArraySessionStore()))->issue();
+        }
+
+        self::assertCount(50, array_unique($tokens));
+    }
+
+    /**
+     * Stable within a session: re-issuing on every render would invalidate the token already
+     * sitting in another open tab.
+     */
+    public function testIssuingTwiceReturnsTheSameTokenWithinASession(): void
+    {
+        self::assertSame($this->csrf->issue(), $this->csrf->issue());
+    }
+
+    public function testAWrongTokenDoesNotValidate(): void
+    {
+        $this->csrf->issue();
+
+        self::assertFalse($this->csrf->validate(bin2hex(random_bytes(32))));
+    }
+
+    /**
+     * Every "not authorised" case is the same answer to the caller, and none of them throws —
+     * throwing would push callers into a `try` around a routine branch.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function rejectedTokens(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'too short' => ['abc'];
+        yield 'right length, wrong value' => [str_repeat('0', 64)];
+        yield 'prefix of the real token' => ['deadbeef'];
+        yield 'non-hex' => [str_repeat('z', 64)];
+    }
+
+    #[DataProvider('rejectedTokens')]
+    public function testRejectedTokensReturnFalseRatherThanThrowing(string $candidate): void
+    {
+        $this->csrf->issue();
+
+        self::assertFalse($this->csrf->validate($candidate));
+    }
+
+    public function testValidationFailsWhenNoTokenHasBeenIssued(): void
+    {
+        self::assertFalse($this->csrf->validate(bin2hex(random_bytes(32))));
+        self::assertFalse($this->csrf->validate(''));
+    }
+
+    /**
+     * **Constant-time comparison, asserted as a mechanism because it is invisible as a behaviour.**
+     *
+     * `hash_equals($a, $b)` and `$a === $b` return *identical values* for every input. They differ
+     * only in how long they take, so no functional assertion can tell them apart — and a timing
+     * assertion at PHP level is too noisy to be anything but flaky. Proven, not assumed: replacing
+     * `hash_equals()` with `===` was planted as a probe and the whole suite still **passed**.
+     *
+     * So the mechanism is asserted directly. This is the pattern roadmap item 4.6 settled when a
+     * saving sat under the measurement noise floor: when the property cannot be observed in
+     * behaviour, assert the thing that produces it rather than pretending a behavioural test
+     * covers it.
+     *
+     * A `===` on the two tokens leaks the length of the matching prefix through timing, which is
+     * enough to reconstruct a token byte by byte given enough attempts.
+     */
+    public function testValidationComparesInConstantTime(): void
+    {
+        $method = new \ReflectionMethod(CsrfToken::class, 'validate');
+        $file = $method->getFileName();
+        self::assertIsString($file);
+
+        $lines = file($file);
+        self::assertIsArray($lines);
+
+        $body = implode('', array_slice(
+            $lines,
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1,
+        ));
+
+        self::assertStringContainsString(
+            'hash_equals(',
+            $body,
+            'CsrfToken::validate() must compare with hash_equals(); a === comparison leaks the '
+            . 'matching prefix length through timing, and returns the same value so no other test '
+            . 'in this file would notice.',
+        );
+        self::assertDoesNotMatchRegularExpression(
+            '/\$stored\s*={2,3}\s*\$token|\$token\s*={2,3}\s*\$stored/',
+            $body,
+            'the tokens must not be compared with == or ===',
+        );
+    }
+
+    // ---- per-form scoping ------------------------------------------------------------------------
+
+    public function testScopesGetSeparateTokens(): void
+    {
+        $login = $this->csrf->issue('login');
+        $checkout = $this->csrf->issue('checkout');
+
+        self::assertNotSame($login, $checkout);
+        self::assertTrue($this->csrf->validate($login, 'login'));
+        self::assertTrue($this->csrf->validate($checkout, 'checkout'));
+    }
+
+    /**
+     * The point of scoping: a token issued for one form does not authorise another.
+     */
+    public function testATokenFromOneScopeDoesNotValidateInAnother(): void
+    {
+        $login = $this->csrf->issue('login');
+        $this->csrf->issue('checkout');
+
+        self::assertFalse($this->csrf->validate($login, 'checkout'));
+    }
+
+    public function testScopesAreStoredUnderDistinctPrefixedKeys(): void
+    {
+        $this->csrf->issue('login');
+        $this->csrf->issue('checkout');
+
+        self::assertSame(['_csrf.login', '_csrf.checkout'], array_keys($this->store->entries));
+    }
+
+    /**
+     * A scope becomes a session-storage key, so a scope taken from user input would let a client
+     * grow the session record one key per request. Application-chosen labels only.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function illegalScopes(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'with a slash' => ['a/b'];
+        yield 'with a space' => ['a b'];
+        yield 'with a newline' => ["a\nb"];
+        yield 'with a null byte' => ["a\0b"];
+        yield 'over-long' => [str_repeat('a', 65)];
+        yield 'unicode' => ['scopé'];
+    }
+
+    #[DataProvider('illegalScopes')]
+    public function testIllegalScopeNamesAreRefused(string $scope): void
+    {
+        $this->expectException(HttpException::class);
+
+        $this->csrf->issue($scope);
+    }
+
+    #[DataProvider('illegalScopes')]
+    public function testValidationAlsoRefusesAnIllegalScope(string $scope): void
+    {
+        $this->expectException(HttpException::class);
+
+        $this->csrf->validate('anything', $scope);
+    }
+
+    public function testLegalScopeShapesAreAccepted(): void
+    {
+        foreach (['login', 'check-out', 'form_1', 'a.b', str_repeat('x', 64)] as $scope) {
+            self::assertSame(1, preg_match('/^[0-9a-f]{64}\z/', $this->csrf->issue($scope)), $scope);
+        }
+    }
+
+    // ---- rotation --------------------------------------------------------------------------------
+
+    /**
+     * The right thing on a privilege transition: any token issued to the previous identity stops
+     * working.
+     */
+    public function testRotateReplacesTheTokenAndInvalidatesTheOldOne(): void
+    {
+        $original = $this->csrf->issue('login');
+        $rotated = $this->csrf->rotate('login');
+
+        self::assertNotSame($original, $rotated);
+        self::assertFalse($this->csrf->validate($original, 'login'));
+        self::assertTrue($this->csrf->validate($rotated, 'login'));
+    }
+
+    public function testRotateOnlyAffectsItsOwnScope(): void
+    {
+        $login = $this->csrf->issue('login');
+        $checkout = $this->csrf->issue('checkout');
+
+        $this->csrf->rotate('login');
+
+        self::assertFalse($this->csrf->validate($login, 'login'));
+        self::assertTrue($this->csrf->validate($checkout, 'checkout'));
+    }
+
+    /**
+     * Deliberately *not* what `validate()` does — rotating on every successful validation would
+     * break the second of two open tabs.
+     */
+    public function testValidationDoesNotConsumeTheToken(): void
+    {
+        $token = $this->csrf->issue();
+
+        self::assertTrue($this->csrf->validate($token));
+        self::assertTrue($this->csrf->validate($token));
+    }
+
+    public function testClearForgetsTheToken(): void
+    {
+        $token = $this->csrf->issue('login');
+        $this->csrf->clear('login');
+
+        self::assertFalse($this->csrf->validate($token, 'login'));
+        self::assertSame([], $this->store->entries);
+    }
+
+    /**
+     * A store that has been emptied out from under the token — a destroyed session — must not
+     * validate anything.
+     */
+    public function testATokenDoesNotSurviveTheStoreBeingCleared(): void
+    {
+        $token = $this->csrf->issue();
+        $this->store->entries = [];
+
+        self::assertFalse($this->csrf->validate($token));
+    }
+}

--- a/src/test/php/d4np/utils/Http/Fixture/ArraySessionStore.php
+++ b/src/test/php/d4np/utils/Http/Fixture/ArraySessionStore.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http\Fixture;
+
+use D4np\Utils\Http\SessionStore;
+
+/**
+ * An in-memory {@see SessionStore}, so CSRF logic can be tested without a live session.
+ *
+ * PHP will not start a session in CLI — `session_start()` returns `false`, verified — so without
+ * this the whole of `CsrfToken` would be untestable until item 6.3's `php -S` integration suite.
+ * CSRF validation is the last thing that should rest on an integration suite alone.
+ *
+ * `$entries` is public so a test can inspect what was stored, which is how the "a token is stored
+ * under a scoped key" and "rotate actually replaces it" assertions are written.
+ */
+final class ArraySessionStore implements SessionStore
+{
+    /** @var array<string, string> */
+    public array $entries = [];
+
+    public function get(string $key): ?string
+    {
+        return $this->entries[$key] ?? null;
+    }
+
+    public function set(string $key, string $value): void
+    {
+        $this->entries[$key] = $value;
+    }
+
+    public function remove(string $key): void
+    {
+        unset($this->entries[$key]);
+    }
+}

--- a/src/test/php/d4np/utils/Http/Fixture/RecordingSessionApi.php
+++ b/src/test/php/d4np/utils/Http/Fixture/RecordingSessionApi.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http\Fixture;
+
+use D4np\Utils\Http\SessionApi;
+
+/**
+ * A {@see SessionApi} that records what was called, in what order, and with what.
+ *
+ * PHP returns `false` from every session function in CLI — verified — so without this fake, every
+ * guard, every error path and the ordering rule in `Session::start()` would be untestable. The
+ * ordering is why the recording exists at all: applying the cookie parameters *after* the session
+ * has started silently produces a working session whose cookie lacks FR-15's flags, and no
+ * assertion on the outcome can tell that apart from the correct sequence. Only the sequence can.
+ *
+ * `status()` is deliberately **not** recorded. It is a query, it is called more than once, and
+ * including it would bury the two calls the ordering assertion is actually about.
+ *
+ * `start()` flips the status to active, because the guards under test read the status back and a
+ * fake that did not would make `regenerate()` unreachable for the wrong reason.
+ */
+final class RecordingSessionApi implements SessionApi
+{
+    /**
+     * The mutating calls, in the order they were made.
+     *
+     * @var list<string>
+     */
+    public array $calls = [];
+
+    /**
+     * Whatever `setCookieParams()` was handed, so a test can assert the policy really reaches PHP
+     * rather than only being returned by `cookieParams()`.
+     *
+     * @var array{lifetime: int, path: string, domain: string, secure: bool, httponly: bool, samesite: 'Lax'|'Strict'|'None'}|null
+     */
+    public ?array $params = null;
+
+    public function __construct(
+        private int $status = PHP_SESSION_NONE,
+        private readonly bool $setCookieParamsSucceeds = true,
+        private readonly bool $startSucceeds = true,
+        private readonly bool $regenerateSucceeds = true,
+        private readonly bool $destroySucceeds = true,
+    ) {
+    }
+
+    public function status(): int
+    {
+        return $this->status;
+    }
+
+    public function setCookieParams(array $params): bool
+    {
+        $this->calls[] = 'setCookieParams';
+        $this->params = $params;
+
+        return $this->setCookieParamsSucceeds;
+    }
+
+    public function start(): bool
+    {
+        $this->calls[] = 'start';
+
+        if ($this->startSucceeds) {
+            $this->status = PHP_SESSION_ACTIVE;
+        }
+
+        return $this->startSucceeds;
+    }
+
+    public function regenerateId(): bool
+    {
+        $this->calls[] = 'regenerateId';
+
+        return $this->regenerateSucceeds;
+    }
+
+    public function destroy(): bool
+    {
+        $this->calls[] = 'destroy';
+
+        if ($this->destroySucceeds) {
+            $this->status = PHP_SESSION_NONE;
+        }
+
+        return $this->destroySucceeds;
+    }
+}

--- a/src/test/php/d4np/utils/Http/NativeSessionApiTest.php
+++ b/src/test/php/d4np/utils/Http/NativeSessionApiTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http;
+
+use D4np\Utils\Http\NativeSessionApi;
+use D4np\Utils\Http\SessionApi;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The production side of the seam (ADR-0026 §8).
+ *
+ * Four of its five methods cannot be called here — PHP returns `false` from them in CLI, which is
+ * the whole reason the seam exists — so what this file can assert is that each one **delegates to
+ * the session function it claims to**. That is a mechanism assertion for the same reason §7's is:
+ * a delegation quietly pointing at the wrong function, or dropping an argument, produces no
+ * observable difference anywhere the unit suite can look.
+ *
+ * The behaviour against a real server belongs to roadmap item **6.3**.
+ */
+#[Group('T-03')]
+final class NativeSessionApiTest extends TestCase
+{
+    /**
+     * The one method that can actually be called here.
+     *
+     * Its reach is limited and worth stating: CLI only ever reports `PHP_SESSION_NONE`, so this
+     * cannot tell the real delegation apart from a hard-coded `PHP_SESSION_NONE` — verified, that
+     * substitution leaves this test green and only the delegation assertion below catches it. It
+     * earns its place by proving the method is callable and returns the right value in the one
+     * state reachable here, not by pinning the implementation.
+     */
+    public function testStatusReportsPhpsOwnSessionStatus(): void
+    {
+        self::assertSame(session_status(), (new NativeSessionApi())->status());
+    }
+
+    /**
+     * Each method against the function it must call.
+     *
+     * `session_regenerate_id(true)` earns its own entry: the `true` deletes the old session record,
+     * and without it the session is merely renamed while the previous identifier keeps working —
+     * which is the half of session fixation that matters. It is fixed here rather than exposed as a
+     * parameter so that no caller can turn it off, and asserted because nothing observable would
+     * reveal its loss.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function delegations(): iterable
+    {
+        yield 'status' => ['status', 'session_status()'];
+        yield 'cookie params' => ['setCookieParams', 'session_set_cookie_params($params)'];
+        yield 'start' => ['start', 'session_start()'];
+        yield 'regenerate, deleting the old record' => ['regenerateId', 'session_regenerate_id(true)'];
+        yield 'destroy' => ['destroy', 'session_destroy()'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('delegations')]
+    public function testEachMethodDelegatesToItsSessionFunction(string $method, string $call): void
+    {
+        $reflected = new \ReflectionMethod(NativeSessionApi::class, $method);
+        $source = (string) file_get_contents((string) $reflected->getFileName());
+        $body = implode("\n", array_slice(
+            explode("\n", $source),
+            $reflected->getStartLine() - 1,
+            $reflected->getEndLine() - $reflected->getStartLine() + 1,
+        ));
+
+        self::assertStringContainsString("return {$call};", $body);
+    }
+
+    public function testItIsTheSeamsContract(): void
+    {
+        self::assertInstanceOf(SessionApi::class, new NativeSessionApi());
+    }
+}

--- a/src/test/php/d4np/utils/Http/SessionTest.php
+++ b/src/test/php/d4np/utils/Http/SessionTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace D4np\Utils\Tests\Http;
 
+use D4np\Utils\Http\NativeSessionApi;
 use D4np\Utils\Http\SameSite;
 use D4np\Utils\Http\Session;
 use D4np\Utils\Http\SessionStore;
 use D4np\Utils\Support\HttpException;
+use D4np\Utils\Tests\Http\Fixture\RecordingSessionApi;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -16,14 +18,19 @@ use PHPUnit\Framework\TestCase;
  *
  * **What this file can and cannot cover, stated up front.** PHP will not run a session in CLI —
  * `session_start()`, `session_set_cookie_params()` and `session_regenerate_id()` all return
- * `false`, verified — so `start()` and `regenerate()` cannot be exercised here at all. That is
- * exactly why the cookie **policy** is a pure value (`cookieParams()`): it lets FR-15's three
- * flags be asserted without a live session, which is the half that would otherwise have no unit
- * test whatsoever.
+ * `false`, verified. Two structural moves put the logic back in reach anyway: the cookie **policy**
+ * is a pure value (`cookieParams()`), and the session functions come through a `SessionApi` seam
+ * (ADR-0026 §8) that a fake can record.
  *
- * The behaviour against a real server — that the cookie actually carries the flags, that the
- * session identifier actually changes across `regenerate()` — is roadmap item **6.3**'s
- * integration suite against a `php -S` process. Named here rather than left as a silent hole.
+ * The second move exists mostly for one property. `start()` must apply the cookie parameters
+ * *before* the session starts; applied after, they have no effect and the cookie goes out without
+ * FR-15's flags — a session that works perfectly and is unprotected. Both orderings produce a
+ * working session, so nothing about the outcome distinguishes them. Only the call sequence does,
+ * which is what `RecordingSessionApi` makes visible.
+ *
+ * What remains outside this file is genuinely behavioural: that a real browser cookie carries the
+ * flags, and that a real session identifier changes across `regenerate()`. That is roadmap item
+ * **6.3**'s integration suite against a `php -S` process.
  */
 #[Group('T-03')]
 final class SessionTest extends TestCase
@@ -166,7 +173,95 @@ final class SessionTest extends TestCase
         self::assertSame([], $_SESSION);
     }
 
-    // ---- the guards that are reachable without a live session ------------------------------------
+    // ---- start(): ordering, guards and error paths, through the seam -----------------------------
+
+    /**
+     * **The reason the seam exists.**
+     *
+     * `session_set_cookie_params()` has no effect once the session has started. Get the order wrong
+     * and everything still works — a session is created, values round-trip, tests pass — except the
+     * cookie went out without `httponly`, `secure` or `samesite`. The failure is invisible in every
+     * observable outcome, so the sequence itself has to be the assertion.
+     */
+    public function testStartAppliesTheCookiePolicyBeforeStartingTheSession(): void
+    {
+        $api = new RecordingSessionApi();
+
+        (new Session(api: $api))->start();
+
+        self::assertSame(
+            ['setCookieParams', 'start'],
+            $api->calls,
+            'parameters set after start() are silently ignored, and the cookie loses FR-15 flags',
+        );
+    }
+
+    /**
+     * And the policy that reaches PHP is the same value `cookieParams()` publishes — otherwise the
+     * flag assertions above would be testing a value nothing consumes.
+     */
+    public function testStartAppliesExactlyThePublishedPolicy(): void
+    {
+        $api = new RecordingSessionApi();
+        $session = new Session(sameSite: SameSite::Strict, path: '/app', api: $api);
+
+        $session->start();
+
+        self::assertSame($session->cookieParams(), $api->params);
+    }
+
+    /**
+     * A request reaching two entry points should not fail on the second, so an already-active
+     * session is a no-op — and, importantly, must not re-apply parameters that would be ignored.
+     */
+    public function testStartOnAnAlreadyActiveSessionDoesNothing(): void
+    {
+        $api = new RecordingSessionApi(status: PHP_SESSION_ACTIVE);
+
+        (new Session(api: $api))->start();
+
+        self::assertSame([], $api->calls);
+    }
+
+    public function testStartRefusesWhenSessionsAreDisabledInTheBuild(): void
+    {
+        $api = new RecordingSessionApi(status: PHP_SESSION_DISABLED);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/disabled in this PHP build/');
+
+        (new Session(api: $api))->start();
+    }
+
+    /**
+     * If the flags cannot be applied, the session must **not** start. Starting anyway would produce
+     * exactly the unprotected session this class exists to prevent, and would do it silently.
+     */
+    public function testStartDoesNotStartASessionWhoseCookiePolicyCouldNotBeApplied(): void
+    {
+        $api = new RecordingSessionApi(setCookieParamsSucceeds: false);
+
+        try {
+            (new Session(api: $api))->start();
+            self::fail('expected the failed cookie policy to be refused');
+        } catch (HttpException $e) {
+            self::assertMatchesRegularExpression('/Could not apply the session cookie parameters/', $e->getMessage());
+        }
+
+        self::assertSame(['setCookieParams'], $api->calls, 'an unprotected session must never be started');
+    }
+
+    public function testStartRefusesWhenTheSessionCannotBeStarted(): void
+    {
+        $api = new RecordingSessionApi(startSucceeds: false);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/Could not start the session/');
+
+        (new Session(api: $api))->start();
+    }
+
+    // ---- regenerate(): the session-fixation defence ----------------------------------------------
 
     /**
      * `regenerate()` before `start()` is a programming error, and saying so is more useful than
@@ -174,11 +269,77 @@ final class SessionTest extends TestCase
      */
     public function testRegenerateBeforeStartIsRefused(): void
     {
-        self::assertNotSame(PHP_SESSION_ACTIVE, session_status(), 'this test assumes no active session');
+        $api = new RecordingSessionApi();
 
         $this->expectException(HttpException::class);
         $this->expectExceptionMessageMatches('/before the session has started/');
 
-        (new Session())->regenerate();
+        (new Session(api: $api))->regenerate();
+    }
+
+    public function testRegenerateReplacesTheIdentifierOnceTheSessionIsRunning(): void
+    {
+        $api = new RecordingSessionApi();
+        $session = new Session(api: $api);
+
+        $session->start();
+        $session->regenerate();
+
+        self::assertSame(['setCookieParams', 'start', 'regenerateId'], $api->calls);
+    }
+
+    /**
+     * A failed regeneration is refused rather than ignored: swallowing it leaves the caller
+     * believing a privilege transition rotated the identifier when it did not, which is the whole
+     * of session fixation.
+     */
+    public function testRegenerateRefusesWhenPhpCannotRegenerate(): void
+    {
+        $api = new RecordingSessionApi(regenerateSucceeds: false);
+        $session = new Session(api: $api);
+        $session->start();
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/Could not regenerate/');
+
+        $session->regenerate();
+    }
+
+    // ---- destroy() -------------------------------------------------------------------------------
+
+    public function testDestroyDestroysTheServerSideRecordWhenOneExists(): void
+    {
+        $_SESSION = ['a' => '1'];
+        $api = new RecordingSessionApi(status: PHP_SESSION_ACTIVE);
+
+        (new Session(api: $api))->destroy();
+
+        self::assertSame([], $_SESSION);
+        self::assertSame(['destroy'], $api->calls);
+    }
+
+    public function testDestroyClearsTheDataWithoutCallingPhpWhenNoSessionIsActive(): void
+    {
+        $_SESSION = ['a' => '1'];
+        $api = new RecordingSessionApi();
+
+        (new Session(api: $api))->destroy();
+
+        self::assertSame([], $_SESSION);
+        self::assertSame([], $api->calls, 'session_destroy() without an active session only emits a warning');
+    }
+
+    // ---- the seam must not become the production path --------------------------------------------
+
+    /**
+     * Everything above runs against a fake, which is only meaningful if the real wiring is the real
+     * thing. A default quietly changed to a test double would leave this whole file green while the
+     * library did nothing.
+     */
+    public function testTheDefaultSessionApiIsPhpsOwn(): void
+    {
+        $api = (new \ReflectionProperty(Session::class, 'api'))->getValue(new Session());
+
+        self::assertInstanceOf(NativeSessionApi::class, $api);
     }
 }

--- a/src/test/php/d4np/utils/Http/SessionTest.php
+++ b/src/test/php/d4np/utils/Http/SessionTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http;
+
+use D4np\Utils\Http\SameSite;
+use D4np\Utils\Http\Session;
+use D4np\Utils\Http\SessionStore;
+use D4np\Utils\Support\HttpException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-15's session hardening.
+ *
+ * **What this file can and cannot cover, stated up front.** PHP will not run a session in CLI —
+ * `session_start()`, `session_set_cookie_params()` and `session_regenerate_id()` all return
+ * `false`, verified — so `start()` and `regenerate()` cannot be exercised here at all. That is
+ * exactly why the cookie **policy** is a pure value (`cookieParams()`): it lets FR-15's three
+ * flags be asserted without a live session, which is the half that would otherwise have no unit
+ * test whatsoever.
+ *
+ * The behaviour against a real server — that the cookie actually carries the flags, that the
+ * session identifier actually changes across `regenerate()` — is roadmap item **6.3**'s
+ * integration suite against a `php -S` process. Named here rather than left as a silent hole.
+ */
+#[Group('T-03')]
+final class SessionTest extends TestCase
+{
+    /**
+     * FR-15's three flags, asserted as a value because they cannot be asserted as behaviour here.
+     */
+    public function testTheCookiePolicyCarriesFr15sThreeFlags(): void
+    {
+        $params = (new Session())->cookieParams();
+
+        self::assertTrue($params['httponly'], 'a session id readable from JavaScript defeats the point');
+        self::assertTrue($params['secure'], 'the id must never travel over plain HTTP');
+        self::assertSame('Lax', $params['samesite'], 'a second, independent line against CSRF');
+    }
+
+    /**
+     * A session cookie, not a persistent one: it dies with the browser session rather than sitting
+     * on disk with an expiry the server cannot revoke.
+     */
+    public function testTheCookieIsASessionCookie(): void
+    {
+        self::assertSame(0, (new Session())->cookieParams()['lifetime']);
+    }
+
+    public function testThePathIsConfigurable(): void
+    {
+        self::assertSame('/', (new Session())->cookieParams()['path']);
+        self::assertSame('/app', (new Session(path: '/app'))->cookieParams()['path']);
+    }
+
+    /**
+     * `secure: false` exists for local `http://` development and nothing else. It is a named
+     * argument rather than an auto-detection precisely so it shows up in the wiring — the same
+     * shape as `Hash`'s `bcryptFallback`.
+     */
+    public function testSecureCanBeDisabledExplicitlyForLocalHttp(): void
+    {
+        self::assertFalse((new Session(secure: false))->cookieParams()['secure']);
+    }
+
+    /**
+     * `httponly` has no opt-out at all: no legitimate caller needs the session identifier readable
+     * from JavaScript, and offering the switch would be offering the vulnerability.
+     */
+    public function testHttpOnlyHasNoOptOut(): void
+    {
+        foreach ([new Session(), new Session(secure: false), new Session(sameSite: SameSite::Strict)] as $session) {
+            self::assertTrue($session->cookieParams()['httponly']);
+        }
+    }
+
+    public function testSameSiteIsConfigurableAmongTheLegalValues(): void
+    {
+        self::assertSame('Strict', (new Session(sameSite: SameSite::Strict))->cookieParams()['samesite']);
+        self::assertSame('None', (new Session(sameSite: SameSite::None))->cookieParams()['samesite']);
+    }
+
+    /**
+     * There is no "illegal SameSite value" test, and its absence is the point.
+     *
+     * `SameSite` is a closed enum, so an illegal value is a compile-time impossibility rather than
+     * a runtime check — the same reasoning ADR-0015 applied to `Sort` and `Operator`, and what
+     * PHPStan pushed this toward by typing `session_set_cookie_params()` against a literal union.
+     * What is worth asserting instead is that the set is exactly the three the specification
+     * defines, so widening it stays a deliberate act.
+     */
+    public function testSameSiteIsAClosedSetOfExactlyThreePolicies(): void
+    {
+        self::assertSame(['Lax', 'Strict', 'None'], array_map(
+            static fn (SameSite $case): string => $case->value,
+            SameSite::cases(),
+        ));
+    }
+
+    /**
+     * The one constraint the type system cannot express, because it spans two arguments: browsers
+     * **drop** a `SameSite=None` cookie that is not `Secure`. Refusing at construction turns that
+     * into a wiring-time error instead of "sessions do not work" in production.
+     */
+    public function testSameSiteNoneWithoutSecureIsRefused(): void
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/requires a Secure cookie/');
+
+        new Session(sameSite: SameSite::None, secure: false);
+    }
+
+    // ---- storage --------------------------------------------------------------------------------
+
+    public function testItIsASessionStore(): void
+    {
+        self::assertInstanceOf(SessionStore::class, new Session());
+    }
+
+    /**
+     * Reads and writes go through `$_SESSION`, which is an ordinary superglobal here even though
+     * no session is active — enough to assert the storage contract `CsrfToken` depends on.
+     */
+    public function testStorageRoundTripsThroughTheSessionSuperglobal(): void
+    {
+        $_SESSION = [];
+        $session = new Session();
+
+        self::assertNull($session->get('absent'));
+
+        $session->set('k', 'v');
+        self::assertSame('v', $session->get('k'));
+        self::assertSame('v', $_SESSION['k'] ?? null);
+
+        $session->remove('k');
+        self::assertNull($session->get('k'));
+
+        $_SESSION = [];
+    }
+
+    /**
+     * A session written by other code can hold anything. Casting an array or object to a string
+     * here would be the same coercion `Request` refuses, for the same reason (ADR-0025).
+     */
+    public function testNonStringSessionValuesReadBackAsNullRatherThanBeingCoerced(): void
+    {
+        $_SESSION = ['arr' => ['a'], 'obj' => new \stdClass(), 'int' => 42, 'null' => null];
+        $session = new Session();
+
+        self::assertNull($session->get('arr'));
+        self::assertNull($session->get('obj'));
+        self::assertNull($session->get('int'));
+        self::assertNull($session->get('null'));
+
+        $_SESSION = [];
+    }
+
+    public function testDestroyEmptiesTheSessionData(): void
+    {
+        $_SESSION = ['a' => '1', 'b' => '2'];
+
+        (new Session())->destroy();
+
+        self::assertSame([], $_SESSION);
+    }
+
+    // ---- the guards that are reachable without a live session ------------------------------------
+
+    /**
+     * `regenerate()` before `start()` is a programming error, and saying so is more useful than
+     * PHP's own warning-and-`false`.
+     */
+    public function testRegenerateBeforeStartIsRefused(): void
+    {
+        self::assertNotSame(PHP_SESSION_ACTIVE, session_status(), 'this test assumes no active session');
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/before the session has started/');
+
+        (new Session())->regenerate();
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item 6.2 (spec FR-12, FR-15; RFC-0001 R-1 places CSRF in `Http`).

**One probe shaped the whole item** — PHP will not run a session in CLI:

```
session_start()             -> false
session_set_cookie_params() -> false
session_regenerate_id(true) -> false
```

Left alone, FR-15's three cookie flags and the entirety of CSRF validation would have had **no unit assertion at all**, resting entirely on item 6.3's integration suite. For CSRF validation that's the wrong place for the only coverage to live. So: the cookie policy is exposed as a **value** (`cookieParams()`, pure — ADR-0022's move), and `CsrfToken` depends on a three-method `SessionStore` rather than `$_SESSION` (ADR-0006 refused an interface until a consumer needed one; here one does).

## ⚠️ The finding: `hash_equals()` → `===` passed the entire suite

| planted | failures |
|---|---|
| predictable token (constant) | 5 |
| scope validation removed | 14 |
| `httponly` turned off | 2 |
| **`hash_equals()` → `===`** | **0 — passed** |

That's the single most important line in CSRF validation. It passed because **`hash_equals($a,$b)` and `$a === $b` return identical values for every input** — they differ only in timing. No functional assertion can distinguish them, and a PHP-level timing test is too noisy to be anything but flaky. (I verified the probe genuinely applied this time — the marker was present before the edit.)

I nearly wrote it up as an accepted gap. **Item 5.3 is why I didn't**: there I documented an untestable branch as acceptable, moved on, and the coverage gate dragged me back to solve it. A gap written up as acceptable is a gap nobody closes.

So the mechanism is asserted directly, via reflection over `validate()`'s source — **item 4.6's pattern**: when a property can't be observed in behaviour, assert the thing that produces it. Re-running the probe now fails. Three occurrences of this shape in three items (4.6 sub-noise saving, 5.3 unreachable branch, 6.2 timing-only property) makes it a pattern worth naming.

## PHPStan pushed `SameSite` to a decision ADR-0015 had already made

It started as a validated `string`; PHPStan rejected it because `session_set_cookie_params()` is typed against a literal union. The right fix wasn't a narrower docblock but an **enum** — exactly what ADR-0015 decided for `Sort`/`Operator`. Reaching that from a static-analysis complaint rather than first principles suggests the earlier decision generalises.

It also *deleted* a test: "illegal SameSite is refused" became a compile-time impossibility, replaced by one assertion that the set is exactly the three the spec defines.

## Defaults, and which have no opt-out

- **`secure: true`** with an explicit named opt-out for local `http://` — **not** auto-detection from `$_SERVER['HTTPS']`, which would silently disable the flag on exactly the misconfigured-proxy deployment that needs it most.
- **`httponly` has no opt-out.** Offering the switch would be offering the vulnerability.
- **`SameSite=Lax`, not `Strict`** — `Strict` withholds the cookie from ordinary inbound links, so a user following one from an email arrives logged out; that's the kind of breakage that gets a control switched off entirely.
- **`None` without `Secure` refused at construction** — browsers drop that combination, so this surfaces at wiring time instead of as "sessions don't work".
- **A token is issued once per scope and reused** — regenerating per render invalidates the token in another open tab. `rotate()` is the explicit privilege-transition call.
- **Scope names validated** — a scope becomes a session-storage key, so one from user input would let a client grow the session record one key per request.

## Test plan

- [x] `vendor/bin/phpunit` — 1175 tests, 2576 assertions, 7 skipped
- [x] `--group T-03` runs 66
- [x] PHPStan max clean · deptrac 0/0 · consistency + action-pin lints OK
- [x] CI — 12/12 green, coverage **90.87%** (816/898)

## The coverage gate found a defect, not just a shortfall

The first push failed `quality / coverage floor` at **89.59%**, `Session` at 61.54% — the `start()`/`regenerate()` gap this PR had written up as acceptable. Chasing it turned up something the suite genuinely could not see.

`start()` must apply the cookie parameters **before** starting the session, because `session_set_cookie_params()` has no effect afterwards. The class docblock already called that ordering *"not optional"*. **Nothing tested it.** Swap the two and everything still works — session created, values round-trip, all 1157 tests green — and the cookie ships with none of `httponly`, `secure`, `samesite`. Both orderings produce a working session, so only the call *sequence* distinguishes them.

That is §7's situation a second time in the same class. `hash_equals` vs `===` is invisible because the values match and only the timing differs; params-before-start is invisible because the session works either way. The first announced itself as a probe that passed; this one sat quietly in a comment I wrote myself.

Three exits rejected, all recorded in ADR-0026's Alternatives:

- **lowering the 90% floor** — the precise failure this project's discipline exists to prevent;
- **`@codeCoverageIgnore`** — would hide the session-fixation defence from measurement;
- **testing only `start()`'s CLI failure path**, which *is* reachable (`session_set_cookie_params()` returns `false`, so the guard throws). One test, +4 lines, **90.03%** — clearing the gate by 0.03% while asserting nothing. A coverage fix wearing a test's clothes, and the one worth naming because it was tempting.

So `SessionApi` (five methods, no behaviour) with `NativeSessionApi` delegating to PHP and nothing else. `Session` keeps the guards, the ordering and the error mapping; `RecordingSessionApi` asserts the sequence. Justified as §2 justifies `SessionStore`, and it satisfies ADR-0006's rule that an interface waits for a consumer — the consumer arrived.

`Session` is now **100%** (39/39). What stays uncovered is `NativeSessionApi`'s five single-statement delegations (1/5), which is the point of the split.

**Probes, all caught:** ordering swapped → **3** failures (previously 0) · `session_regenerate_id(true)` → `()` → **1** (previously 0) · `status()` stubbed to a constant → **1**.

That last probe also exposed a weak test of my own: `testStatusReportsPhpsOwnSessionStatus` stayed green under the stub, because CLI only ever reports `PHP_SESSION_NONE`. Its docblock now says so rather than implying it pins the implementation.

## Honest gap

What remains is genuinely behavioural: that a real browser cookie carries the flags, and that a real identifier changes across `regenerate()`. **Item 6.3**'s `php -S` suite owns it.

Route mismatch recorded (frontier-routed, standard session), on the precedent you set at 5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
