### PR TITLE
feat(container): PSR-11 Container and ServiceProvider, with NFR-02 measured

### DIFF
--- a/.eados-core/learning/runs/2026-08-05-utils-5.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils-5.yaml
@@ -1,0 +1,33 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- `D4np\Utils\Container\Container` (PSR-11), `ServiceProvider`, and the `ContainerException` /
+  `NotFoundException` / `CircularDependencyException` trio (**ADR-0028**) — spec FR-04, FR-05,
+  NFR-02, imported ADR-001. Constructor autowiring over the **shared** `ReflectionCache`, plus
+  `instance()`, `singleton()`, `factory()` and `bind()` definitions.
+  **The refusals are the design.** Imported ADR-001 bought a hand-written container by promising it
+  would fail loudly wherever a mature one adds a feature, so an unbound interface, an abstract
+  class, a non-public constructor, a built-in or untyped parameter without a default, and a
+  union-typed parameter are each declined with a message naming the parameter and the class.
+  Circular dependencies throw with the **full path** (`A -> B -> C -> A`) and are a distinct
+  exception type, because the container acts on the distinction: a parameter default may answer an
+  absent dependency and must not answer a cycle.
+  Autowired instances are **shared** by default, with `factory()` as the explicit opt-out; `has()`
+  answers for what `get()` would actually do rather than for the registration table.
+  **`get()` declares a conditional return type PSR-11 does not have** — `get(Mailer::class)` is a
+  `Mailer`, while a string-keyed entry stays `mixed`. `ContainerInterface::get()` carries no return
+  type at all in psr/container 2.0.2, so without this every consumer at PHPStan max would narrow at
+  every call site.
+  **NFR-02 measured and met**: 0.173 µs warm singleton resolve (≤ 2 µs) and 18.593 µs first
+  autowired resolve of a four-class graph (≤ 30 µs), on a developer machine rather than NFR-06's
+  reference machine — not asserted as a CI gate, per ADR-0018; nightly tracking is item 7.1.
+
 - **T-03**, spec §7's session/CSRF integration suite, against a real `php -S` process — 17 tests
   covering everything ADR-0026 structurally could not reach in CLI: FR-15's three flags on a live
   `Set-Cookie`, the configured policy reaching the header, state surviving across requests,

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ setup.
 
 | # | Title | Status |
 |---|---|---|
-| 1 | Project bootstrap & CI | ⏳ in progress |
-| 2 | Support layer | ⏳ planned |
-| 3 | DTO & data mapping | ⏳ planned |
-| 4 | Database | ⏳ planned |
-| 5 | Security | ⏳ planned |
-| 6 | HTTP, container, errors | ⏳ planned |
+| 1 | Project bootstrap & CI | ✅ done |
+| 2 | Support layer | ✅ done |
+| 3 | DTO & data mapping | ✅ done |
+| 4 | Database | ✅ done |
+| 5 | Security | ✅ done |
+| 6 | HTTP, container, errors | 🚧 in progress (6.5 remaining) |
 | 7 | Release engineering & bridge | ⏳ planned |
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-05 — Measuring the requirement instead of arguing with it](docs/journal/2026/08/2026-08-05-t03-integration.md).
+  [2026-08-05 — Two assumptions, and a benchmark that measured the harness](docs/journal/2026/08/2026-08-05-container.md).
 
 ## Model & effort routing (advisory)
 
@@ -388,8 +388,20 @@ The application-facing groups (RFC-0001).
       T-03 r2 now requires the **mechanism assertion** instead, stated positively and negatively
       across every secret-comparison path, with a registry that guards its own completeness. No
       standing deviation. **No production code changed in this item.***
-- [ ] 6.4 `Container` (PSR-11) + `ServiceProvider`; NFR-02 benchmarks (RFC-0001, imported
-      ADR-001) (severity:medium) — route: standard / medium
+- [x] 6.4 `Container` (PSR-11) + `ServiceProvider`; NFR-02 benchmarks (RFC-0001, imported
+      ADR-001) (severity:medium) — route: standard / medium *(session model matched the route —
+      no mismatch)* · **ADR-0028**. *Constructor autowiring over the shared `ReflectionCache`,
+      singleton/factory/bind definitions, and imported ADR-001's non-goals enforced as refusals —
+      unbound interfaces, abstract classes, built-in and untyped parameters, and union types are all
+      declined with a message naming the parameter and the class. **NFR-02 met: 0.173 µs warm
+      (≤ 2), 18.593 µs first autowired (≤ 30).** Getting there needed two benchmark fixes: phpbench
+      runs `beforeMethods` once per *iteration*, so a cold subject must build its container inside
+      the subject; and the first revolution was paying Composer's autoloading, which phpbench
+      smeared across all revs — the tell was **93 µs at 200 revs vs 26 µs at 2000 for identical
+      work**. Container exceptions live in the `Container` group, not `Support`, because `Support`
+      depends on nothing and PSR-11 would have broken that (5 deptrac violations, probed). `get()`
+      carries a **conditional return type** PSR-11 lacks, so consumers at PHPStan max are not taxed
+      at every call site.*
 - [ ] 6.5 `Result`, PSR-3 `Logger`, `ExceptionHandler` with env-gated trace policy (RFC-0001)
       (severity:medium) — route: standard / medium
 

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -96,6 +96,11 @@ deptrac:
       - Support
     Container:
       - Support
+      # The Container implements PSR-11, and its exceptions implement PSR-11's own exception
+      # interfaces (spec FR-04, imported ADR-001). Those exceptions live in this group rather than
+      # in Support with the rest of the hierarchy precisely so this grant stays here: Support
+      # depends on nothing, and that must not change to accommodate one class (ADR-0028).
+      - Psr
     Database:
       - Support
     Security:

