### PR TITLE
ci(release): BC gate on release PRs, and settle the deprecation window

### DIFF
--- a/.eados-core/learning/runs/2026-08-05-utils-8.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils-8.yaml
@@ -1,0 +1,33 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,3 +344,113 @@ jobs:
           name: benchmark-reports
           path: build/logs/*.xml
           if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # Backward-compatibility gate (spec NFR-07, ADR-0031).
+  #
+  # Runs only on a **release PR**, which the imported spec §8 defines as the place this check
+  # belongs. A release PR is detected mechanically — the PR changes `Version.php`'s VERSION
+  # constant, which is step 1 of docs/workflow/release.md — rather than by a label, because a
+  # label the maintainer forgets is a gate that silently does not run.
+  #
+  # Two things this job must not do:
+  #
+  # 1. **Fail before the first tag exists.** `roave/backward-compatibility-check` exits 1 with
+  #    "Could not detect any released versions for the given repository" when a repo has no tags —
+  #    verified. This one has none yet, and the first release PR is exactly when the check would
+  #    first run. So it SKIPS on a declared condition and self-enables at the first `v*.*.*` tag
+  #    (lesson L-0010).
+  # 2. **Enter this package's dependency graph.** Every version from 8.7.0 requires PHP >= 8.2,
+  #    later >= 8.3 and >= 8.4, while this library's floor is 8.1 — which is why
+  #    `config.platform.php` is pinned to 8.1.34. Adding it as a dev dependency would either break
+  #    the 8.1 matrix cell or abandon 8.1 support. It is installed into a throwaway project
+  #    instead, so the tool can be modern while the library stays on its floor.
+  # ---------------------------------------------------------------------------
+  backward-compatibility:
+    name: quality / backward compatibility
+    needs: bootstrap
+    if: needs.bootstrap.outputs.ready == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tags and the base commit are both needed; the default shallow fetch has neither.
+          fetch-depth: 0
+
+      - name: Is this a release PR, and is there anything to compare against?
+        id: scope
+        shell: bash
+        run: |
+          CURRENT="$(sed -n "s/.*VERSION = '\([^']*\)'.*/\1/p" src/main/php/d4np/utils/Version.php)"
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+
+          PREVIOUS="$(git tag -l 'v*.*.*' --sort=-v:refname | head -n1)"
+          echo "previous=$PREVIOUS" >> "$GITHUB_OUTPUT"
+
+          BASE="${{ github.event.pull_request.base.sha }}"
+          RELEASE_PR=false
+          if [ -n "$BASE" ] && ! git diff --quiet "$BASE" HEAD -- src/main/php/d4np/utils/Version.php; then
+            RELEASE_PR=true
+          fi
+          echo "release_pr=$RELEASE_PR" >> "$GITHUB_OUTPUT"
+
+          if [ "$RELEASE_PR" != "true" ]; then
+            echo "::notice title=Not a release PR::Version.php is unchanged, so the BC check does not apply. Spec NFR-07 places it on release PRs."
+          elif [ -z "$PREVIOUS" ]; then
+            echo "::notice title=No released version yet::This repository has no v*.*.* tag, and roave/backward-compatibility-check needs one to compare against. The gate self-enables at the first tag."
+          else
+            echo "::notice title=BC check will run::Comparing $PREVIOUS against $CURRENT."
+          fi
+
+      - name: Set up PHP
+        if: steps.scope.outputs.release_pr == 'true' && steps.scope.outputs.previous != ''
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          # The tool's own floor, not this library's. See the header comment.
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install the BC checker outside this package's dependency graph
+        if: steps.scope.outputs.release_pr == 'true' && steps.scope.outputs.previous != ''
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/bc-tool"
+          # Constrained rather than floating: an unpinned tool that changes its own findings between
+          # runs makes a release gate unreviewable.
+          composer require --working-dir="$RUNNER_TEMP/bc-tool" --no-interaction \
+            "roave/backward-compatibility-check:^8.16"
+
+      - name: Install this package's own dependencies
+        if: steps.scope.outputs.release_pr == 'true' && steps.scope.outputs.previous != ''
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Detect backward-incompatible changes since ${{ steps.scope.outputs.previous }}
+        id: bc
+        if: steps.scope.outputs.release_pr == 'true' && steps.scope.outputs.previous != ''
+        shell: bash
+        run: |
+          set +e
+          php "$RUNNER_TEMP/bc-tool/vendor/bin/roave-backward-compatibility-check" \
+            --from="${{ steps.scope.outputs.previous }}" --format=markdown | tee bc-report.md
+          CODE=${PIPESTATUS[0]}
+          set -e
+          echo "code=$CODE" >> "$GITHUB_OUTPUT"
+          echo "The checker exited $CODE (0 means no backward-incompatible change)."
+
+      - name: Gate the findings against the version bump
+        if: steps.scope.outputs.release_pr == 'true' && steps.scope.outputs.previous != ''
+        shell: bash
+        run: |
+          python3 tools/bc_gate.py \
+            --previous "${{ steps.scope.outputs.previous }}" \
+            --current "${{ steps.scope.outputs.current }}" \
+            --bc-exit "${{ steps.bc.outputs.code }}"
+
+      - name: Keep the BC report
+        if: always() && steps.scope.outputs.release_pr == 'true' && steps.scope.outputs.previous != ''
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: backward-compatibility-report
+          path: bc-report.md
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **Backward-compatibility gate on release PRs** (**ADR-0031**) — spec NFR-07, imported spec §8.
+  A new `quality / backward compatibility` CI job plus `tools/bc_gate.py`.
+  **`roave/backward-compatibility-check` is installed into a throwaway project, not into
+  `composer.json`.** Every release from 8.7.0 requires PHP ≥ 8.2 (later ≥ 8.3, ≥ 8.4) while this
+  library supports **8.1** — hence the `config.platform.php` pin at `8.1.34`. As a dev dependency it
+  would resolve to 8.6.0 at best, break the 8.1 matrix cell, or force abandoning 8.1. It analyses
+  this package from outside, so its floor need not be ours; upstream ships no PHAR any more.
+  **The job skips while no `v*.*.*` tag exists** and self-enables at the first one: the checker
+  hard-fails with *"Could not detect any released versions for the given repository"*, and the first
+  release PR is exactly when it would first run. A release PR is detected from a `Version.php` diff
+  — step 1 of the documented release process — rather than a label a maintainer could forget.
+  **`bc_gate.py` gates breaks by the bump they arrive in**, which the checker cannot: it reports
+  breaks but not whether *this* bump permits them, and pre-1.0 that matters — SemVer 2.0.0 §4 permits
+  a break in `0.7 → 0.8` and forbids the identical break in `0.7.0 → 0.7.1`. Breaks fail a PATCH and
+  a post-1.0 MINOR; they pass a MAJOR and a pre-1.0 MINOR, always printing what was permitted, since
+  "the gate passed" and "there were no breaks" are different facts.
+
+### Changed
+
+- **The deprecation window is now stated as one full *published* MINOR** (**ADR-0031**), resolving a
+  contradiction that had been in the repository since scaffold: `docs/workflow/maintenance.md` said
+  deprecations are kept *"for at least the rest of the current MAJOR line"* while the imported spec
+  §8 says they *"live one minor before removal"*. The spec is the contract.
+  The window is measured in released versions rather than time or commits — deprecating and removing
+  inside one release warns nobody, whatever the version numbers say — and removal must still land in
+  a bump that permits a break, since removing a public symbol *is* one. The section also gains the
+  pre-1.0 case it never had: deprecate in `0.N`, remove no earlier than `0.N+2`.
+
 - **Benchmark regression and budget gates in CI** (**ADR-0030**) — spec NFR-06, plus
   `.github/workflows/nightly.yml`. No production code changed.
   NFR-06's *"regression > 10% fails"* could not be built against a stored baseline: measured from

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-05 — The gate NFR-06 asked for would have fired on nothing](docs/journal/2026/08/2026-08-05-bench-harness.md).
+  [2026-08-05 — A tool whose own PHP floor is above ours](docs/journal/2026/08/2026-08-05-bc-gate.md).
 
 ## Model & effort routing (advisory)
 