--- a/docs/adr/0028-container-exceptions-live-in-the-container-group-and-get-carries-a-type.md
+++ b/docs/adr/0028-container-exceptions-live-in-the-container-group-and-get-carries-a-type.md
@@ -1,0 +1,150 @@
+# ADR-0028: Container exceptions live in the Container group, and `get()` carries a type PSR-11 does not
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 6.4 · spec FR-04, FR-05, NFR-02 ·
+  imported [ADR-001](../../.specs/d4np_php_adr_001_di_container.md) (why a hand-written container
+  at all) · [ADR-0004](0004-root-the-exception-hierarchy-on-an-interface.md) (the exception root) ·
+  [ADR-0006](0006-shared-reflection-metadata-cache.md) (the one metadata cache, and the union-type
+  refusal this depends on) · [ADR-0012](0012-deptrac-layers-by-directory.md) (the layering this
+  obeys) · [ADR-0018](0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md) (the
+  benchmark caveat carried forward)
+
+## Context
+
+Imported ADR-001 already decided *whether* to ship a container and what its non-goals are. Three
+questions it does not answer came up while building it, and each has a wrong answer that would have
+looked reasonable.
+
+## Decision
+
+### 1. The container's exceptions live in `Container/`, not in `Support/` with every other exception
+
+PSR-11 requires them to implement `ContainerExceptionInterface` and `NotFoundExceptionInterface`.
+Every other exception in this library lives in `Support`, and `deptrac.yaml` declares
+`Support: ~` — depending on **nothing**. That empty list is the load-bearing half of RFC-0001's
+layering rule; ADR-0010 had to design around it once already.
+
+So either `Support` gains a dependency on PSR-11 to host one class, or the class moves to the layer
+already allowed to see PSR-11. It moves. A layering rule that bends the first time something is
+inconvenient is not a rule, and `Container` is where these exceptions are thrown anyway.
+
+**Verified, not assumed:** removing the `Psr` grant from the `Container` layer produces five deptrac
+violations naming each class. `Support`, having no grants at all, would have failed the same way.
+
+The hierarchy is unaffected in the way that matters: `ContainerException extends UtilsException`, so
+ADR-0004's contract holds — a consumer catching `UtilsThrowable` catches these, and one catching
+`ContainerExceptionInterface` gets the PSR behaviour. Neither audience is told about the other.
+
+`CircularDependencyException` is a third class rather than a message on the second, because the
+container **acts** on the distinction: an ordinary resolution failure may fall back to a parameter's
+default, and a cycle must not. Deciding that by matching on message text would be a decision that
+breaks the day someone rewords a string.
+
+### 2. `get()` declares a conditional return type, which PSR-11 does not
+
+`ContainerInterface::get()` is untyped in psr/container 2.0.2 — verified, the interface declares
+`get(string $id)` with no return type at all. Implemented plainly as `mixed`, every consumer under
+PHPStan at max must narrow at every call site. This library holds *itself* to max, so shipping that
+would be exporting the noise.
+
+```php
+@return ($id is class-string<T> ? T : mixed)
+```
+
+A class name returns that class; any other identifier stays `mixed`, because a string key genuinely
+says nothing about its value. That asymmetry is honest rather than incidental, and it shows up in
+the tests: `get(Greeter::class)->greet()` type-checks, `get('greeting.suffix')` gets narrowed.
+
+**This needs no dedicated test.** Removing the annotation fails **11** existing PHPStan checks,
+because tests like `testDependenciesAreResolvedRecursively()` dereference `get()`'s result. The
+property is already gated by CI's static-analysis step, non-vacuously — probed to confirm rather
+than assumed.
+
+### 3. Autowired instances are shared by default; `factory()` is the opt-out
+
+NFR-02's warm budget only means something if a second `get()` is a lookup rather than a rebuild, and
+a container that silently rebuilt a graph on every call would turn one shared connection into
+hundreds. `factory()` states the other intent explicitly.
+
+### 4. `has()` answers for behaviour, not for the registration table
+
+It returns `true` for any instantiable class, because those are exactly the identifiers `get()` will
+return a value for, and `false` for an unbound interface or abstract class, because those are what
+it refuses. Reporting `false` for a class the container would happily autowire would make `has()` a
+statement about bookkeeping rather than about what the container does.
+
+## The NFR-02 benchmark, and a measurement error worth recording
+
+Measured on an idle Windows developer machine, OPcache off:
+
+| subject | measured | NFR-02 |
+|---|---|---|
+| warm singleton resolve (4-class graph) | **0.173 µs** | ≤ 2 µs |
+| warm instance resolve (plain value) | 0.169 µs | — (the floor) |
+| first autowired resolve (4-class graph) | **18.593 µs** | ≤ 30 µs |
+| first autowired resolve (single class) | 2.646 µs | — (per-class floor) |
+
+Both halves pass. The first version of the benchmark said otherwise, and the reason is instructive.
+
+phpbench runs `beforeMethods` **once per iteration** and then loops the subject over every
+revolution — read from `Executor/Benchmark/template/remote.template`, not assumed. A cold subject
+therefore has to build its own container *inside* the subject, or 999 of 1000 revolutions measure
+the warm path.
+
+Doing that correctly still reported **93 µs** against a 30 µs budget. The tell was that the number
+moved with the revolution count: **93 µs at 200 revs, 26 µs at 2000, for identical work.** The
+subject's first revolution was paying Composer's autoloading — four `stat`s and four `include`s —
+and phpbench divides the total by the revolution count, smearing a one-time cost across every
+measurement. Warming the *class loader* (while leaving the *metadata cache* cold, which is what
+NFR-02's "first" actually means) gives **18.4 / 18.3 / 18.1 µs at 200 / 1000 / 4000 revs** — a
+number that no longer moves with the harness is a number about the subject.
+
+This is the second time a benchmark of mine has been wrong in the same direction; ADR-0020 records
+the first, on NFR-03. Both were caught by asking what the workload actually contained rather than by
+trusting the total.
+
+Per ADR-0018, these ceilings are **not** asserted as a hard CI gate: they are tied to spec NFR-06's
+reference machine, and a slower runner would fail for reasons unrelated to a regression. The
+numbers above are from a developer machine, not that reference machine. Nightly baseline tracking is
+roadmap item **7.1**.
+
+## Alternatives Considered
+
+- **Container exceptions in `Support/` with the rest** — rejected in §1: it requires the bottom
+  layer to depend on PSR-11, which deptrac correctly refuses.
+- **One `ContainerException` with a "circular" message** — rejected in §1: the container branches on
+  the distinction, and branching on message text breaks on a reword.
+- **Plain `mixed` from `get()`** — rejected in §2 as exporting analysis noise to every consumer.
+- **`ServiceProvider` with a `boot()` phase** — rejected: two-phase lifecycles exist to order side
+  effects across providers, which is application composition, not a utility library's job. The base
+  class stays at one method, and a test asserts it has not grown a second.
+- **Rebuilding autowired instances per `get()`** — rejected in §3.
+- **`has()` true only for registered entries** — rejected in §4.
+- **Resolving cycles** (lazy proxies, deferred injection) — rejected by imported ADR-001, which
+  answers such requests with "adopt a mature container instead".
+
+## Consequences
+
+- 37 tests across `Container` and `ServiceProvider`. **Verified non-vacuous**: disabling the cycle
+  guard exhausts memory and kills the process (which is what an unguarded cycle does); disabling
+  instance sharing fails 3; removing the `get()` annotation fails 11 PHPStan checks; removing the
+  deptrac `Psr` grant produces 5 violations.
+- Two bugs were found by tests failing rather than by review, both from assumptions worth naming:
+  `class_exists()` is **false for an interface**, so an unbound interface was reported as "no such
+  class" instead of "bind it" — the exact case `ReflectionCache`'s three-way check exists for; and
+  `mixed` is a **named built-in type**, not an absent one, so the original "untyped parameter"
+  fixture silently exercised the built-in branch. A promoted readonly property cannot be untyped at
+  all, which is why that fixture is the only one not using promotion.
+- The container accepts and exposes a `ReflectionCache`, honouring imported ADR-001's commitment to
+  **one** metadata cache shared with the DTO hydrator.
+
+## References
+
+- Imported ADR-001 — the scope limits this implements
+- ADR-0006 — the shared cache, and the preserved `declaredType` that makes the union-type refusal
+  able to name what it saw
+- ADR-0012 — the deptrac layering that decided §1
+- ADR-0020 — the previous benchmark-workload error, same shape as the one above
+- psr/container **2.0.2**, whose `ContainerInterface::get()` carries no return type — verified

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0025](0025-typed-http-wrappers-that-refuse-rather-than-coerce.md) | HTTP wrappers that mirror PSR-7's naming, and refuse rather than coerce | Accepted |
 | [0026](0026-session-hardening-as-a-value-and-csrf-through-a-seam.md) | Session hardening as a value, CSRF through a seam, and a mechanism asserted because behaviour cannot see it | Accepted |
 | [0027](0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md) | Constant-time comparison asserted by mechanism, not by timing — the spec amended on measured evidence | Accepted |
+| [0028](0028-container-exceptions-live-in-the-container-group-and-get-carries-a-type.md) | Container exceptions in the Container group, a typed `get()`, and a benchmark that measured the harness | Accepted |

--- a/docs/journal/2026/08/2026-08-05-container.md
+++ b/docs/journal/2026/08/2026-08-05-container.md
@@ -1,0 +1,101 @@
+# 2026-08-05 — Two assumptions, and a benchmark that measured the harness
+
+Roadmap item **6.4**. Route `standard / medium` → Opus 5, which is the session model: **no mismatch
+for the first time since 5.2.** Nothing to record.
+
+## The layering decided a placement I'd have got wrong by habit
+
+Every exception in this library lives in `Support`. PSR-11 requires the container's to implement
+`ContainerExceptionInterface`, and `deptrac.yaml` says `Support: ~` — depends on **nothing**.
+
+So the habit was wrong, and the config was right. Putting them in `Support` means the bottom layer
+takes a dependency to host one class; putting them in `Container` costs nothing, since that is where
+they are thrown. Probed rather than reasoned: dropping the `Psr` grant produces five deptrac
+violations naming each class, and `Support` — which has no grants at all — would fail identically.
+
+`ContainerException extends UtilsException` still, so ADR-0004 holds: catch `UtilsThrowable` and you
+catch these, catch PSR-11's interface and you get PSR behaviour.
+
+One extra class: `CircularDependencyException`. I first wrote the fallback logic as
+`str_contains($e->getMessage(), 'Circular dependency')` — a branch on prose, which breaks silently
+the day someone rewords a message. The container genuinely acts on the distinction (a default may
+answer an absent dependency; it must not answer a cycle), so the distinction gets a type.
+
+## Two things I assumed, and both were wrong
+
+Caught by tests failing, not by review.
+
+**`class_exists()` is false for an interface.** So `get(Greeter::class)` on an unbound interface
+came back "no entry is registered … not a loadable class" — sending the reader to hunt for a typo
+instead of telling them to `bind()` it. `ReflectionCache`'s docblock had already written this down
+for me, in item 2.5: *"the Container in particular must be able to reflect an interface in order to
+refuse it as non-instantiable."* I read that class, used it, and still assumed the wrong thing about
+`class_exists`.
+
+**`mixed` is a named built-in type, not an absent one.** My "untyped parameter" fixture used
+`mixed $anything` and quietly exercised the built-in branch instead. Worse, a promoted readonly
+property *must* carry a type, so the fixture could not have been written the obvious way — the
+fixture is the only one in the set that doesn't use promotion, and now says why.
+
+Both are the same shape as the T-03 probe that reported `ABSENT`: the code did something reasonable,
+and I read the result as confirming what I expected.
+
+## The benchmark was measuring the benchmark
+
+NFR-02: ≤ 2 µs warm, ≤ 30 µs first autowired. First run said **103 µs**.
+
+Before calling that an NFR violation, I timed the same resolve directly: **17.8 µs**. A 6× gap
+between two measurements of identical work means at least one of them is not measuring what it
+claims.
+
+Two errors, found in order:
+
+1. phpbench runs `beforeMethods` **once per iteration**, then loops the subject over every
+   revolution — read out of `remote.template`, since guessing this wrong is exactly how a cold
+   benchmark quietly becomes a warm one. A cold container set up in a hook would have been cold for
+   revolution 1 and warm for the other 999.
+2. Fixing that still gave 93 µs — and the tell was that **the number moved with the revolution
+   count**: 93 µs at 200 revs, 26 µs at 2000, same work. The subject's first revolution was paying
+   Composer's autoloading, and phpbench divides the total by the revolution count, so a one-time
+   cost got smeared across every measurement.
+
+Warm the class loader, leave the metadata cache cold — which is what NFR-02's "first" actually
+means, since class loading happens once per process whatever the container does:
+
+```
+revs  200 -> 18.368 us
+revs 1000 -> 18.276 us
+revs 4000 -> 18.089 us
+```
+
+A number that stops moving with the harness is a number about the subject. **18.6 µs against a 30 µs
+budget**, and 0.173 µs warm against 2 µs.
+
+This is the second benchmark of mine to be wrong in the same direction — ADR-0020 records the first,
+on NFR-03. Both times the total looked plausible and the *workload* was the thing that wasn't.
+
+## PHPStan turned an annoyance into an API decision
+
+`ContainerInterface::get()` has no return type in psr/container 2.0.2 (checked the vendored file,
+because I would have bet on `: mixed`). Implemented plainly, PHPStan max flagged **12** errors in my
+own tests — every `get()` result dereferenced.
+
+The lazy fix is to narrow in the tests. But the tests are the first consumer, and what they were
+telling me is that every future consumer at max level pays the same tax. So `get()` declares a
+conditional return type: a class name returns that class, any other identifier stays `mixed`.
+
+Twelve errors became two, and those two were honest — string-keyed entries really are untyped.
+
+No test asserts the annotation, and it doesn't need one: removing it fails **11** existing PHPStan
+checks, because the tests dereference what `get()` returns. Probed to confirm that, rather than
+assuming the gate covers it.
+
+## Bar
+
+1233 tests / 2780 assertions green (up from 1196). PHPStan max clean, deptrac 0/0, PHP-CS-Fixer
+clean, consistency lint OK.
+
+## Next
+
+**6.5** — `Result`, PSR-3 `Logger`, `ExceptionHandler` with an env-gated trace policy. Last item of
+Milestone 6.

--- a/src/bench/php/d4np/utils/ContainerBench.php
+++ b/src/bench/php/d4np/utils/ContainerBench.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench;
+
+use D4np\Utils\Bench\Fixture\AutowiredGraph;
+use D4np\Utils\Bench\Fixture\GraphLeaf;
+use D4np\Utils\Container\Container;
+use PhpBench\Attributes as Bench;
+
+/**
+ * NFR-02: a singleton resolve in ≤ 2 µs warm, and a first autowired resolve in ≤ 30 µs.
+ *
+ * **The two halves measure different things, and keeping them apart took reading phpbench's
+ * runner.** Its generated script calls `beforeMethods` **once per iteration** and then loops the
+ * subject over every revolution — verified in `Executor/Benchmark/template/remote.template`. So a
+ * cold subject set up in a `BeforeMethods` hook and run at 1000 revs would measure **one** cold
+ * resolve and 999 warm ones, and report a "cold" number roughly an order of magnitude better than
+ * the truth. The cold subject therefore builds its own container **inside** the subject, where per
+ * revolution means per revolution.
+ *
+ * What that includes, stated plainly: `new Container()` allocates two objects, which is charged to
+ * the cold measurement. Against a ~30 µs budget it is noise, and the alternative — trusting a hook
+ * that does not run when it needs to — is not a trade.
+ *
+ * What "cold" honestly means here is **a cold metadata cache**, not a cold PHP. The classes are
+ * loaded and linked after the first revolution no matter what this file does, and that is the right
+ * subject anyway: `ReflectionCache` pays reflection once per process, so NFR-02's "first" is about
+ * the cache, and the *warm* half is what a running application pays on every request thereafter.
+ * `ContainerTest::testAClassIsReflectedOnlyOnce()` proves the once-per-process half deterministically,
+ * which no benchmark can.
+ *
+ * Both ceilings carry the caveat every benchmark here carries (roadmap 3.5, ADR-0018): they are
+ * tied to spec NFR-06's reference machine and are **not** asserted as a hard CI gate, since a
+ * slower runner would fail for reasons unrelated to a regression. The nightly baseline-tracked
+ * check is roadmap item 7.1.
+ */
+#[Bench\Iterations(10)]
+#[Bench\RetryThreshold(5)]
+final class ContainerBench
+{
+    private Container $warm;
+
+    /**
+     * A container with the graph already resolved, so the subjects below measure the lookup alone.
+     */
+    public function setUpWarm(): void
+    {
+        $this->warm = new Container();
+        $this->warm->instance('config.dsn', 'sqlite::memory:');
+        $this->warm->get(AutowiredGraph::class);
+    }
+
+    /**
+     * NFR-02's warm half: ≤ 2 µs. An autowired graph, resolved again.
+     */
+    #[Bench\BeforeMethods('setUpWarm')]
+    #[Bench\Revs(1000)]
+    #[Bench\Subject]
+    public function benchWarmSingletonResolve(): void
+    {
+        $this->warm->get(AutowiredGraph::class);
+    }
+
+    /**
+     * The cheapest path the container has — a plain registered value — which is the floor the warm
+     * budget is measured against.
+     */
+    #[Bench\BeforeMethods('setUpWarm')]
+    #[Bench\Revs(1000)]
+    #[Bench\Subject]
+    public function benchWarmInstanceResolve(): void
+    {
+        $this->warm->get('config.dsn');
+    }
+
+    /**
+     * Load and link the graph's classes, without warming any metadata cache the subject will use.
+     *
+     * **This hook is the fix for a measurement error, and the error is worth recording.** Without
+     * it the subject's first revolution paid Composer's autoloading — four `stat`s and four
+     * `include`s — and phpbench divides the total by the revolution count, so that one-time cost
+     * was smeared across every revolution. It reported **93 µs** at 200 revs and **26 µs** at 2000,
+     * for identical work: a number that moves with the revolution count is measuring the harness,
+     * not the subject. Directly timed, the same resolve is **~17.8 µs**.
+     *
+     * With the classes loaded here, each revolution below still constructs a fresh `Container` with
+     * a fresh, empty `ReflectionCache` — which is exactly what NFR-02's "first autowired resolve"
+     * means, since class loading happens once per process no matter what any container does.
+     */
+    public function warmTheClassLoader(): void
+    {
+        (new Container())->get(AutowiredGraph::class);
+    }
+
+    /**
+     * NFR-02's cold half: ≤ 30 µs for the first autowired resolve of a four-class graph.
+     *
+     * The container is constructed inside the subject, not in a hook, because phpbench runs hooks
+     * once per *iteration* — see the class docblock.
+     */
+    #[Bench\BeforeMethods('warmTheClassLoader')]
+    #[Bench\Revs(1000)]
+    #[Bench\Subject]
+    public function benchFirstAutowiredResolve(): void
+    {
+        (new Container())->get(AutowiredGraph::class);
+    }
+
+    /**
+     * The same, for a single dependency-free class — the per-class floor, so the graph number above
+     * can be read as "four classes' worth" rather than as an unexplained total.
+     */
+    #[Bench\BeforeMethods('warmTheClassLoader')]
+    #[Bench\Revs(1000)]
+    #[Bench\Subject]
+    public function benchFirstAutowiredResolveOfASingleClass(): void
+    {
+        (new Container())->get(GraphLeaf::class);
+    }
+}

--- a/src/bench/php/d4np/utils/Fixture/AutowiredGraph.php
+++ b/src/bench/php/d4np/utils/Fixture/AutowiredGraph.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench\Fixture;
+
+/** One node of NFR-02's benchmark graph: a small, realistic service chain. */
+final class AutowiredGraph
+{
+    public function __construct(public readonly GraphService $service)
+    {
+    }
+}

--- a/src/bench/php/d4np/utils/Fixture/GraphLeaf.php
+++ b/src/bench/php/d4np/utils/Fixture/GraphLeaf.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench\Fixture;
+
+/** The leaf of NFR-02's benchmark graph. */
+final class GraphLeaf
+{
+}

--- a/src/bench/php/d4np/utils/Fixture/GraphRepository.php
+++ b/src/bench/php/d4np/utils/Fixture/GraphRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench\Fixture;
+
+/** One node of NFR-02's benchmark graph: a small, realistic service chain. */
+final class GraphRepository
+{
+    public function __construct(public readonly GraphLeaf $leaf)
+    {
+    }
+}

--- a/src/bench/php/d4np/utils/Fixture/GraphService.php
+++ b/src/bench/php/d4np/utils/Fixture/GraphService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench\Fixture;
+
+/** One node of NFR-02's benchmark graph: a small, realistic service chain. */
+final class GraphService
+{
+    public function __construct(public readonly GraphRepository $repository)
+    {
+    }
+}

--- a/src/main/php/d4np/utils/Container/CircularDependencyException.php
+++ b/src/main/php/d4np/utils/Container/CircularDependencyException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Container;
+
+/**
+ * A dependency cycle was reached while autowiring (imported ADR-001's stated non-goal).
+ *
+ * Its own class rather than a plain {@see ContainerException} because the container has to *act* on
+ * the distinction: an ordinary resolution failure may legitimately fall back to a parameter's
+ * default, whereas a cycle is a structural error that a default would paper over. Deciding that by
+ * matching on message text would be a decision that breaks the day someone rewords the message.
+ */
+final class CircularDependencyException extends ContainerException
+{
+}