@@ -439,8 +439,21 @@ dedicated post-M7 API-freeze review.
       the whole `php.ini`, not NFR-06's environment. The environment is now **asserted** rather than
       configured and hoped for. Still not the named reference CPU; NFR-04 stays ungated (a memory
       delta phpbench's `mem_peak` does not report) — both named, not quietly skipped.*
-- [ ] 7.2 `roave/backward-compatibility-check` wired to release PRs; deprecation policy
-      documented (RFC-0001) (severity:medium) — route: standard / medium
+- [x] 7.2 `roave/backward-compatibility-check` wired to release PRs; deprecation policy
+      documented (RFC-0001) (severity:medium) — route: standard / medium *(session model matched
+      the route)* · **ADR-0031**. *Three obstacles, each found by trying: the tool's own PHP floor
+      is **above this library's** (8.2+ from 8.7.0, later 8.3+/8.4+, against our pinned 8.1.34), so
+      it is installed into a **throwaway project** rather than `composer.json` — the 8.1 matrix cell,
+      `--prefer-lowest` and NFR-08 all stay untouched; upstream **ships no PHAR** any more; and it
+      **hard-fails with zero tags** (`Could not detect any released versions`), which is exactly the
+      state of this repo, so the job skips on a declared condition and self-enables at the first tag
+      (lesson L-0010). A release PR is detected from a **`Version.php` diff**, not a label a
+      maintainer could forget. The substance is `tools/bc_gate.py`: the checker cannot say whether a
+      break is *allowed in this bump*, and pre-1.0 that matters — SemVer §4 permits a break in
+      `0.7 → 0.8` and forbids the same break in `0.7.0 → 0.7.1`. **Also resolved a contradiction
+      already in the repo:** `maintenance.md` said deprecations last "the rest of the current MAJOR
+      line", the imported spec §8 says "one minor" — the spec wins, restated as **one full published
+      MINOR**, with the pre-1.0 case it previously lacked.*
 - [ ] 7.3 Signed tags → validated release action → Packagist publish (RFC-0001)
       (severity:high — supply-chain surface) — route: standard / high
 - [ ] 7.4 `egl/utils-psr7-bridge` packaging decision: subtree vs second repository (possibly a

--- a/docs/adr/0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md
+++ b/docs/adr/0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md
@@ -1,0 +1,152 @@
+# ADR-0031: Run the BC checker outside this package's dependency graph, and gate breaks by the bump they arrive in
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 7.2 · spec **NFR-07**, NFR-08 (dependency policy) · imported spec §8
+  (the BC policy and the deprecation window this resolves) ·
+  [RFC-0001](../rfc/0001-egl-utils-library.md) (versioning) ·
+  [ADR-0030](0030-same-runner-ab-because-a-stored-baseline-cannot-carry-a-10-percent-gate.md) (the
+  sibling gates, and the same absence-is-failure discipline) ·
+  [ADR-0003](0003-pin-ci-actions-by-commit-sha.md) · `docs/workflow/maintenance.md`,
+  `docs/workflow/release.md`
+
+## Context
+
+NFR-07 requires *"`roave/backward-compatibility-check` on release PRs"*. Three things stood in the
+way, and each was found by trying rather than by reading.
+
+**The tool cannot be a dependency of this package.** Every release from 8.7.0 requires PHP `~8.2`,
+later `~8.3` and then `~8.4`. This library supports **PHP 8.1** — that is why
+`config.platform.php` is pinned to `8.1.34` and why the CI matrix has an 8.1 cell. A `composer
+require --dev` resolves to 8.6.0 at best, or breaks the 8.1 cell, or forces abandoning the 8.1
+promise. The dry run states it plainly:
+
+```
+roave/backward-compatibility-check[8.12.0, ..., 8.14.0] require php ~8.2.0 || ~8.3.0 || ~8.4.0
+  -> your php version (8.1.34; overridden via config.platform) does not satisfy that requirement.
+```
+
+**There is no PHAR any more.** The obvious escape — run it as a self-contained binary — is gone:
+`gh release view` on the upstream repository shows **no assets** on recent tags.
+
+**It hard-fails on a repository with no tags.** Verified directly:
+
+```
+In invariant_violation.php line 16:
+  Could not detect any released versions for the given repository
+```
+
+This repository has **no tags** (`git tag -l` is empty, `VERSION = '0.0.0'`). The first release PR
+is precisely when the check would first run, so a naive wiring would fail the very PR it exists to
+protect.
+
+## Decision
+
+### 1. The checker is installed into a throwaway project, not into `composer.json`
+
+`composer require --working-dir="$RUNNER_TEMP/bc-tool"` on PHP 8.3. The tool analyses this
+package's source from outside, so its own PHP floor need not be this package's floor — and keeping
+it out of the lock file means the 8.1 matrix cell, the `--prefer-lowest` job and NFR-08's dependency
+policy are all untouched.
+
+Pinned to `^8.16` rather than left floating: a release gate whose own findings change between runs
+is a gate nobody can review.
+
+### 2. The gate skips on a declared condition and self-enables at the first tag
+
+No `v*.*.*` tag means nothing to compare against, so the job emits a notice saying so and passes.
+This is lesson **L-0010** applied verbatim — *make it SKIP on a declared condition rather than fail,
+and drive that condition from data so the guard self-disables the moment the item lands.* The moment
+the first tag exists the check runs, with no edit to the workflow.
+
+### 3. A release PR is detected from `Version.php`, not from a label
+
+Step 1 of `docs/workflow/release.md` is bumping the `VERSION` constant, so the PR's diff against its
+base is a mechanical, unforgeable signal. A label would work until someone forgot it, and a gate that
+silently does not run is worse than no gate — the failure mode this project has already had to go
+back and fix twice.
+
+### 4. Breaks are gated **by the bump they arrive in**, which the checker cannot do
+
+This is the substance of the item. `roave/backward-compatibility-check` answers *"are there
+backward-incompatible changes since the last release?"* It cannot answer the question that actually
+gates a release: *"are those breaks allowed in **this** bump?"*
+
+Those differ, and pre-1.0 they differ sharply — SemVer 2.0.0 §4 says that under `0.y.z` anything may
+change, so a break in `0.7 -> 0.8` is not a violation while the identical break in `0.7.0 -> 0.7.1`
+is. `tools/bc_gate.py` encodes the rule:
+
+| previous | bump | breaks | verdict |
+|---|---|---|---|
+| any | PATCH | yes | **FAIL** — a PATCH promises nothing changed |
+| `0.y.z` | MINOR | yes | pass — SemVer §4; pre-1.0 MINOR is this project's declared vehicle |
+| `>= 1.0.0` | MINOR | yes | **FAIL** — post-1.0 a MINOR must be additive |
+| any | MAJOR | yes | pass — a MAJOR is what a break is for |
+| any | any | no | pass |
+
+**A permitted break is never a silent one.** Every passing case still prints what was permitted and
+why, because "the gate passed" and "there were no breaks" are different facts, and a release note
+that conflates them is how a consumer gets surprised.
+
+### 5. The deprecation window is **one full published MINOR**, and the contradiction is resolved
+
+`docs/workflow/maintenance.md` said deprecations are kept *"for at least the rest of the current
+MAJOR line"*. The imported spec §8 says they *"live one minor before removal"*. Both were in the
+repository, contradicting each other, and nobody noticed until the item that had to implement them.
+
+The spec is the contract, so the spec wins — and the reconciliation matters, because removing a
+public symbol *is* a BC break and therefore cannot land in any bump that forbids one. Stated
+precisely:
+
+1. Deprecate in a MINOR; the symbol keeps working.
+2. **One full published MINOR** must ship with it present and deprecated. The window is measured in
+   released versions, not in time or commits: deprecating and removing inside one release gives no
+   consumer a chance to see the warning, whatever the numbers say.
+3. Remove in a bump that permits a break — MAJOR after 1.0, MINOR while on `0.y.z`.
+
+Pre-1.0 that reads: deprecate in `0.N`, remove no earlier than `0.N+2`. SemVer's relaxation under
+`0.y.z` is about *which bump may carry a break*, not about whether consumers are warned first.
+
+## Alternatives Considered
+
+- **`composer require --dev roave/backward-compatibility-check`** — rejected in §1: its PHP floor is
+  above this library's, so it would break the 8.1 matrix cell or the 8.1 promise.
+- **Pinning `^8.6`, the last version supporting PHP 8.1** — possible, and rejected: it freezes the
+  gate on an old analyser to satisfy a constraint that only exists because of where it was installed.
+  Moving the install solves the constraint instead of accommodating it.
+- **Raising the platform pin to 8.2** — rejected outright: the spec says PHP 8.1+, and a tooling
+  convenience is not a reason to drop a supported runtime.
+- **A PHAR** — unavailable (§ Context); upstream ships no release assets.
+- **A label to mark release PRs** — rejected in §3: a gate that depends on being remembered.
+- **Running the checker on every PR** — rejected: pre-1.0 it would report breaks that are legal by
+  §4 on most PRs, and a gate that is routinely and correctly ignored stops being read at all. NFR-07
+  places it on release PRs; that is also where it is actionable, since the remedy is the bump.
+- **Failing on any break at all** — rejected in §4: it would force a premature 1.0.0 to express a
+  change that `0.y` exists to permit.
+- **Leaving `maintenance.md` as it stood** — rejected in §5. Two documents disagreeing about the
+  deprecation window is worse than either rule, because the answer depends on which one a
+  maintainer happens to read.
+
+## Consequences
+
+- New job `quality / backward compatibility` in `ci.yml`, and `tools/bc_gate.py`.
+- **The gate is proven to fail before being trusted** (lesson L-0008), ten cases with verified exit
+  codes: PATCH+breaks, post-1.0 MINOR+breaks, no bump, a decreasing version, an unparseable version
+  and a non-integer exit code all exit 1; pre-1.0 MINOR+breaks, MAJOR+breaks, `0.x -> 1.0` and
+  PATCH-without-breaks all exit 0.
+- **Release-PR detection proven in both directions**: unchanged `Version.php` is not a release PR; a
+  committed bump is detected, with the version read back correctly.
+- Until the first `v*.*.*` tag the job emits a notice and passes. That state is visible in CI rather
+  than implied by a green tick.
+- `docs/workflow/maintenance.md`'s deprecation section is rewritten, and gains the pre-1.0 case it
+  did not previously have.
+- 30 action pins across three workflows verified upstream (ADR-0003).
+
+## References
+
+- Imported spec §8 — *"`roave/backward-compatibility-check` against the previous tag on every
+  release PR; deprecations live one minor before removal"*
+- SemVer 2.0.0 §4 — major version zero, and what it does and does not permit
+- Verified against `roave/backward-compatibility-check` 8.x: the PHP constraints above, the absence
+  of release assets, and the no-tags failure mode

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,3 +46,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0028](0028-container-exceptions-live-in-the-container-group-and-get-carries-a-type.md) | Container exceptions in the Container group, a typed `get()`, and a benchmark that measured the harness | Accepted |
 | [0029](0029-result-carries-a-throwable-and-production-withholds-the-message-too.md) | A `Result` failure carries a throwable, `map()` does not catch, and production withholds the message too | Accepted |
 | [0030](0030-same-runner-ab-because-a-stored-baseline-cannot-carry-a-10-percent-gate.md) | A same-runner A/B, because a stored baseline cannot carry NFR-06's 10% gate — and all three deferred budgets are met | Accepted |
+| [0031](0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md) | Run the BC checker outside this package's dependency graph, gate breaks by the bump, and settle the deprecation window | Accepted |

--- a/docs/journal/2026/08/2026-08-05-bc-gate.md
+++ b/docs/journal/2026/08/2026-08-05-bc-gate.md
@@ -1,0 +1,103 @@
+# 2026-08-05 — A tool whose own PHP floor is above ours
+
+Roadmap item **7.2**. Route `standard / medium` → Opus 5, the session model. No mismatch.
+
+NFR-07 asks for one line of wiring: run `roave/backward-compatibility-check` on release PRs. Three
+things were in the way, and none of them were visible from reading.
+
+## It cannot be a dependency of this package
+
+```
+roave/backward-compatibility-check[8.12.0, ..., 8.14.0] require php ~8.2.0 || ~8.3.0 || ~8.4.0
+  -> your php version (8.1.34; overridden via config.platform) does not satisfy that requirement
+```
+
+Every release from 8.7.0 wants PHP ≥ 8.2, later ≥ 8.3, then ≥ 8.4. **This library supports 8.1** —
+that is the whole reason `config.platform.php` is pinned to `8.1.34` and the matrix has an 8.1 cell.
+So `composer require --dev` gives one of: 8.6.0 (the last 8.1-compatible release, frozen), a broken
+8.1 matrix cell, or dropping 8.1 support for a tooling convenience.
+
+None of those are acceptable, and the constraint only exists because of *where* the tool would live.
+It analyses our source from outside; its own floor need not be ours. So it goes into a throwaway
+`composer require --working-dir="$RUNNER_TEMP/bc-tool"` on PHP 8.3, and our lock file never learns
+about it.
+
+I checked the obvious escape first — a PHAR. Upstream ships **no release assets** any more.
+
+## It hard-fails on a repo with no tags
+
+```
+In invariant_violation.php line 16:
+  Could not detect any released versions for the given repository
+```
+
+`git tag -l` here is empty. `VERSION` is `0.0.0`. **The first release PR is exactly when this check
+would first run**, so wiring it naively would have failed the very PR it exists to protect — and
+failed it with an error about the tool, not about the code.
+
+Lesson **L-0010** almost verbatim: skip on a declared condition, drive the condition from data, and
+let the guard self-enable the moment the condition is met. The job emits a notice saying why it did
+nothing, which is the part that matters — a silent skip and a real pass look identical on a green
+tick.
+
+## The checker answers the wrong question
+
+This is the part worth the item. `roave/backward-compatibility-check` answers *"are there
+backward-incompatible changes since the last release?"* The question that gates a release is *"are
+those breaks allowed in **this** bump?"*
+
+Pre-1.0 those come apart completely. SemVer 2.0.0 §4: under `0.y.z`, anything may change. So a break
+in `0.7 → 0.8` is fine and the identical break in `0.7.0 → 0.7.1` is not — the checker reports both
+the same way. Wiring it straight through would have given a gate that either fails legitimate pre-1.0
+minors or passes an illegitimate patch.
+
+So `tools/bc_gate.py` takes the checker's exit code and the two version numbers and applies the rule.
+Ten cases, exit codes verified: PATCH+breaks fails, post-1.0 MINOR+breaks fails, pre-1.0
+MINOR+breaks passes, MAJOR+breaks passes, and the malformed inputs all fail rather than being read as
+"probably fine".
+
+Every permitted break still prints *what* was permitted. "The gate passed" and "there were no breaks"
+are different facts and a release note that conflates them is how a consumer gets surprised.
+
+## A contradiction already sitting in the repo
+
+`docs/workflow/maintenance.md`:
+
+> **Honour a window** — keep it for at least the rest of the current MAJOR line.
+
+The imported spec §8:
+
+> deprecations live one minor before removal
+
+Both in the repository, disagreeing, since scaffold. Nobody noticed until the item that had to
+implement them — and the answer would have depended on which document a maintainer happened to open.
+
+The spec is the contract, so the spec wins. But the reconciliation needed care, because removing a
+public symbol **is** a BC break and so cannot land in a bump that forbids one: satisfying the window
+does not license a removal in a PATCH. Restated as *one full **published** MINOR* — measured in
+released versions, not time or commits, because deprecating and removing inside one release warns
+nobody whatever the numbers say. Plus the pre-1.0 case the section never had: deprecate in `0.N`,
+remove no earlier than `0.N+2`.
+
+## Two mistakes of my own
+
+**I forgot to create a branch.** Item 7.2's first hour of work happened on `master`, and worse, I
+tested the release-PR detection by committing a version bump *to master* and then
+`git reset --hard`-ing it. Master is fine — verified it matches `origin/master` — but `reset --hard`
+also discarded the uncommitted `ci.yml` job I had just written. Recovered it from the scratchpad copy.
+Two separate lapses in one command: destructive reset with uncommitted work in the tree, on the
+protected branch.
+
+**My first detection test proved nothing.** `git diff --quiet master HEAD -- Version.php` on a
+checkout where `HEAD` *is* `master` is empty by construction, so the test reported "failed to detect"
+when the logic was fine and the experiment was broken. Same family as the `| tail` exit-code mistake
+in item 7.1, one item ago: the check was measuring itself, not the thing.
+
+## Bar
+
+1299 tests / 2916 assertions green. PHPStan max clean, deptrac 0/0, consistency lint OK, 30 action
+pins verified upstream.
+
+## Next
+
+**7.3** — signed tags → validated release action → Packagist publish.

--- a/docs/workflow/maintenance.md
+++ b/docs/workflow/maintenance.md
@@ -51,10 +51,30 @@ advisory/CVE; backport to every supported line.
 
 ## Deprecation policy
 
-1. **Deprecate in a MINOR** — mark deprecated in the API docs + a `Deprecated` changelog
-   line; the symbol keeps working; record the replacement in an ADR.
-2. **Honour a window** — keep it for at least the rest of the current MAJOR line.
-3. **Remove in the next MAJOR** — with the breaking-change ADR + a migration note.
+The window is **one full published MINOR**, per the imported spec §8: *"deprecations live one minor
+before removal."* An earlier version of this section said "at least the rest of the current MAJOR
+line", which contradicted that; the spec is the contract and wins. Resolved in **ADR-0031**.
+
+1. **Deprecate in a MINOR** — mark it deprecated in the API docs, add a `Deprecated` changelog line,
+   and record the replacement in an ADR. **The symbol keeps working**, unchanged.
+2. **Let one full MINOR ship with it deprecated.** The window is measured in *published releases*,
+   not in time or commits: a symbol deprecated and removed inside the same release gave no consumer
+   any chance to see the warning, whatever the version numbers say.
+3. **Remove in a release whose bump permits a break** — a MAJOR after 1.0, or a MINOR while still on
+   `0.y.z`, where SemVer 2.0.0 §4 permits it. With the breaking-change ADR and a migration note.
+
+Removing a public symbol **is** a backward-incompatible change, which is why step 3 is about the
+bump and not merely about the window: satisfying the window does not license a removal in a PATCH.
+`tools/bc_gate.py` enforces exactly that boundary on release PRs — it permits detected breaks in a
+MAJOR bump, and in a pre-1.0 MINOR, and refuses them in a PATCH or in a post-1.0 MINOR.
+
+### While the version is still `0.y.z`
+
+SemVer 2.0.0 §4 says anything may change under `0.y.z`, and this project's pre-1.0 line bumps MINOR
+per completed milestone. So pre-1.0 the policy reads: deprecate in `0.N`, remove no earlier than
+`0.N+2` — one full published MINOR (`0.N+1`) must have shipped with the symbol present and
+deprecated. The relaxation SemVer grants is in *which bump may carry a break*, not in whether
+consumers get a warning first.
 
 ## Consistency lint — failure → remediation
 

--- a/tools/bc_gate.py
+++ b/tools/bc_gate.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Daniel Polo
+"""Decide whether detected BC breaks are permitted by the version bump — spec NFR-07, ADR-0031.
+
+`roave/backward-compatibility-check` answers one question: *are there backward-incompatible
+changes since the previous release?* It cannot answer the question that actually gates a release,
+which is *are those breaks allowed in **this** bump?* Those differ, and pre-1.0 they differ a lot:
+SemVer 2.0.0 §4 says that under `0.y.z` "anything MAY change at any time", so a break in a 0.7 ->
+0.8 bump is not a violation — while the same break in 0.7.0 -> 0.7.1 is, because a PATCH promises
+nothing changed.
+
+    php .../roave-backward-compatibility-check --from=v0.7.0 ; echo $? > bc.code
+    python tools/bc_gate.py --previous 0.7.0 --current 0.8.0 --bc-exit "$(cat bc.code)"
+
+The rule, which is this project's own policy and not SemVer alone:
+
+| previous | current | breaks found | verdict |
+|---|---|---|---|
+| any       | PATCH bump   | yes | **FAIL** — a PATCH may never break |
+| `0.y.z`   | MINOR bump   | yes | pass — SemVer §4, and pre-1.0 MINOR is this project's declared vehicle |
+| `>=1.0.0` | MINOR bump   | yes | **FAIL** — post-1.0 a MINOR must be additive |
+| `>=1.0.0` | MAJOR bump   | yes | pass — a MAJOR is what a break is for |
+| `0.y.z`   | MAJOR bump   | yes | pass — 0.x -> 1.0 is the API freeze |
+| any       | any          | no  | pass |
+
+**A break is never silently allowed.** Every permitted case still prints what was permitted and
+why, because "the gate passed" and "there were no breaks" are different facts and a release note
+that conflates them is how a consumer gets surprised.
+
+**Absence is failure**, as in the sibling gates: a version that does not parse, a non-increasing
+bump, or a missing argument exits non-zero rather than being treated as "probably fine".
+"""
+
+import argparse
+import re
+import sys
+
+SEMVER = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
+
+
+class GateError(Exception):
+    """A condition that must fail the gate rather than be reported as a verdict."""
+
+
+def parse(version, label):
+    """`1.2.3` (with an optional leading `v` and trailing pre-release) into (1, 2, 3)."""
+    cleaned = version.strip().lstrip("vV")
+    match = SEMVER.match(cleaned)
+    if match is None:
+        raise GateError(
+            f'the {label} version "{version}" is not SemVer. A release that cannot be compared '
+            "cannot be gated, which is a failure and not a pass."
+        )
+    return tuple(int(part) for part in match.groups())
+
+
+def bump_level(previous, current):
+    """'major', 'minor' or 'patch' — which component increased."""
+    if current[0] != previous[0]:
+        return "major"
+    if current[1] != previous[1]:
+        return "minor"
+    if current[2] != previous[2]:
+        return "patch"
+    raise GateError(
+        f"the version did not change ({'.'.join(map(str, previous))}). A release PR must bump it; "
+        "the consistency lint's version lockstep covers the same ground from the other side."
+    )
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Gate detected BC breaks against the version bump they arrive in."
+    )
+    ap.add_argument("--previous", required=True, help="version of the previous release (the tag)")
+    ap.add_argument("--current", required=True, help="version being released (Version.php)")
+    ap.add_argument(
+        "--bc-exit",
+        required=True,
+        help="exit code from roave/backward-compatibility-check: 0 means no breaks",
+    )
+    args = ap.parse_args(argv)
+
+    try:
+        previous = parse(args.previous, "previous")
+        current = parse(args.current, "current")
+
+        if current < previous:
+            raise GateError(
+                f"the current version {'.'.join(map(str, current))} is lower than the previous "
+                f"{'.'.join(map(str, previous))}. Releases move forward."
+            )
+
+        level = bump_level(previous, current)
+
+        try:
+            bc_exit = int(args.bc_exit)
+        except ValueError as exc:
+            raise GateError(f'--bc-exit "{args.bc_exit}" is not an integer: {exc}') from exc
+    except GateError as exc:
+        print(f"bc gate: FAIL\n\n  {exc}")
+        return 1
+
+    breaks = bc_exit != 0
+    pre_one_zero = previous[0] == 0
+
+    print(
+        f"bc gate: {'.'.join(map(str, previous))} -> {'.'.join(map(str, current))} "
+        f"({level.upper()} bump), breaks detected: {'yes' if breaks else 'no'}"
+    )
+
+    if not breaks:
+        print("\nbc gate: OK — no backward-incompatible change since the previous release.")
+        return 0
+
+    if level == "patch":
+        print(
+            "\nbc gate: FAIL — backward-incompatible changes in a PATCH bump.\n\n"
+            "  A PATCH promises that nothing changed for a consumer. Either drop the breaking\n"
+            "  change from this release, or make it a MINOR (pre-1.0) / MAJOR (post-1.0) bump."
+        )
+        return 1
+
+    if level == "minor" and not pre_one_zero:
+        print(
+            "\nbc gate: FAIL — backward-incompatible changes in a MINOR bump after 1.0.\n\n"
+            "  Post-1.0 a MINOR must be additive; a break needs a MAJOR. If the symbol was\n"
+            "  deprecated, check it has been published as deprecated for at least one full MINOR\n"
+            "  before removal (docs/workflow/maintenance.md)."
+        )
+        return 1
+
+    if level == "minor":
+        print(
+            "\nbc gate: OK — breaks are PERMITTED in a pre-1.0 MINOR bump (SemVer 2.0.0 §4:\n"
+            "  under 0.y.z anything may change). They are permitted, not invisible: list them\n"
+            "  under a `Breaking` heading in the changelog and the release notes, because a\n"
+            "  consumer reading only the version number has no other warning."
+        )
+        return 0
+
+    print(
+        "\nbc gate: OK — breaks are PERMITTED in a MAJOR bump, which is what a MAJOR is for.\n"
+        "  Record them under a `Breaking` heading with a migration note (ADR required per\n"
+        "  docs/workflow/maintenance.md)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Roadmap item **7.2**. NFR-07 asks for one line of wiring. Three things were in the way, and none were visible from reading.

## The tool's own PHP floor is above this library's

```
roave/backward-compatibility-check[8.12.0, ..., 8.14.0] require php ~8.2.0 || ~8.3.0 || ~8.4.0
  -> your php version (8.1.34; overridden via config.platform) does not satisfy that requirement
```

Every release from 8.7.0 wants PHP ≥ 8.2, later ≥ 8.3, then ≥ 8.4. **This library supports 8.1** — which is exactly why `config.platform.php` is pinned to `8.1.34` and the matrix has an 8.1 cell. As a dev dependency the options were: 8.6.0 (the last 8.1-compatible release, frozen), a broken 8.1 cell, or dropping 8.1 support for a tooling convenience.

The constraint only exists because of *where* the tool would live. It analyses our source from outside, so its floor needn't be ours — it goes into a throwaway `composer require --working-dir="$RUNNER_TEMP/bc-tool"` on PHP 8.3 and our lock file never learns about it. The 8.1 cell, `--prefer-lowest` and NFR-08 all stay untouched. I checked the obvious escape first: upstream **ships no PHAR** any more.

## It hard-fails on a repo with no tags

```
In invariant_violation.php line 16:
  Could not detect any released versions for the given repository
```

`git tag -l` here is empty; `VERSION` is `0.0.0`. **The first release PR is exactly when this check would first run** — so naive wiring would have failed the very PR it exists to protect, with an error about the tool rather than the code. Lesson **L-0010** verbatim: skip on a declared condition, self-enable at the first tag, and *say so in a notice*, because a silent skip and a real pass look identical on a green tick.

A release PR is detected from a `Version.php` diff — step 1 of the documented release process — not a label a maintainer could forget.

## The checker answers the wrong question

It reports *whether there are breaks since the last release*. What gates a release is *whether those breaks are allowed in **this** bump*. Pre-1.0 those come apart: SemVer 2.0.0 §4 permits a break in `0.7 → 0.8` and forbids the identical break in `0.7.0 → 0.7.1`, and the checker reports both the same way. Wired straight through, it would either fail legitimate pre-1.0 minors or pass an illegitimate patch.

`tools/bc_gate.py` applies the rule, and every permitted break still prints *what* was permitted — "the gate passed" and "there were no breaks" are different facts.

## A contradiction that was already in the repo

`docs/workflow/maintenance.md`: deprecations kept *"for at least the rest of the current MAJOR line"*.
Imported spec §8: they *"live one minor before removal"*.

Both present since scaffold, disagreeing — and the answer would have depended on which document you opened. The spec is the contract, so it wins, restated as **one full *published* MINOR**: measured in released versions, not time or commits, because deprecating and removing inside one release warns nobody whatever the numbers say. Removal must still land in a bump that permits a break, since removing a public symbol *is* one — satisfying the window doesn't license a removal in a PATCH. The section also gains the pre-1.0 case it never had (deprecate in `0.N`, remove no earlier than `0.N+2`).

## Gates proven to fail before being trusted

| case | exit |
|---|---|
| PATCH + breaks | 1 |
| post-1.0 MINOR + breaks | 1 |
| no bump / decreasing version | 1 |
| unparseable version / non-integer checker code | 1 |
| pre-1.0 MINOR + breaks | 0 |
| MAJOR + breaks · `0.x → 1.0` · PATCH without breaks | 0 |

Release-PR detection proven both ways: unchanged `Version.php` is not a release PR; a committed bump is detected with the version read back correctly.

## Bar

1299 tests / 2916 assertions green, PHPStan max clean, deptrac 0/0, consistency lint OK, 30 action pins verified upstream.

Route `standard / medium` matched the session model.

## Two mistakes of mine, recorded in the journal

I started this item **on `master`** without branching, and tested the detection by committing a version bump to master then `git reset --hard`-ing it — which also discarded the uncommitted `ci.yml` job I'd just written (recovered from a scratchpad copy). `master` is verified identical to `origin/master`. And my first detection test proved nothing: `git diff master HEAD` on a checkout where `HEAD` *is* `master` is empty by construction, so it reported failure while the logic was fine — the same family of error as item 7.1's `| tail` exit-code mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