--- a/src/main/php/d4np/utils/Container/Container.php
+++ b/src/main/php/d4np/utils/Container/Container.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Container;
+
+use D4np\Utils\Support\ParameterMetadata;
+use D4np\Utils\Support\ReflectionCache;
+use Psr\Container\ContainerInterface;
+
+/**
+ * A deliberately small PSR-11 container (spec FR-04, imported ADR-001, ADR-0028).
+ *
+ * **The non-goals are the design.** Imported ADR-001 chose to ship this rather than depend on
+ * PHP-DI, on the condition that its scope stay stated and small: constructor autowiring through the
+ * shared reflection cache, singleton and factory definitions, `ServiceProvider` registration — and
+ * **no compilation, no attribute configuration, no lazy proxies, and no circular-dependency
+ * resolution**. Where a mature container would add a feature, this one fails loudly and names
+ * ADR-001, whose answer to such a request is "adopt a mature container instead".
+ *
+ * The escape hatch is structural rather than promised: everything in this library that consumes a
+ * container consumes `Psr\Container\ContainerInterface`, so replacing this class with PHP-DI or
+ * Symfony DI is a wiring change and nothing else.
+ *
+ * **Resolution is memoised by default.** `get()` on the same identifier returns the same instance,
+ * whether the entry was registered or autowired, which is what makes NFR-02's warm path a single
+ * array read. {@see factory()} is the opt-out for entries that must be built fresh each time —
+ * stated as an opt-out because a container that silently rebuilt a graph on every `get()` would
+ * turn one shared connection into hundreds.
+ *
+ * @see ServiceProvider for grouping registrations
+ */
+final class Container implements ContainerInterface
+{
+    /**
+     * Resolved values, including autowired ones. The hot path of NFR-02.
+     *
+     * @var array<string, mixed>
+     */
+    private array $instances = [];
+
+    /** @var array<string, callable(self): mixed> */
+    private array $factories = [];
+
+    /**
+     * Identifiers whose factory result is memoised. A factory absent from here is rebuilt per call.
+     *
+     * @var array<string, true>
+     */
+    private array $shared = [];
+
+    /** @var array<string, string> */
+    private array $aliases = [];
+
+    /**
+     * The identifiers currently being constructed, in order — the dependency path a circular
+     * reference is reported with.
+     *
+     * @var list<string>
+     */
+    private array $building = [];
+
+    /** @var array<string, true> */
+    private array $buildingIndex = [];
+
+    public function __construct(private readonly ReflectionCache $cache = new ReflectionCache())
+    {
+    }
+
+    /**
+     * Store an already-built value under `$id`.
+     *
+     * Takes `mixed` rather than `object` because a container is also where configuration lands —
+     * a DSN, a feature flag, a timeout. PSR-11 says nothing narrower.
+     */
+    public function instance(string $id, mixed $value): self
+    {
+        $this->instances[$id] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Register `$id` as built once and reused.
+     *
+     * With no factory this marks a class to be autowired and shared, which is already the default —
+     * it is accepted so that a `ServiceProvider` can state the intent explicitly rather than relying
+     * on the reader knowing the default.
+     *
+     * @param (callable(self): mixed)|null $factory
+     */
+    public function singleton(string $id, ?callable $factory = null): self
+    {
+        if ($factory !== null) {
+            $this->factories[$id] = $factory;
+        }
+
+        $this->shared[$id] = true;
+        unset($this->instances[$id]);
+
+        return $this;
+    }
+
+    /**
+     * Register `$id` as built fresh on every `get()`.
+     *
+     * @param callable(self): mixed $factory
+     */
+    public function factory(string $id, callable $factory): self
+    {
+        $this->factories[$id] = $factory;
+        unset($this->shared[$id], $this->instances[$id]);
+
+        return $this;
+    }
+
+    /**
+     * Point an identifier — typically an interface — at a concrete class.
+     *
+     * This is the only way an interface-typed constructor parameter can be autowired, since nothing
+     * about an interface says which implementation was meant. Without a binding the container
+     * refuses rather than guessing.
+     */
+    public function bind(string $abstract, string $concrete): self
+    {
+        $this->aliases[$abstract] = $concrete;
+        unset($this->instances[$abstract]);
+
+        return $this;
+    }
+
+    public function register(ServiceProvider ...$providers): self
+    {
+        foreach ($providers as $provider) {
+            $provider->register($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * **The return type is conditional on the identifier, which is a deliberate addition to
+     * PSR-11.** The interface declares `get()` as returning `mixed`, so under PHPStan at max every
+     * consumer would have to narrow at every call site — `$container->get(Mailer::class)` would be
+     * an `object` at best and this library holds itself to that analysis level, so it would be
+     * exporting the noise. When `$id` is a class name the return is that class; for any other
+     * identifier it stays `mixed`, because a string key genuinely says nothing about its value.
+     * Verified against PHPStan max before being relied on.
+     *
+     * @template T of object
+     *
+     * @param class-string<T>|string $id
+     *
+     * @return ($id is class-string<T> ? T : mixed)
+     *
+     * @throws NotFoundException  if nothing is registered under `$id` and it is not an autowirable class
+     * @throws ContainerException if the entry exists but cannot be built
+     */
+    public function get(string $id): mixed
+    {
+        // NFR-02's warm path, kept to one isset and one array read. `isset()` is false for a
+        // stored null, which resolve() handles; paying array_key_exists() here to cover that
+        // would tax every hit for a rare entry.
+        if (isset($this->instances[$id])) {
+            return $this->instances[$id];
+        }
+
+        return $this->resolve($id);
+    }
+
+    /**
+     * Whether `get($id)` would find something.
+     *
+     * True for a registered entry **and** for any instantiable class, because those are exactly the
+     * identifiers `get()` will return a value for. Reporting `false` for a class this container
+     * would happily autowire would make `has()` a statement about the registration table rather
+     * than about the container's behaviour, which is not what PSR-11 asks of it.
+     */
+    public function has(string $id): bool
+    {
+        if (isset($this->factories[$id]) || isset($this->aliases[$id]) || array_key_exists($id, $this->instances)) {
+            return true;
+        }
+
+        return class_exists($id) && $this->cache->for($id)->isInstantiable;
+    }
+
+    private function resolve(string $id): mixed
+    {
+        if (array_key_exists($id, $this->instances)) {
+            return $this->instances[$id];
+        }
+
+        $target = $this->aliases[$id] ?? $id;
+
+        if (isset($this->buildingIndex[$id])) {
+            throw new CircularDependencyException(sprintf(
+                'Circular dependency detected while resolving "%s": %s. This container does not '
+                . 'resolve cycles by design (imported ADR-001); break the cycle, or inject a '
+                . 'factory so one side is built on demand.',
+                $id,
+                implode(' -> ', [...$this->building, $id]),
+            ));
+        }
+
+        $this->building[] = $id;
+        $this->buildingIndex[$id] = true;
+
+        try {
+            $value = isset($this->factories[$id])
+                ? ($this->factories[$id])($this)
+                : $this->build($target, $id);
+        } finally {
+            array_pop($this->building);
+            unset($this->buildingIndex[$id]);
+        }
+
+        // Autowired entries are shared unless explicitly registered as a factory.
+        if (!isset($this->factories[$id]) || isset($this->shared[$id])) {
+            $this->instances[$id] = $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Construct `$class` by autowiring its constructor.
+     *
+     * `$id` is carried separately so a failure names what the *caller* asked for, not the concrete
+     * class a `bind()` happened to point at.
+     */
+    private function build(string $class, string $id): mixed
+    {
+        // Interfaces and traits must reach the cache, not be rejected here: `class_exists()` is
+        // false for both — verified — and an unbound interface is the single most likely thing to
+        // arrive at this method. Refusing it as "no such class" would send the reader hunting for a
+        // typo instead of telling them to bind() it. This mirrors ReflectionCache's own three-way
+        // check, and is the reason that check exists.
+        if (!class_exists($class) && !interface_exists($class) && !trait_exists($class)) {
+            throw new NotFoundException(sprintf(
+                'No entry is registered for "%s", and it is not a loadable class this container '
+                . 'could autowire.',
+                $id,
+            ));
+        }
+
+        $metadata = $this->cache->for($class);
+
+        if (!$metadata->isInstantiable) {
+            throw new ContainerException(sprintf(
+                '"%s" cannot be instantiated (it is an interface, an abstract class, or has a '
+                . 'non-public constructor). Bind it to a concrete class with bind(), or register a '
+                . 'factory for it.',
+                $class,
+            ));
+        }
+
+        $arguments = [];
+        foreach ($metadata->parameters as $parameter) {
+            // A variadic tail is legitimately empty: there is nothing for the container to
+            // enumerate, and inventing a value would be guessing.
+            if ($parameter->isVariadic) {
+                continue;
+            }
+
+            $arguments[] = $this->argumentFor($parameter, $class);
+        }
+
+        return new $class(...$arguments);
+    }
+
+    private function argumentFor(ParameterMetadata $parameter, string $class): mixed
+    {
+        // ADR-0006 records union and intersection types as a null `type` with the declaration
+        // preserved verbatim, precisely so this refusal can name what it saw. Imported ADR-001
+        // requires failing here rather than picking an arm.
+        if ($parameter->type === null && $parameter->declaredType !== null) {
+            return $this->fallbackOrFail($parameter, sprintf(
+                'Cannot autowire $%s of %s: its type "%s" is a union or intersection, and choosing '
+                . 'an arm would be a guess. Register a factory for %s instead.',
+                $parameter->name,
+                $class,
+                $parameter->declaredType,
+                $class,
+            ));
+        }
+
+        if ($parameter->type === null) {
+            return $this->fallbackOrFail($parameter, sprintf(
+                'Cannot autowire $%s of %s: it has no type declaration, so there is nothing to '
+                . 'resolve it by.',
+                $parameter->name,
+                $class,
+            ));
+        }
+
+        if ($parameter->isBuiltin) {
+            return $this->fallbackOrFail($parameter, sprintf(
+                'Cannot autowire $%s of %s: "%s" is a built-in type with no default. Register a '
+                . 'factory for %s, or give the parameter a default.',
+                $parameter->name,
+                $class,
+                $parameter->type,
+                $class,
+            ));
+        }
+
+        try {
+            return $this->get($parameter->type);
+        } catch (CircularDependencyException $e) {
+            // A cycle is a structural error, not the kind of absence a default answers. Falling
+            // back here would hide it and hand back a half-built graph.
+            throw $e;
+        } catch (ContainerException $e) {
+            // A default is the author's own answer to "what if this is absent", so it wins over
+            // failing.
+            if ($parameter->hasDefault) {
+                return $parameter->default;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @throws ContainerException
+     */
+    private function fallbackOrFail(ParameterMetadata $parameter, string $message): mixed
+    {
+        if ($parameter->hasDefault) {
+            return $parameter->default;
+        }
+
+        throw new ContainerException($message);
+    }
+
+    /**
+     * The shared metadata cache, exposed so a consumer can hand the same one to the DTO hydrator.
+     *
+     * Imported ADR-001 commits to **one** cache across the container and the hydrator; this is how
+     * that commitment is honoured when the container built its own.
+     */
+    public function reflectionCache(): ReflectionCache
+    {
+        return $this->cache;
+    }
+}

--- a/src/main/php/d4np/utils/Container/ContainerException.php
+++ b/src/main/php/d4np/utils/Container/ContainerException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Container;
+
+use D4np\Utils\Support\UtilsException;
+use Psr\Container\ContainerExceptionInterface;
+
+/**
+ * A container failed to resolve something it was asked for (spec FR-04, ADR-0028).
+ *
+ * **Why this lives in `Container/` and not in `Support/` with the rest of the hierarchy.** Every
+ * other library exception sits in `Support`, and this one cannot: PSR-11 requires it to implement
+ * `ContainerExceptionInterface`, and `Support` is declared in `deptrac.yaml` as depending on
+ * *nothing*. That empty list is load-bearing — it is what makes an inverted import a build failure
+ * rather than a review opinion — so the exception moves to the layer that is already allowed to see
+ * PSR-11, instead of the rule bending to accommodate it.
+ *
+ * It still extends {@see UtilsException}, so ADR-0004's contract holds unchanged: a consumer
+ * catching `UtilsThrowable` catches this too, and one catching `ContainerExceptionInterface` gets
+ * the PSR behaviour. Both audiences are served without either being told about the other.
+ */
+class ContainerException extends UtilsException implements ContainerExceptionInterface
+{
+}

--- a/src/main/php/d4np/utils/Container/NotFoundException.php
+++ b/src/main/php/d4np/utils/Container/NotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Container;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * No entry exists for the requested identifier (PSR-11's `NotFoundExceptionInterface`).
+ *
+ * Kept distinct from its parent because PSR-11 draws exactly this line: *"no entry was found"* is a
+ * different answer from *"the entry exists and could not be built"*. A caller probing for an
+ * optional service wants to distinguish the two, and collapsing them would make a misconfigured
+ * dependency look identical to an absent one.
+ */
+final class NotFoundException extends ContainerException implements NotFoundExceptionInterface
+{
+}

--- a/src/main/php/d4np/utils/Container/ServiceProvider.php
+++ b/src/main/php/d4np/utils/Container/ServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Container;
+
+/**
+ * A group of related container registrations (spec FR-05, imported ADR-001).
+ *
+ * The whole contract is one method. A provider says what a slice of the application offers, and
+ * {@see Container::register()} applies it — so wiring lives next to the thing being wired instead
+ * of accumulating in one bootstrap file that every feature has to touch.
+ *
+ * **There is deliberately no `boot()` phase.** A two-phase lifecycle exists in frameworks to order
+ * side effects across providers, and side-effect ordering is application composition, not a utility
+ * library's job — the same line imported ADR-001 draws at compilation and lazy proxies. A provider
+ * here registers definitions and nothing else; anything needing to *run* after wiring is a call the
+ * application makes, in an order it can see.
+ */
+abstract class ServiceProvider
+{
+    abstract public function register(Container $container): void;
+}

--- a/src/test/php/d4np/utils/Container/ContainerTest.php
+++ b/src/test/php/d4np/utils/Container/ContainerTest.php
@@ -1,0 +1,455 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container;
+
+use D4np\Utils\Container\CircularDependencyException;
+use D4np\Utils\Container\Container;
+use D4np\Utils\Container\ContainerException;
+use D4np\Utils\Container\NotFoundException;
+use D4np\Utils\Support\ReflectionCache;
+use D4np\Utils\Support\UtilsThrowable;
+use D4np\Utils\Tests\Container\Fixture\AbstractThing;
+use D4np\Utils\Tests\Container\Fixture\CycleA;
+use D4np\Utils\Tests\Container\Fixture\EnglishGreeter;
+use D4np\Utils\Tests\Container\Fixture\FrenchGreeter;
+use D4np\Utils\Tests\Container\Fixture\Greeter;
+use D4np\Utils\Tests\Container\Fixture\NeedsAGreeter;
+use D4np\Utils\Tests\Container\Fixture\NeedsAScalar;
+use D4np\Utils\Tests\Container\Fixture\NoDependencies;
+use D4np\Utils\Tests\Container\Fixture\OneDependency;
+use D4np\Utils\Tests\Container\Fixture\OptionalMissingImplementation;
+use D4np\Utils\Tests\Container\Fixture\PrivateConstructor;
+use D4np\Utils\Tests\Container\Fixture\ScalarWithDefault;
+use D4np\Utils\Tests\Container\Fixture\SelfReferential;
+use D4np\Utils\Tests\Container\Fixture\TwoLevelsDeep;
+use D4np\Utils\Tests\Container\Fixture\UnionTyped;
+use D4np\Utils\Tests\Container\Fixture\UnionTypedWithDefault;
+use D4np\Utils\Tests\Container\Fixture\UntypedParameter;
+use D4np\Utils\Tests\Container\Fixture\Variadic;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * Spec FR-04's minimal PSR-11 container.
+ *
+ * The interesting half of this file is the refusals. Imported ADR-001 bought a hand-written
+ * container by promising it would **fail loudly** exactly where a mature one would add a feature —
+ * so the tests that matter most are the ones asserting it declines to guess, and says why.
+ */
+final class ContainerTest extends TestCase
+{
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new Container();
+    }
+
+    // ---- PSR-11 conformance ----------------------------------------------------------------------
+
+    public function testItIsAPsr11Container(): void
+    {
+        self::assertInstanceOf(ContainerInterface::class, $this->container);
+    }
+
+    /**
+     * Both exception hierarchies at once. A consumer catching PSR-11's interface and one catching
+     * this library's root (ADR-0004) must each get what they expect, without either being told
+     * about the other.
+     */
+    public function testExceptionsSatisfyBothPsr11AndTheLibraryRoot(): void
+    {
+        try {
+            $this->container->get('no\such\entry');
+            self::fail('expected a not-found failure');
+        } catch (NotFoundException $e) {
+            self::assertInstanceOf(NotFoundExceptionInterface::class, $e);
+            self::assertInstanceOf(ContainerExceptionInterface::class, $e);
+            self::assertInstanceOf(UtilsThrowable::class, $e);
+        }
+    }
+
+    public function testNotFoundIsDistinctFromAFailureToBuild(): void
+    {
+        self::assertInstanceOf(ContainerException::class, new NotFoundException('x'));
+
+        // "absent" and "present but unbuildable" must not collapse into one answer.
+        try {
+            $this->container->get(AbstractThing::class);
+            self::fail('expected a build failure');
+        } catch (ContainerException $e) {
+            self::assertNotInstanceOf(NotFoundExceptionInterface::class, $e);
+        }
+    }
+
+    // ---- definitions -----------------------------------------------------------------------------
+
+    public function testAnInstanceIsReturnedAsIs(): void
+    {
+        $value = new NoDependencies();
+        $this->container->instance('leaf', $value);
+
+        self::assertSame($value, $this->container->get('leaf'));
+    }
+
+    /**
+     * A container is also where configuration lands, so entries are not restricted to objects.
+     */
+    public function testEntriesNeedNotBeObjects(): void
+    {
+        $this->container->instance('dsn', 'sqlite::memory:')->instance('retries', 3);
+
+        self::assertSame('sqlite::memory:', $this->container->get('dsn'));
+        self::assertSame(3, $this->container->get('retries'));
+    }
+
+    /**
+     * `null` is a legitimate stored value, and the `isset()` fast path in `get()` is blind to it —
+     * so this asserts the slow path catches what the fast one cannot see.
+     */
+    public function testANullEntryIsStoredRatherThanTreatedAsAbsent(): void
+    {
+        $this->container->instance('maybe', null);
+
+        self::assertTrue($this->container->has('maybe'));
+        self::assertNull($this->container->get('maybe'));
+    }
+
+    public function testASingletonFactoryRunsOnce(): void
+    {
+        $calls = 0;
+        $this->container->singleton('thing', function () use (&$calls): NoDependencies {
+            $calls++;
+
+            return new NoDependencies();
+        });
+
+        $first = $this->container->get('thing');
+
+        self::assertSame($first, $this->container->get('thing'));
+        self::assertSame(1, $calls);
+    }
+
+    /**
+     * `singleton()` with no factory marks a class to be autowired and shared — already the default,
+     * and accepted so a `ServiceProvider` can say so explicitly rather than relying on the reader
+     * knowing the default. Asserted because "documented API path with no test" is how a default
+     * quietly changes.
+     */
+    public function testSingletonWithoutAFactoryMarksAClassSharedAndAutowired(): void
+    {
+        $this->container->singleton(OneDependency::class);
+
+        $first = $this->container->get(OneDependency::class);
+
+        self::assertInstanceOf(OneDependency::class, $first);
+        self::assertSame($first, $this->container->get(OneDependency::class));
+    }
+
+    /**
+     * Re-registering must not leave the previous decision half-applied: a factory promoted to a
+     * singleton starts sharing, and a singleton demoted to a factory stops.
+     */
+    public function testRedefiningAnEntrySwitchesItsSharingBehaviour(): void
+    {
+        $make = static fn (): NoDependencies => new NoDependencies();
+
+        $this->container->factory('thing', $make);
+        self::assertNotSame($this->container->get('thing'), $this->container->get('thing'));
+
+        $this->container->singleton('thing', $make);
+        self::assertSame($this->container->get('thing'), $this->container->get('thing'));
+
+        $this->container->factory('thing', $make);
+        self::assertNotSame($this->container->get('thing'), $this->container->get('thing'));
+    }
+
+    public function testAFactoryRunsEveryTime(): void
+    {
+        $calls = 0;
+        $this->container->factory('thing', function () use (&$calls): NoDependencies {
+            $calls++;
+
+            return new NoDependencies();
+        });
+
+        self::assertNotSame($this->container->get('thing'), $this->container->get('thing'));
+        self::assertSame(2, $calls);
+    }
+
+    public function testAFactoryReceivesTheContainer(): void
+    {
+        $this->container->instance('name', 'world');
+
+        // A string-keyed entry really is `mixed` — the key says nothing about the value — so a
+        // consumer narrows. Only class-keyed lookups carry a type (see `Container::get()`).
+        $this->container->factory('greeting', static function (Container $c): string {
+            $name = $c->get('name');
+
+            return 'hello ' . (is_string($name) ? $name : '');
+        });
+
+        self::assertSame('hello world', $this->container->get('greeting'));
+    }
+
+    // ---- autowiring ------------------------------------------------------------------------------
+
+    public function testAClassWithNoDependenciesIsBuilt(): void
+    {
+        self::assertInstanceOf(NoDependencies::class, $this->container->get(NoDependencies::class));
+    }
+
+    public function testDependenciesAreResolvedRecursively(): void
+    {
+        $deep = $this->container->get(TwoLevelsDeep::class);
+
+        self::assertInstanceOf(TwoLevelsDeep::class, $deep);
+        self::assertInstanceOf(OneDependency::class, $deep->middle);
+        self::assertInstanceOf(NoDependencies::class, $deep->middle->leaf);
+    }
+
+    /**
+     * Autowired results are shared. NFR-02's "warm" resolve only means anything if a second `get()`
+     * is a lookup rather than a rebuild — and a container that quietly rebuilt the graph each time
+     * would turn one shared connection into hundreds.
+     */
+    public function testAutowiredInstancesAreSharedByDefault(): void
+    {
+        self::assertSame(
+            $this->container->get(NoDependencies::class),
+            $this->container->get(NoDependencies::class),
+        );
+    }
+
+    public function testASharedDependencyIsTheSameObjectEverywhere(): void
+    {
+        $leaf = $this->container->get(NoDependencies::class);
+        $parent = $this->container->get(OneDependency::class);
+
+        self::assertSame($leaf, $parent->leaf);
+    }
+
+    public function testAVariadicTailIsLeftEmpty(): void
+    {
+        self::assertSame([], $this->container->get(Variadic::class)->items);
+    }
+
+    // ---- bind() ----------------------------------------------------------------------------------
+
+    public function testAnInterfaceResolvesThroughItsBinding(): void
+    {
+        $this->container->bind(Greeter::class, EnglishGreeter::class);
+
+        self::assertInstanceOf(EnglishGreeter::class, $this->container->get(Greeter::class));
+        self::assertSame('hello', $this->container->get(NeedsAGreeter::class)->greeter->greet());
+    }
+
+    public function testRebindingReplacesAnAlreadyResolvedBinding(): void
+    {
+        $this->container->bind(Greeter::class, EnglishGreeter::class);
+        self::assertSame('hello', $this->container->get(Greeter::class)->greet());
+
+        $this->container->bind(Greeter::class, FrenchGreeter::class);
+        self::assertSame('bonjour', $this->container->get(Greeter::class)->greet());
+    }
+
+    // ---- the refusals, which are the point -------------------------------------------------------
+
+    public function testAnUnboundInterfaceIsRefusedRatherThanGuessed(): void
+    {
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/cannot be instantiated.*bind\(\)/s');
+
+        $this->container->get(Greeter::class);
+    }
+
+    public function testAnAbstractClassIsRefused(): void
+    {
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/cannot be instantiated/');
+
+        $this->container->get(AbstractThing::class);
+    }
+
+    public function testANonPublicConstructorIsRefused(): void
+    {
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/cannot be instantiated/');
+
+        $this->container->get(PrivateConstructor::class);
+    }
+
+    public function testABuiltinTypedParameterWithNoDefaultIsRefused(): void
+    {
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/built-in type with no default/');
+
+        $this->container->get(NeedsAScalar::class);
+    }
+
+    public function testAnUntypedParameterIsRefused(): void
+    {
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/no type declaration/');
+
+        $this->container->get(UntypedParameter::class);
+    }
+
+    /**
+     * Imported ADR-001 names union-typed parameters as a place this container fails loudly. The
+     * message must name the declaration, which is why ADR-0006 preserved it verbatim.
+     */
+    public function testAUnionTypedParameterIsRefusedAndTheDeclarationIsNamed(): void
+    {
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessageMatches('/union or intersection/');
+
+        $this->container->get(UnionTyped::class);
+    }
+
+    public function testARefusalMessageNamesTheParameterAndTheClass(): void
+    {
+        try {
+            $this->container->get(NeedsAScalar::class);
+            self::fail('expected a refusal');
+        } catch (ContainerException $e) {
+            self::assertStringContainsString('$dsn', $e->getMessage());
+            self::assertStringContainsString(NeedsAScalar::class, $e->getMessage());
+        }
+    }
+
+    // ---- defaults are the author's own answer ----------------------------------------------------
+
+    public function testADefaultIsUsedWhenTheParameterCannotBeResolved(): void
+    {
+        self::assertSame('sqlite::memory:', $this->container->get(ScalarWithDefault::class)->dsn);
+        self::assertSame('fallback', $this->container->get(UnionTypedWithDefault::class)->either);
+        self::assertNull($this->container->get(OptionalMissingImplementation::class)->greeter);
+    }
+
+    /**
+     * But a default must not paper over a *cycle*. That is a structural error, and falling back
+     * would hand the caller a half-built graph while reporting success — which is why the container
+     * distinguishes the two by exception type rather than by matching on message text.
+     */
+    public function testADefaultDoesNotSwallowACircularDependency(): void
+    {
+        $this->expectException(CircularDependencyException::class);
+
+        $this->container->get(CycleA::class);
+    }
+
+    // ---- circular dependencies -------------------------------------------------------------------
+
+    /**
+     * ADR-001 requires the *path*, not just the fact. "Circular dependency detected" alone leaves
+     * the reader to find the cycle by hand in a graph they cannot see.
+     */
+    public function testACycleIsReportedWithItsFullPath(): void
+    {
+        try {
+            $this->container->get(CycleA::class);
+            self::fail('expected a circular dependency failure');
+        } catch (CircularDependencyException $e) {
+            $message = $e->getMessage();
+
+            self::assertStringContainsString('CycleA', $message);
+            self::assertStringContainsString('CycleB', $message);
+            self::assertStringContainsString('CycleC', $message);
+            self::assertStringContainsString('->', $message, 'the path must show the order');
+        }
+    }
+
+    public function testASelfReferentialClassIsACycleToo(): void
+    {
+        $this->expectException(CircularDependencyException::class);
+
+        $this->container->get(SelfReferential::class);
+    }
+
+    /**
+     * A failed resolution must leave nothing behind. Without the `finally` that unwinds the
+     * in-progress stack, the second attempt would report a cycle that is not there.
+     */
+    public function testTheResolutionStackUnwindsAfterAFailure(): void
+    {
+        for ($attempt = 1; $attempt <= 2; $attempt++) {
+            try {
+                $this->container->get(NeedsAScalar::class);
+                self::fail('expected a refusal');
+            } catch (ContainerException $e) {
+                self::assertStringNotContainsString(
+                    'Circular',
+                    $e->getMessage(),
+                    "attempt {$attempt} reported a cycle, so the previous failure leaked state",
+                );
+            }
+        }
+    }
+
+    // ---- has() -----------------------------------------------------------------------------------
+
+    public function testHasIsTrueForRegisteredEntries(): void
+    {
+        $this->container->instance('leaf', new NoDependencies());
+        $this->container->factory('made', static fn (): NoDependencies => new NoDependencies());
+        $this->container->bind(Greeter::class, EnglishGreeter::class);
+
+        self::assertTrue($this->container->has('leaf'));
+        self::assertTrue($this->container->has('made'));
+        self::assertTrue($this->container->has(Greeter::class));
+    }
+
+    /**
+     * `has()` answers for the container's *behaviour*, not its registration table: it is true for
+     * anything `get()` would build, and false for what it would refuse.
+     */
+    public function testHasReflectsWhatGetWouldActuallyDo(): void
+    {
+        self::assertTrue($this->container->has(NoDependencies::class), 'get() would autowire this');
+        self::assertFalse($this->container->has(AbstractThing::class), 'get() would refuse this');
+        self::assertFalse($this->container->has(Greeter::class), 'unbound interface');
+        self::assertFalse($this->container->has('no\such\entry'));
+    }
+
+    // ---- the one shared reflection cache ---------------------------------------------------------
+
+    /**
+     * Imported ADR-001 commits to **one** metadata cache across the container and the DTO hydrator.
+     * Accepting one is how a consumer honours that; exposing it is how a consumer that let the
+     * container build its own can still hand the same instance to the hydrator.
+     */
+    public function testItUsesTheSharedReflectionCache(): void
+    {
+        $cache = new ReflectionCache();
+        $container = new Container($cache);
+
+        self::assertSame($cache, $container->reflectionCache());
+
+        $container->get(OneDependency::class);
+
+        self::assertTrue($cache->isCached(OneDependency::class));
+        self::assertTrue($cache->isCached(NoDependencies::class), 'dependencies go through it too');
+    }
+
+    /**
+     * The cache must be consulted once per class, not once per resolution — this is the mechanism
+     * NFR-02's warm budget actually rests on, and a count is the only way to see it.
+     */
+    public function testAClassIsReflectedOnlyOnce(): void
+    {
+        $cache = new ReflectionCache();
+        $container = new Container($cache);
+
+        $container->get(TwoLevelsDeep::class);
+        $afterFirst = $cache->count();
+
+        $container->get(TwoLevelsDeep::class);
+
+        self::assertSame($afterFirst, $cache->count(), 'a warm resolve reflected something again');
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/AbstractThing.php
+++ b/src/test/php/d4np/utils/Container/Fixture/AbstractThing.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+abstract class AbstractThing
+{
+}

--- a/src/test/php/d4np/utils/Container/Fixture/CycleA.php
+++ b/src/test/php/d4np/utils/Container/Fixture/CycleA.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** A three-node cycle: A -> B -> C -> A. */
+final class CycleA
+{
+    public function __construct(public readonly CycleB $b)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/CycleB.php
+++ b/src/test/php/d4np/utils/Container/Fixture/CycleB.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+final class CycleB
+{
+    public function __construct(public readonly CycleC $c)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/CycleC.php
+++ b/src/test/php/d4np/utils/Container/Fixture/CycleC.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+final class CycleC
+{
+    public function __construct(public readonly CycleA $a)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/EnglishGreeter.php
+++ b/src/test/php/d4np/utils/Container/Fixture/EnglishGreeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+final class EnglishGreeter implements Greeter
+{
+    public function greet(): string
+    {
+        return 'hello';
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/FrenchGreeter.php
+++ b/src/test/php/d4np/utils/Container/Fixture/FrenchGreeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+final class FrenchGreeter implements Greeter
+{
+    public function greet(): string
+    {
+        return 'bonjour';
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/FrenchGreeterProvider.php
+++ b/src/test/php/d4np/utils/Container/Fixture/FrenchGreeterProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+use D4np\Utils\Container\Container;
+use D4np\Utils\Container\ServiceProvider;
+
+/** A second provider binding the same abstract, so registration order is observable. */
+final class FrenchGreeterProvider extends ServiceProvider
+{
+    public function register(Container $container): void
+    {
+        $container->bind(Greeter::class, FrenchGreeter::class);
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/Greeter.php
+++ b/src/test/php/d4np/utils/Container/Fixture/Greeter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+interface Greeter
+{
+    public function greet(): string;
+}

--- a/src/test/php/d4np/utils/Container/Fixture/GreeterProvider.php
+++ b/src/test/php/d4np/utils/Container/Fixture/GreeterProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+use D4np\Utils\Container\Container;
+use D4np\Utils\Container\ServiceProvider;
+
+/** A provider that registers a binding, a singleton and a plain value. */
+final class GreeterProvider extends ServiceProvider
+{
+    public int $registerCalls = 0;
+
+    public function register(Container $container): void
+    {
+        $this->registerCalls++;
+
+        $container
+            ->bind(Greeter::class, EnglishGreeter::class)
+            ->instance('greeting.suffix', '!')
+            ->singleton('greeting.full', static function (Container $c): string {
+                // `get(Greeter::class)` infers `Greeter`; a string-keyed entry stays `mixed` and is
+                // narrowed. That asymmetry is `Container::get()`'s conditional return type showing
+                // through, and it is the behaviour a consumer will see.
+                $suffix = $c->get('greeting.suffix');
+
+                return $c->get(Greeter::class)->greet() . (is_string($suffix) ? $suffix : '');
+            });
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/NeedsAGreeter.php
+++ b/src/test/php/d4np/utils/Container/Fixture/NeedsAGreeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** Interface-typed: unresolvable without a bind(), because nothing says which implementation. */
+final class NeedsAGreeter
+{
+    public function __construct(public readonly Greeter $greeter)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/NeedsAScalar.php
+++ b/src/test/php/d4np/utils/Container/Fixture/NeedsAScalar.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** A built-in type with no default: the container has nothing to resolve it by. */
+final class NeedsAScalar
+{
+    public function __construct(public readonly string $dsn)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/NoDependencies.php
+++ b/src/test/php/d4np/utils/Container/Fixture/NoDependencies.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** A leaf: nothing to autowire. */
+final class NoDependencies
+{
+}

--- a/src/test/php/d4np/utils/Container/Fixture/OneDependency.php
+++ b/src/test/php/d4np/utils/Container/Fixture/OneDependency.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** One level of autowiring. */
+final class OneDependency
+{
+    public function __construct(public readonly NoDependencies $leaf)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/OptionalMissingImplementation.php
+++ b/src/test/php/d4np/utils/Container/Fixture/OptionalMissingImplementation.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** An unbound interface, but with a default: the default is the author's stated intent. */
+final class OptionalMissingImplementation
+{
+    public function __construct(public readonly ?Greeter $greeter = null)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/PrivateConstructor.php
+++ b/src/test/php/d4np/utils/Container/Fixture/PrivateConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** Not instantiable, despite being a concrete class. */
+final class PrivateConstructor
+{
+    private function __construct()
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/ScalarWithDefault.php
+++ b/src/test/php/d4np/utils/Container/Fixture/ScalarWithDefault.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** The same, with the author's own answer for the absent case. */
+final class ScalarWithDefault
+{
+    public function __construct(public readonly string $dsn = 'sqlite::memory:')
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/SelfReferential.php
+++ b/src/test/php/d4np/utils/Container/Fixture/SelfReferential.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** The degenerate cycle, which a naive stack check can miss. */
+final class SelfReferential
+{
+    public function __construct(public readonly SelfReferential $itself)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/TwoLevelsDeep.php
+++ b/src/test/php/d4np/utils/Container/Fixture/TwoLevelsDeep.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** Recursion: the container must build the whole chain, not just the first level. */
+final class TwoLevelsDeep
+{
+    public function __construct(public readonly OneDependency $middle)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/UnionTyped.php
+++ b/src/test/php/d4np/utils/Container/Fixture/UnionTyped.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** A union type: imported ADR-001 requires refusal rather than picking an arm. */
+final class UnionTyped
+{
+    public function __construct(public readonly NoDependencies|OneDependency $either)
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/UnionTypedWithDefault.php
+++ b/src/test/php/d4np/utils/Container/Fixture/UnionTypedWithDefault.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+final class UnionTypedWithDefault
+{
+    public function __construct(public readonly NoDependencies|string $either = 'fallback')
+    {
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/UntypedParameter.php
+++ b/src/test/php/d4np/utils/Container/Fixture/UntypedParameter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/**
+ * A constructor parameter with **no type declaration at all**.
+ *
+ * Neither promoted nor `mixed`, and both exclusions are the point. A promoted property must carry a
+ * type, and `mixed` is a *named built-in* type — verified: it arrives as `isBuiltin` with the name
+ * `"mixed"`, so it exercises the built-in branch rather than this one. The first version of this
+ * fixture used `mixed` and silently tested the wrong refusal.
+ */
+final class UntypedParameter
+{
+    public readonly mixed $anything;
+
+    /** @param mixed $anything */
+    public function __construct($anything)
+    {
+        $this->anything = $anything;
+    }
+}

--- a/src/test/php/d4np/utils/Container/Fixture/Variadic.php
+++ b/src/test/php/d4np/utils/Container/Fixture/Variadic.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container\Fixture;
+
+/** A variadic tail is legitimately empty; there is nothing for the container to enumerate. */
+final class Variadic
+{
+    /** @var list<NoDependencies> */
+    public readonly array $items;
+
+    public function __construct(NoDependencies ...$items)
+    {
+        $this->items = array_values($items);
+    }
+}

--- a/src/test/php/d4np/utils/Container/ServiceProviderTest.php
+++ b/src/test/php/d4np/utils/Container/ServiceProviderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Container;
+
+use D4np\Utils\Container\Container;
+use D4np\Utils\Container\ServiceProvider;
+use D4np\Utils\Tests\Container\Fixture\EnglishGreeter;
+use D4np\Utils\Tests\Container\Fixture\FrenchGreeter;
+use D4np\Utils\Tests\Container\Fixture\FrenchGreeterProvider;
+use D4np\Utils\Tests\Container\Fixture\Greeter;
+use D4np\Utils\Tests\Container\Fixture\GreeterProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec FR-05's `ServiceProvider`.
+ *
+ * The contract is one method, so most of what is worth asserting is about what a provider is
+ * *not*: no boot phase, no ordering machinery, no lifecycle beyond "apply these definitions".
+ */
+final class ServiceProviderTest extends TestCase
+{
+    public function testAProviderRegistersItsDefinitions(): void
+    {
+        $container = new Container();
+
+        $container->register(new GreeterProvider());
+
+        self::assertInstanceOf(EnglishGreeter::class, $container->get(Greeter::class));
+        self::assertSame('!', $container->get('greeting.suffix'));
+        self::assertSame('hello!', $container->get('greeting.full'));
+    }
+
+    public function testSeveralProvidersRegisterInOneCall(): void
+    {
+        $container = new Container();
+
+        $container->register(new GreeterProvider(), new FrenchGreeterProvider());
+
+        self::assertInstanceOf(
+            FrenchGreeter::class,
+            $container->get(Greeter::class),
+            'the later provider must win, so registration order is something the caller controls',
+        );
+    }
+
+    public function testRegisterIsCalledOncePerProvider(): void
+    {
+        $provider = new GreeterProvider();
+
+        (new Container())->register($provider);
+
+        self::assertSame(1, $provider->registerCalls);
+    }
+
+    public function testRegisterReturnsTheContainerForChaining(): void
+    {
+        $container = new Container();
+
+        self::assertSame($container, $container->register(new GreeterProvider()));
+    }
+
+    /**
+     * The absence of a `boot()` is a decision, not an omission (imported ADR-001's line on scope).
+     * A two-phase lifecycle exists to order side effects across providers, and that is application
+     * composition rather than a utility library's job — so the base class stays at exactly one
+     * method, and this asserts it has not quietly grown a second.
+     */
+    public function testTheContractIsExactlyOneMethod(): void
+    {
+        $declared = array_map(
+            static fn (\ReflectionMethod $m): string => $m->getName(),
+            (new \ReflectionClass(ServiceProvider::class))->getMethods(),
+        );
+
+        self::assertSame(['register'], $declared);
+    }
+}


### PR DESCRIPTION
Roadmap item **6.4** — spec FR-04, FR-05, NFR-02, imported ADR-001.

Imported ADR-001 already decided *whether* to ship a container. Three questions it left open are settled in **ADR-0028**, and each had a reasonable-looking wrong answer.

## The refusals are the design

ADR-001 bought a hand-written container by promising it fails loudly wherever a mature one adds a feature. An unbound interface, an abstract class, a non-public constructor, a built-in or untyped parameter without a default, and a union-typed parameter are each declined with a message naming the parameter and the class. Cycles throw with the **full path** (`A -> B -> C -> A`).

Autowired instances are **shared** by default — NFR-02's warm budget is meaningless if a second `get()` rebuilds, and silent rebuilding turns one shared connection into hundreds. `factory()` is the opt-out. `has()` answers for what `get()` would do, not for the registration table.

## Exceptions live in the Container group, not Support

Every other exception here is in `Support`. PSR-11 requires these to implement `ContainerExceptionInterface`, and deptrac declares `Support: ~` — depends on **nothing**. That empty list is the load-bearing half of RFC-0001's layering rule, so the class moves rather than the rule bending.

Probed: dropping the `Psr` grant produces **5** deptrac violations naming each class; `Support`, having no grants at all, would fail identically. `ContainerException` still extends `UtilsException`, so ADR-0004 holds in both directions.

`CircularDependencyException` is its own type because the container *acts* on the distinction: a parameter default may answer an absent dependency and must not answer a cycle. My first version branched on `str_contains($message, 'Circular dependency')` — a decision that breaks the day someone rewords a string.

## `get()` carries a type PSR-11 does not

`ContainerInterface::get()` has **no return type at all** in psr/container 2.0.2 — I checked the vendored file, having expected `: mixed`. Implemented plainly, PHPStan max flagged **12** errors in my own tests. The tests are the first consumer, and they were telling me every consumer at max pays the same tax. So `get()` declares a conditional return type: a class name returns that class, any other identifier stays `mixed`. Twelve errors became two, and those two were honest — string keys really are untyped.

No test asserts the annotation and none is needed: removing it fails **11** existing PHPStan checks. Probed, not assumed.

## NFR-02 — and a benchmark that measured the harness

| subject | measured | budget |
|---|---|---|
| warm singleton resolve (4-class graph) | **0.173 µs** | ≤ 2 µs |
| warm instance resolve (plain value) | 0.169 µs | (floor) |
| first autowired resolve (4-class graph) | **18.593 µs** | ≤ 30 µs |
| first autowired resolve (single class) | 2.646 µs | (per-class floor) |

Both halves pass. The first version said **103 µs**, and I did not report that as a violation because a direct timing of the same work said 17.8 µs — a 6× gap means one measurement isn't measuring what it claims. Two errors:

1. phpbench runs `beforeMethods` once per **iteration**, then loops the subject over every revolution — read out of `remote.template` rather than guessed, since guessing wrong is how a cold benchmark quietly becomes a warm one.
2. Fixing that still gave 93 µs, and the tell was that **the number moved with the revolution count**: 93 µs at 200 revs, 26 µs at 2000, identical work. The first revolution was paying Composer's autoloading, which phpbench smears across all revs.

Warming the class loader while leaving the metadata cache cold — what NFR-02's "first" actually means — gives **18.368 / 18.276 / 18.089 µs at 200 / 1000 / 4000 revs**. A number that stops moving with the harness is a number about the subject.

Second benchmark of mine wrong in this direction; **ADR-0020** has the first, on NFR-03. Per **ADR-0018** these ceilings are not a CI gate — they're tied to NFR-06's reference machine and these numbers come from a dev machine.

## Two assumptions that were wrong

Both caught by tests failing, not by review:

- **`class_exists()` is false for an interface**, so an unbound interface reported "no such class" instead of "bind it". `ReflectionCache`'s own docblock had written this down for me back at item 2.5, and I still assumed otherwise.
- **`mixed` is a *named* built-in type**, not an absent one — so my "untyped parameter" fixture silently exercised the built-in branch. A promoted readonly property cannot be untyped at all, which is why that fixture is the only one not using promotion.

## Verified non-vacuous

| planted | result |
|---|---|
| cycle guard disabled | memory exhausted, process killed |
| instance sharing disabled | 3 failures |
| `get()` annotation removed | 11 PHPStan errors |
| deptrac `Psr` grant removed | 5 violations |

## Bar

1235 tests / 2785 assertions green (was 1196). PHPStan max clean, PHP-CS-Fixer clean, deptrac 0/0, consistency + action-pin lints OK.

Route `standard / medium` matched the session model — **no mismatch to record**, first since 5.2.

## One thing slightly beyond the item

README's milestone table still showed milestone 1 "in progress" and 2–7 "planned", while 1–5 are complete. Corrected, since `AGENTS.md` §7 asks every PR to keep README in sync — but flagging it as it wasn't part of 6.4's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
