### PR TITLE
docs(bridge): the packaging decision — monorepo source, generated split repo, independent tags

### DIFF
--- a/.eados-core/learning/runs/2026-08-05-utils-10.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils-10.yaml
@@ -1,0 +1,33 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **The PSR-7 bridge packaging decision** (**ADR-0033**, closing Milestone 7 and RFC-0001's A-8) —
+  plus [`docs/specs/02_spec_psr7_bridge.md`](docs/specs/02_spec_psr7_bridge.md), the frozen contract
+  Milestone 8 implements. **No code lands**: item 7.4's deliverable is the decision.
+  Two findings reframed "subtree vs second repository" before options could be weighed: Packagist
+  requires `composer.json` at a repository root, so a second repository exists under **every**
+  option — the real question is whether it is authored or **generated**; and the maintainer struck a
+  phantom cost from the analysis (EADOS is an external generation tool, not repository governance,
+  so "duplicating" it never belonged on the ledger).
+  Decision: canonical source under **`packages/utils-psr7-bridge/`** in this monorepo; the split
+  repository is a generated, **read-only** publication target; **independent versioning by design**
+  — `utils-psr7-bridge-vX.Y.Z` tags, signed at the source and verified before splitting
+  (ADR-0032's mechanism), translate to `vX.Y.Z` on the split repository. The load-bearing property
+  is same-PR integration: a core change that breaks the conversion contract fails in the PR that
+  introduces it — with its flip side named, a **release-mode** re-test against the *released* core
+  before any bridge tag ships.
+  Imported ADR-002's conversion contract is now numbered, testable clauses (**BFR-01…BFR-22**),
+  including its two sharpest edges: a PSR-7 response bearing multiple `Set-Cookie` headers is
+  **refused** rather than comma-joined (RFC 6265 cookie strings contain commas — joining corrupts
+  them silently), and uploaded files cross the `$_FILES` ↔ `UploadedFileInterface` boundary with
+  error codes preserved verbatim and **no stream access on a failed upload**. Milestone 8
+  (items 8.1–8.3) carries the implementation; the Spec Coverage Map's §7 row honestly **reopens**,
+  since the spec-named bridge contract tests do not exist yet.
+
 - **A verified release path** (**ADR-0032**) — spec §8, NFR-07. `release.yml` previously drafted a
   GitHub Release from whatever was tagged, having checked only that `composer install` succeeded. It
   is now three jobs, and **nothing is drafted until all of them pass**, because a draft is

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ setup.
 | 4 | Database | ✅ done |
 | 5 | Security | ✅ done |
 | 6 | HTTP, container, errors | ✅ done |
-| 7 | Release engineering & bridge | ⏳ planned |
+| 7 | Release engineering & bridge | ✅ done |
+| 8 | PSR-7 bridge (`packages/utils-psr7-bridge`) | ⏳ planned |
 
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-05 — The same defect, in the second place it happened](docs/journal/2026/08/2026-08-05-release-gate.md).
+  [2026-08-05 — The question under the question](docs/journal/2026/08/2026-08-05-bridge-packaging.md).
 
 ## Model & effort routing (advisory)
 
@@ -471,9 +471,57 @@ dedicated post-M7 API-freeze review.
       than being pushed from CI: no Packagist token here, and AGENTS.md §11's line intact. Two
       one-time maintainer prerequisites are documented — a signing key on the GitHub account and the
       Packagist integration — and **the first release cannot succeed without them**.*
-- [ ] 7.4 `egl/utils-psr7-bridge` packaging decision: subtree vs second repository (possibly a
+- [x] 7.4 `egl/utils-psr7-bridge` packaging decision: subtree vs second repository (possibly a
       second EADOS run) + ADR-002's conversion contract tests (RFC-0001 A-8)
-      (adr, decision-heavy) — route: frontier-reasoning / extra
+      (adr, decision-heavy) — route: frontier-reasoning / extra *(run at the routed tier — the
+      maintainer switched the session to Fable 5 rather than accepting a sixth mismatch)* ·
+      **ADR-0033**, **spec 02 r1**. *Two findings reframed A-8's wording before options could be
+      weighed: Packagist needs `composer.json` at a repository root, so a second repository exists
+      under **every** option and the real question is authored vs **generated**; and the maintainer
+      struck a phantom cost from the analysis — EADOS is an external generation tool, not repository
+      governance, so "duplicating it" never belonged on the ledger. Decision: canonical source under
+      **`packages/utils-psr7-bridge/`** in this monorepo (own composer.json, namespace
+      `D4np\Utils\Bridge\Psr7\`, tests, static analysis, changelog); the split repository is a
+      **generated, read-only publication target** — no PRs, no authored commits; **independent
+      versioning by design, not inheritance**: `utils-psr7-bridge-vX.Y.Z` tags translate to
+      `vX.Y.Z` on the split repo, signed at the source and verified before splitting (ADR-0032's
+      mechanism). The load-bearing property is same-PR integration: a core change that breaks the
+      conversion contract fails in the PR that introduces it — with the flip side named, a
+      **release-mode** re-test against the released core before any bridge tag ships, because the
+      committed constraint is a claim PR-mode evidence cannot support. Imported ADR-002's
+      conversion contract is now **BFR-01…BFR-22**, including the two traps that make it more than
+      ceremony: multiple `Set-Cookie` headers are refused rather than comma-joined (RFC 6265), and
+      uploaded files cross the `$_FILES` ↔ stream boundary with no stream access on a failed
+      upload. **A decision, not an implementation** — the ADR-002 contract *tests* move to item
+      8.2, which is why the Spec Coverage Map's §7 row reopens. Milestone 8 carries the build.*
+
+---
+
+## Milestone 8 — PSR-7 bridge (`utils-psr7-bridge-v0.1.0`) · size: M
+
+The implementation of ADR-0033's decision, specified end to end by
+[`docs/specs/02_spec_psr7_bridge.md`](docs/specs/02_spec_psr7_bridge.md). **Bridge-scoped:** this
+milestone versions under the bridge's own tag line (`utils-psr7-bridge-v0.1.0`), not the core's —
+the core's minor-per-milestone rule (AGENTS.md §11) applies to milestones that change the core
+package, and the core-side work here (a CI job, docs) is chore-level. The post-M7 `1.0.0`
+API-freeze review for the **core** is unaffected by this milestone.
+
+- [ ] 8.1 Scaffold `packages/utils-psr7-bridge/` per spec 02 §2 (composer.json, PSR-4, quality
+      bar, in-package changelog) + the self-enabling `bridge-contract` CI job (PR mode: path
+      repository injected in the CI workspace only; guard on the package's composer.json existing,
+      lesson L-0010) + the core deptrac rule that a core → `D4np\Utils\Bridge\` import is a build
+      failure — route: standard / medium
+- [ ] 8.2 `Psr7Bridge` converters + the full **T-B** contract suite: every clause of spec 02
+      §4–§5 (BFR-01…BFR-22) tested against **two** PSR-17 implementations (nyholm/psr7,
+      guzzlehttp/psr7), each refusal and fidelity clause probe-verified by planting the defect it
+      claims to catch (severity:high — the conversion contract is the package's entire value) —
+      route: standard / high
+- [ ] 8.3 Publication pipeline per spec 02 §6: signed-source-tag verification (ADR-0032 reused),
+      **release-mode** contract run against the released core, `git subtree split` + translated
+      tag push to the read-only split repository; verify the `v*.*.*` / `utils-psr7-bridge-v*`
+      tag-grammar isolation with a real tag before the first publication; one-time maintainer
+      actions documented (create the split repo, register `egl/utils-psr7-bridge` on Packagist)
+      (severity:high — supply-chain surface) — route: standard / high
 
 ---
 
@@ -491,6 +539,6 @@ Legend: ⏳ not started · 🚧 in progress · ✅ done · ❎ N/A.
 | §4 | NFR budgets & benchmark methodology | 3.5, 4.5, 5.5, 6.4, 7.1 | ✅ |
 | §5 | Security test criteria | 4.4, 5.4, 5.5, 6.3 | ✅ |
 | §6 | API example / public interface | 1.6, 3.1 | ✅ |
-| §7 | Verification & test strategy (r2) | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3 | ✅ |
-| §8 | CI/CD & release engineering | 1.4, 1.7, 7.1–7.3 | 🚧 |
-| §9 | Decision log (imported + seeded ADRs) | 2.1, 5.3, 7.4 | 🚧 |
+| §7 | Verification & test strategy (r2) | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3, 8.2 | 🚧 |
+| §8 | CI/CD & release engineering | 1.4, 1.7, 7.1–7.3, 8.3 | 🚧 |
+| §9 | Decision log (imported + seeded ADRs) | 2.1, 5.3, 7.4 | ✅ |

--- a/docs/adr/0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md
+++ b/docs/adr/0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md
@@ -1,0 +1,177 @@
+# ADR-0033: The bridge's source lives in this monorepo; a generated, read-only split repository is only its publication target
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Deciders:** maintainer (`@danielPoloWork`, who selected the topology and corrected the
+  analysis), agent acting as tech-lead — **run at the routed tier** (`frontier-reasoning / extra`,
+  protected floor; the maintainer switched the session to Fable 5 rather than accepting a mismatch)
+- **Related:** ROADMAP item 7.4 (closes Milestone 7) · [RFC-0001](../rfc/0001-egl-utils-library.md)
+  A-8 (the deferred packaging decision this settles) ·
+  imported [ADR-002](../../.specs/d4np_php_adr_002_http_psr7.md) (the bridge exists, is optional,
+  and owes conversion-fidelity contract tests) · spec NFR-08 (dependency policy) ·
+  [ADR-0025](0025-typed-http-wrappers-that-refuse-rather-than-coerce.md) (the refuse-don't-coerce
+  semantics the contract carries across the boundary) ·
+  [ADR-0032](0032-verify-the-tag-before-drafting-and-let-packagist-pull.md) (the signed-tag
+  verification the publication pipeline reuses) ·
+  **Contract:** [`docs/specs/02_spec_psr7_bridge.md`](../specs/02_spec_psr7_bridge.md) (the package
+  boundary, versioning scheme, publication pipeline and conversion contract this ADR commissions)
+
+## Context
+
+Imported ADR-002 already decided the *what*: `Request`/`Response` stay dependency-free in the core,
+and PSR-7 interop lives in an **optional separate Composer package**, `egl/utils-psr7-bridge`, which
+owes conversion-fidelity contract tests. RFC-0001's A-8 deferred the *where*: "subtree vs second
+repository (possibly a second EADOS run)".
+
+Two findings reframed that wording before any option could be weighed.
+
+**First, the mechanical one.** Packagist resolves a VCS-backed package from a repository whose
+`composer.json` sits at the **root**. A path inside this repository cannot be a Packagist package,
+which is why monorepo-split tooling exists at all. So "subtree" was never an alternative to a second
+repository — a second repository exists under every option, and the real question is whether it is
+**authored** (development happens there) or **generated** (a read-only publication artifact).
+
+**Second, a correction from the maintainer that removed a cost from the ledger.** The first analysis
+counted "a second copy of the governance built in items 7.1–7.3" against the authored-repository
+option. That conflated an external code-generation tool with repository governance: EADOS is not
+part of the library, is not committed, and duplicating a generation *tool* is not an architectural
+cost of a second *repository*. With that struck, the comparison stands on four honest axes:
+
+1. one authored repository versus two;
+2. **same-PR integration testing versus cross-repository compatibility testing**;
+3. one contribution and review flow versus two;
+4. generated publication infrastructure versus duplicated repository maintenance.
+
+The authored-repository option is stronger than the uncorrected analysis made it look — and still
+loses, on axis 2 above all.
+
+## Decision
+
+### 1. Canonical source: `packages/utils-psr7-bridge/` in this repository
+
+A strict package boundary containing its own `composer.json` (package `egl/utils-psr7-bridge`), its
+own PSR-4 namespace (`D4np\Utils\Bridge\Psr7\`), its own tests, static-analysis configuration,
+changelog and documentation — the full boundary is specified in
+[`02_spec_psr7_bridge.md` §2](../specs/02_spec_psr7_bridge.md). All development happens here, under
+this repository's review flow and quality bar.
+
+The load-bearing property is axis 2: **a core change that violates the PSR-7 conversion contract
+fails in the pull request that introduces it.** In CI the bridge installs the core from the working
+tree via an injected Composer path repository, so the contract tests run against the exact code
+under review — not against whatever core release the bridge happened to pin. With an authored second
+repository, the same defect is discovered later, in the other repository's CI, after the offending
+change has already merged here.
+
+### 2. The split repository is a publication target and nothing else
+
+Generated, **read-only**: no authored changes, no manual commits, no pull requests. Its README
+states that it is produced from this repository and links back. Its only writer is the publication
+pipeline. It exists because Packagist needs it, and for no other reason.
+
+### 3. The bridge versions independently, by package-scoped tags — designed, not inherited
+
+Tags in this repository of the form `utils-psr7-bridge-vMAJOR.MINOR.PATCH` version the bridge; the
+publication pipeline translates each into a plain `vMAJOR.MINOR.PATCH` tag on the split repository,
+which is what Packagist reads. The bridge starts its own pre-1.0 line at `utils-psr7-bridge-v0.1.0`.
+
+Nothing about the core's release cycle forces a bridge release or vice versa: a core release that
+does not touch the bridge ships no bridge version, and a bridge fix does not wait for a core
+milestone. The two tag grammars cannot collide: `release.yml` triggers on `v*.*.*`, and GitHub's
+filter patterns match the whole ref name, so `utils-psr7-bridge-v0.1.0` — which starts with `u` —
+does not match (`likely`, from GitHub's documented pattern semantics; item 8.3 verifies it against a
+real tag before the first publication, because a documented behavior is still an assumption until a
+tag has been pushed).
+
+The core's "one MINOR per completed milestone" rule (AGENTS.md §11) applies to milestones that
+change the **core package**. Milestone 8's deliverable versions under the bridge's own line; its
+core-side changes (a CI job, docs) are chore-level and roll into whichever core release follows.
+
+### 4. Two test modes, because the same-PR guarantee has a flip side
+
+PR mode proves the bridge against the **working tree**. But the bridge's committed `composer.json`
+declares a constraint against **released** core versions — and a constraint proven only against
+unreleased HEAD is a claim without evidence. So the publication pipeline runs the contract suite a
+second time, in **release mode**: a clean install with no path repository, resolving `egl/utils`
+from Packagist as a consumer would. A bridge tag ships only if both modes pass. The two modes and
+their mechanics are specified in [`02_spec_psr7_bridge.md` §6](../specs/02_spec_psr7_bridge.md).
+
+### 5. The authenticity chain anchors at a signed monorepo tag
+
+The split repository's tags are created by automation holding a `GITHUB_TOKEN`, so they cannot be
+maintainer-signed — and per ADR-0032, no signing key ever reaches a runner. The chain is instead:
+the maintainer signs `utils-psr7-bridge-vX.Y.Z` **here**; the pipeline verifies that signature via
+GitHub's own verification (ADR-0032's mechanism, reused) before splitting; the split tag is a
+derived build artifact of a verified source. The split repository asserts nothing on its own — the
+assertion lives where the signature is.
+
+### 6. What Milestone 8 contains
+
+This ADR decides; it does not implement. A new ROADMAP milestone carries the implementation:
+
+- **8.1** — scaffold `packages/utils-psr7-bridge/` per the boundary spec, and the self-enabling
+  monorepo CI job (guarded on the package's `composer.json` existing, lesson L-0010's shape).
+- **8.2** — the converters and the full contract suite (`T-B`), every clause of
+  `02_spec_psr7_bridge.md` §4–§5 tested against **two** PSR-17 implementations, with the planted-
+  defect verification discipline this project already holds tests to.
+- **8.3** — the publication pipeline: split, tag translation, signed-source verification, release-
+  mode gate, the read-only split repository and the Packagist registration (the last two are
+  one-time maintainer actions, documented as such).
+
+The CI job is deliberately **not** added now: a job that skips for the months until 8.1 lands is
+noise, and unlike the scaffold-generated benchmark job (which had to self-enable because the
+workflow could not be edited later), `ci.yml` is ordinary authored code that 8.1 can extend.
+
+## Alternatives Considered
+
+- **An authored second repository** — the strongest rival, and stronger after the EADOS correction
+  removed a phantom cost. Rejected on the remaining axes: cross-repository compatibility testing
+  discovers a contract-breaking core change only after it merges here; two contribution flows and
+  two review surfaces for one team; and the operational overhead of a second authored repository
+  buys independence the bridge does not want — its whole purpose is to track the core closely.
+- **A second EADOS run to create that repository** (RFC A-8's parenthetical) — rejected as a
+  category error, per the maintainer's correction: EADOS is an external generation tool, not
+  governance to be duplicated. Whatever generates code, its output is reviewed as ordinary source in
+  the canonical repository; the tool, its state, credentials and caches stay outside both
+  repositories.
+- **Building `toPsr7()`/`fromPsr7()` into the core** behind `interface_exists()` guards — rejected:
+  it contradicts imported ADR-002 (the bridge is a separate optional package) and NFR-08 (no
+  implementation dependencies in the core), and would put PSR types in the core's public signatures
+  where PHPStan-level consumers would meet them without the interfaces installed.
+- **Sharing the core's tags** (bridge published at every `vX.Y.Z`) — rejected explicitly rather than
+  by omission, because it is the *default outcome* of a monorepo if versioning is not designed: the
+  bridge's version would then communicate core events, not bridge API changes. The maintainer's
+  instruction was precise on this — independent versioning is part of the decision, not an option
+  within it.
+- **Deferring the decision** — rejected: item 7.4 *is* the decision, and RFC A-8 already deferred it
+  once, to plan. A second deferral leaves Milestone 8 unplannable.
+
+## Consequences
+
+- No code lands with this ADR. The deliverable is this decision plus
+  [`02_spec_psr7_bridge.md`](../specs/02_spec_psr7_bridge.md) — the package boundary, the
+  independent-versioning scheme, the publication pipeline contract, ADR-002's conversion contract as
+  numbered, testable clauses (BFR-01…BFR-22), and the CI design for both test modes.
+- **Milestone 8** (items 8.1–8.3) is added to the ROADMAP; the README milestone table gains its row.
+- The Spec Coverage Map's §7 row **reopens** (✅ → 🚧, gaining 8.2): the frozen spec's §6 names
+  *"bridge conversion-fidelity contract tests in egl/utils-psr7-bridge CI"*, and those tests do not
+  exist yet. Marking §7 done at 6.3 was correct for the suites that had components to land with;
+  with the bridge milestone now real, leaving the row closed would hide named, unfinished spec work.
+  §8 gains 8.3 (the publication pipeline is release engineering) and stays 🚧.
+- Imported ADR-002's literal naming — `Request::toPsr7()` — is realized as bridge-owned converters
+  instead, because PHP has no partial classes and the core cannot carry methods whose signatures
+  name PSR types without violating NFR-08. The deviation and its API shape are recorded in the
+  contract's §3, not silently.
+- The two fidelity traps that make the contract more than ceremony are specified with refusal
+  semantics carried over from ADR-0025: a PSR-7 response bearing **multiple `Set-Cookie` headers**
+  is refused rather than comma-joined (RFC 6265 cookie strings contain commas; joining corrupts
+  them), and uploaded files cross the `$_FILES`-array ↔ `UploadedFileInterface`-stream boundary with
+  error codes preserved and **no stream access on a failed upload**.
+
+## References
+
+- Imported ADR-002 — the bridge's existence, optionality, and contract-test obligation
+- RFC-0001 A-8 — the deferral this closes; R-1/R-3 — placement and the dependency-policy correction
+- The maintainer's decision record (2026-08-05): canonical monorepo source, generated read-only
+  split, package-scoped tags translated at publication, decision-not-implementation scope — and the
+  EADOS scoping correction incorporated above
+- Packagist/Composer VCS repository resolution (root `composer.json`) — the fact that reframed A-8

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,3 +48,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0030](0030-same-runner-ab-because-a-stored-baseline-cannot-carry-a-10-percent-gate.md) | A same-runner A/B, because a stored baseline cannot carry NFR-06's 10% gate — and all three deferred budgets are met | Accepted |
 | [0031](0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md) | Run the BC checker outside this package's dependency graph, gate breaks by the bump, and settle the deprecation window | Accepted |
 | [0032](0032-verify-the-tag-before-drafting-and-let-packagist-pull.md) | Verify the tag before a draft exists, ask GitHub about the signature, and let Packagist pull | Accepted |
+| [0033](0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md) | The bridge's source lives in this monorepo; a generated, read-only split repository is only its publication target | Accepted |

--- a/docs/journal/2026/08/2026-08-05-bridge-packaging.md
+++ b/docs/journal/2026/08/2026-08-05-bridge-packaging.md
@@ -1,0 +1,114 @@
+# 2026-08-05 — The question under the question
+
+Roadmap item **7.4**, the last one. Route `frontier-reasoning / extra`, protected floor — and for
+the first time on a frontier-routed item, **run at the routed tier**: the maintainer switched the
+session to Fable 5 rather than accepting a sixth mismatch. Worth noticing what that implies about
+the five acceptances before it. The precedent was never "the floor doesn't matter"; it was a
+per-item cost call, and on the item whose entire deliverable is a decision, the floor got honoured.
+
+## The reframing that dissolved the roadmap's wording
+
+A-8 asked: subtree vs second repository. But Packagist resolves a package from a repository whose
+`composer.json` sits at the **root** — a directory inside this repo cannot be a Packagist package,
+which is why split tooling exists. So a second repository exists under *every* option, and the
+question that was actually open is whether it is **authored** or **generated**.
+
+Once asked that way, the options stop being symmetrical. An authored second repo buys independence
+the bridge does not want — its whole purpose is to track the core closely — and pays for it with
+cross-repository failure discovery: a core change that breaks the conversion contract merges here
+green and fails *there*, later. A generated split repo keeps the failure in the PR that causes it.
+
+## The correction that made the analysis better and the answer the same
+
+I had counted "a second copy of the governance we built in 7.1–7.3" as a cost of the authored
+option. The maintainer struck it: **EADOS is an external code-generation tool, not repository
+governance** — not committed, not runtime infrastructure, and duplicating a generation tool is not
+an architectural cost of a second repository. What remains is the honest four-axis comparison:
+authored-repo count, same-PR vs cross-repo integration, one review flow vs two, generated
+publication vs duplicated maintenance.
+
+The topology survived its best argument being deleted — the maintainer chose the monorepo anyway,
+on the remaining axes. But the episode is the recordable part: my analysis recommended the right
+option partly for a wrong reason, and a decision that wins with a phantom cost on the ledger is a
+decision that can be relitigated the day someone notices the phantom. Now it can't be.
+
+## Independent versioning is a design act, not a default
+
+The maintainer's instruction was precise: the bridge must not inherit the core's tags
+*accidentally*. That word is doing work. In a monorepo, shared versioning is what happens when
+nobody decides — every `vX.Y.Z` tag would publish a "new" bridge whose version communicates core
+events, not bridge API changes.
+
+So: `utils-psr7-bridge-vX.Y.Z` in the monorepo, translated to `vX.Y.Z` on the split repo. Signed at
+the source; the pipeline verifies the signature (ADR-0032's GitHub-side check, reused — still no key
+material on any runner) before splitting, so the split repo's unsigned tags are derived artifacts of
+a verified assertion rather than assertions themselves.
+
+One glob to respect: `release.yml` triggers on `v*.*.*`, and GitHub's filter patterns match the
+whole ref name, so `utils-psr7-bridge-v0.1.0` — starting with `u` — should not match. *Should*:
+that is documented behavior, not probed behavior, because probing it means pushing a tag. It is the
+one assumption in this decision I could not discharge from a working tree, so item 8.3 verifies it
+with a real tag before the first publication. Named, not waved at.
+
+## The flip side of the same-PR guarantee
+
+The monorepo's strongest property — contract tests run against the working tree via an injected
+path repository — has a shadow: the bridge's committed `composer.json` claims compatibility with
+**released** core versions, and working-tree evidence cannot support that claim. Twenty green PRs
+against HEAD say nothing about `^0.7` as a consumer resolves it.
+
+So the publication pipeline runs the suite twice: PR mode (path repo, working tree) on every PR,
+and **release mode** (clean install, released core from Packagist) before any bridge tag ships.
+The injected repository lives only in the CI workspace — a committed `repositories` entry pointing
+outside the package would break every standalone install of the split package, which is the kind of
+defect that is invisible in the monorepo and fatal outside it.
+
+## Writing the contract found the two real traps
+
+Turning imported ADR-002's one line — "conversion fidelity (headers, uploaded files, immutability
+boundaries)" — into twenty-two testable clauses forced the corner cases out:
+
+- **Multiple `Set-Cookie` headers cannot be comma-joined.** PSR-7's own `getHeaderLine()` reduction
+  is correct for every header except this one: RFC 6265 cookie strings contain commas
+  (`Expires=Wed, 21 Oct…`), so the join that is right everywhere else silently corrupts cookies.
+  The core's header projection is single-valued, so a multi-`Set-Cookie` response is **refused** —
+  ADR-0025's refuse-don't-coerce, crossing the bridge intact. A naive implementation passes every
+  other test while mangling this; that is exactly the clause contract tests exist for.
+- **Uploaded files cross a representation boundary.** `$_FILES`-shaped arrays on one side,
+  `UploadedFileInterface` streams on the other. The contract pins error codes verbatim, byte
+  identity through the round-trip, and — the easy one to get wrong — **no stream access when
+  `error !== UPLOAD_ERR_OK`**, because PSR-7 permits `getStream()` to throw on a failed upload and
+  there is nothing valid to read anyway.
+
+Also recorded as a deviation rather than smoothed over: imported ADR-002 wrote `Request::toPsr7()`,
+and PHP has no partial classes — core methods naming PSR types would put those interfaces in the
+core's requirements, which NFR-08 forbids. The bridge owns the converters; the factories arrive at
+construction, injected, never discovered.
+
+## Housekeeping that is honest rather than tidy
+
+The Spec Coverage Map's §7 row **reopens** (✅ → 🚧, gaining 8.2). The frozen spec names *"bridge
+conversion-fidelity contract tests in egl/utils-psr7-bridge CI"*, and with Milestone 8 now real,
+a closed row would hide named, unfinished spec work. Closing it at 6.3 was right for what existed
+then; keeping it closed now would not be. §8 gains 8.3 (the publication pipeline is release
+engineering) and stays open. §9 closes — 2.1, 5.3 and 7.4 were the decision-log items, and this was
+the last.
+
+## The roadmap is complete
+
+With 7.4 merged, every planned item from the 2026-08-03 negotiation is done: 40 items, 7
+milestones, 33 ADRs, two frozen specs. What remains is not on the original map: Milestone 8 (the
+bridge build, 8.1–8.3), the post-M7 **1.0.0 API-freeze review** the versioning policy reserved, and
+the first actual release — `VERSION` is still `0.0.0`, no tag exists, and the release machinery
+from 7.2/7.3 waits unexercised for the maintainer to cut `v0.x`. The gates are built; the first
+release is the human's move, as designed.
+
+## Bar
+
+Docs-only change. 1299 tests / 2916 assertions green, PHPStan max clean, deptrac 0/0, consistency
+lint OK, 32 action pins verified upstream.
+
+## Next
+
+**8.1**, when the maintainer calls it — or the v0.7.0 release PR, or the 1.0.0 freeze review.
+The order of those three is a maintainer decision, not a roadmap fact.

--- a/docs/specs/02_spec_psr7_bridge.md
+++ b/docs/specs/02_spec_psr7_bridge.md
@@ -1,0 +1,221 @@
+# Package Specification: `egl/utils-psr7-bridge`
+
+> Commissioned by [ADR-0033](../adr/0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md)
+> (roadmap item 7.4) to carry imported [ADR-002](../../.specs/d4np_php_adr_002_http_psr7.md)'s
+> conversion-contract obligation. Frozen contract for Milestone 8, under the same amendment
+> discipline as [`01_spec_utils.md`](01_spec_utils.md): a diverging implementation updates this spec
+> in the same PR, with a revision entry and a rationale.
+
+**Revision r1** — 2026-08-05. See [Revision history](#revision-history).
+
+## 1. Scope & non-goals
+
+The bridge converts between this library's HTTP values (`D4np\Utils\Http\Request`, `Response`) and
+PSR-7 messages, in both directions, using consumer-supplied PSR-17 factories. It is the **only
+sanctioned crossing point** between the two vocabularies (imported ADR-002).
+
+Non-goals, restated from the decisions that set them:
+
+- **No middleware, routing, or emission.** The wrappers "must never grow middleware ambitions"
+  (imported ADR-002); `Response::send()` is never called by the bridge, and PSR-15 concerns belong
+  to the consumer's stack.
+- **No `Session`/`CsrfToken` conversion.** PSR-7 has no session concept; those classes do not cross.
+- **No streaming passthrough.** The bridge converts *values*: a PSR-7 body stream is read in full to
+  a string, and a string becomes a fresh stream. A message too large to hold in memory is outside
+  the lightweight tier this package serves (BFR-19 states the boundary).
+
+## 2. Package boundary
+
+Canonical source: **`packages/utils-psr7-bridge/`** in the `egl-util-php` repository. The directory
+is a complete Composer package:
+
+```
+packages/utils-psr7-bridge/
+├── composer.json            # name: egl/utils-psr7-bridge — no `repositories` entry, ever (§6)
+├── CHANGELOG.md             # the bridge's own, Keep a Changelog format
+├── README.md                # install, factory wiring, the two-vocabulary rationale
+├── phpstan.neon.dist        # max level, analysing this package with the core loaded
+└── src/
+    ├── main/php/d4np/utils/bridge/psr7/   # PSR-4: D4np\Utils\Bridge\Psr7\
+    └── test/php/d4np/utils/bridge/psr7/   # PSR-4 (dev): D4np\Utils\Bridge\Psr7\Tests\
+```
+
+The layout mirrors the monorepo's Maven-style convention (AGENTS.md §5) rather than inventing a
+second one. The namespace nests under `D4np\Utils\` deliberately — Composer resolves the longest
+PSR-4 prefix, so `D4np\Utils\Bridge\Psr7\` maps to this package while everything else under
+`D4np\Utils\` stays the core's; consumers read one vendor namespace.
+
+`composer.json` contract:
+
+| field | value | why |
+|---|---|---|
+| `name` | `egl/utils-psr7-bridge` | RFC-0001's naming mapping of imported ADR-002's `d4np/php-psr7-bridge` |
+| `require.php` | `>=8.1` | the core's floor; the bridge must not narrow it |
+| `require.egl/utils` | the released core line (e.g. `^0.7`) | proven in **release mode**, §6 — never `@dev` in the committed file |
+| `require.psr/http-message` | `^2.0` | the return-typed release; every maintained implementation supports it, and dual `^1.1 \|\| ^2.0` support doubles the matrix for no consumer this library targets |
+| `require.psr/http-factory` | `^1.0` | the factory interfaces the converter consumes |
+| `require-dev` | `nyholm/psr7`, `guzzlehttp/psr7`, phpunit, phpstan | the two reference implementations §7's matrix runs against |
+
+Dependency direction is one-way and mechanical: the bridge depends on the core's **public API**;
+the core never references the bridge (when 8.1 lands, the core's deptrac gains a rule making a
+core → `D4np\Utils\Bridge\` import a build failure, the same way `Support: ~` works today).
+
+## 3. API surface
+
+```php
+final class Psr7Bridge
+{
+    public function __construct(
+        ServerRequestFactoryInterface $serverRequestFactory,
+        ResponseFactoryInterface $responseFactory,
+        StreamFactoryInterface $streamFactory,
+        UploadedFileFactoryInterface $uploadedFileFactory,
+        UriFactoryInterface $uriFactory,
+    );
+
+    public function requestToPsr7(Request $request): ServerRequestInterface;
+    public function requestFromPsr7(ServerRequestInterface $message): Request;
+    public function responseToPsr7(Response $response): ResponseInterface;
+    public function responseFromPsr7(ResponseInterface $message): Response;
+}
+```
+
+**This is a recorded deviation from imported ADR-002's letter**, which wrote `Request::toPsr7()` /
+`Request::fromPsr7()`. PHP has no partial classes: methods on the core `Request` would live in the
+core package, and their signatures would name PSR interfaces the core must not require (NFR-08).
+The bridge therefore owns the converters; the factories arrive once, at construction — "using any
+PSR-17 factory" (imported ADR-002) means *injected*, never discovered or defaulted by the bridge.
+
+The core `Request` converts to **`ServerRequestInterface`** (not plain `RequestInterface`): it wraps
+superglobals, which is precisely PSR-7's server-side request.
+
+## 4. Conversion contract — requests
+
+Each clause is a testable obligation; §7 maps them to the suite. "Refused" always means a
+`D4np\Utils\Support\HttpException` naming what was seen — ADR-0025's refuse-don't-coerce semantics,
+crossing the bridge intact.
+
+### Core → PSR-7 (`requestToPsr7`)
+
+- **BFR-01** — the method is preserved case-exactly (PSR-7 treats method as case-sensitive).
+- **BFR-02** — the URI round-trips scheme, host, port, path and query; `isSecure()` ⇔ the produced
+  URI's scheme is `https`.
+- **BFR-03** — every header visible through `Request::headers()` appears on the message with its
+  value; the core is single-valued per name, so each becomes a one-element PSR-7 header list.
+- **BFR-04** — `getQueryParams()` equals the core's query projection, arrays included (what
+  `queryList()` sees survives as an array).
+- **BFR-05** — `getParsedBody()` equals the core's POST array.
+- **BFR-06** — `getCookieParams()` equals the core's cookie projection.
+- **BFR-07** — each file the core exposes becomes an `UploadedFileInterface` preserving size, error
+  code (`UPLOAD_ERR_*`, verbatim), client filename and client media type. The stream lazily wraps
+  `tmp_name`; **when `error !== UPLOAD_ERR_OK` the stream is never opened** — PSR-7 permits
+  `getStream()` to throw on a failed upload, and there is nothing valid to read.
+- **BFR-08** — **detachment**: mutating a superglobal after conversion does not change the produced
+  message. The conversion is a snapshot, not a view.
+
+### PSR-7 → core (`requestFromPsr7`)
+
+- **BFR-09** — multi-valued headers reduce by PSR-7's own `getHeaderLine()` semantics (comma-join);
+  the core's projection then shows that line. The reduction is the PSR-blessed one, not an
+  invention.
+- **BFR-10** — an **object** parsed body is refused: PSR-7 allows `array|object|null`, the core's
+  POST projection is an array, and no lossless array projection of an arbitrary object exists. A
+  `null` parsed body converts as an empty POST.
+- **BFR-11** — uploaded files: for `error === UPLOAD_ERR_OK` the stream is materialized once to a
+  private temporary path, byte-identical to the source; for any other error code the entry carries
+  the code with **no stream access attempted**. An upload tree whose values are not flat
+  `UploadedFileInterface` instances (PSR-7's nested normalization) is refused, naming the key —
+  the core's `file(string $key)` surface is flat, and silently flattening would invent structure.
+- **BFR-12** — query values pass through as-is; the *core's* typed accessors keep their own refusal
+  semantics (ADR-0025) on read. The bridge transports; it does not pre-coerce.
+- **BFR-08b** — detachment holds in this direction too: later `with*()` derivatives of the source
+  message do not affect the produced `Request`, and no stream is shared between them.
+
+## 5. Conversion contract — responses
+
+### Core → PSR-7 (`responseToPsr7`)
+
+- **BFR-13** — the status code is preserved; the reason phrase is the factory's default for that
+  code (the core carries none).
+- **BFR-14** — every core header appears on the message; single-valued per name, as in BFR-03.
+- **BFR-15** — the body string becomes a stream readable in full from offset 0.
+- **BFR-16** — conversion emits nothing: no headers are sent, `send()` is never invoked.
+
+### PSR-7 → core (`responseFromPsr7`)
+
+- **BFR-17** — the status code is preserved.
+- **BFR-18** — multi-valued headers reduce per `getHeaderLine()` — **except `Set-Cookie`**. A
+  message bearing **multiple** `Set-Cookie` headers is refused: RFC 6265 cookie strings contain
+  commas (`Expires=Wed, 21 Oct…`), so the comma-join that is correct for every other header
+  *corrupts* this one, and the core's single-valued header projection cannot carry the list. One
+  `Set-Cookie` header passes through unchanged. This is the contract's sharpest edge and exists
+  precisely because a naive implementation passes every other test while silently mangling cookies.
+- **BFR-19** — the body stream is read in full: rewound first when seekable, read to end when not.
+  The memory implication is accepted and stated (§1 non-goals): the bridge converts values.
+
+### Round-trips
+
+- **BFR-20** — core → PSR-7 → core preserves every core-observable projection of a `Request`.
+- **BFR-21** — the same for `Response`, for messages that do not hit a refusal clause.
+- **BFR-22** — an uploaded file's bytes survive the full round-trip identically.
+
+## 6. Versioning & publication
+
+- **Package-scoped tags** in the monorepo: `utils-psr7-bridge-vMAJOR.MINOR.PATCH`, starting at
+  `utils-psr7-bridge-v0.1.0`, annotated and **signed** like every release tag (ADR-0032).
+- The publication pipeline (item 8.3), on such a tag:
+  1. **verifies the tag's signature** via GitHub's verification — ADR-0032's mechanism, reused;
+  2. runs the contract suite in **release mode**: a clean install of the package with **no path
+     repository**, resolving `egl/utils` from Packagist exactly as a consumer would — because the
+     committed constraint is a claim about *released* core versions, and PR-mode evidence (working
+     tree) does not support it;
+  3. splits `packages/utils-psr7-bridge/` (e.g. `git subtree split`) and pushes to the split
+     repository with the translated tag `vMAJOR.MINOR.PATCH`.
+- The split repository is **read-only**: generated, no PRs, no authored commits; its README says so
+  and links here. Its tags are unsigned build artifacts of a verified signed source — the
+  authenticity assertion lives at the monorepo tag, per ADR-0033 §5.
+- The committed `composer.json` **never contains a `repositories` entry**: a path repository
+  pointing outside the package would break every standalone install of the split package. PR mode
+  injects it in the CI workspace only (§7).
+- Tag-grammar isolation: core `v*.*.*` workflows do not match `utils-psr7-bridge-v*` tags and vice
+  versa. Documented GitHub pattern semantics; **item 8.3 verifies with a real tag before the first
+  publication.**
+- One-time maintainer actions, mirroring `docs/workflow/release.md`'s prerequisites section: create
+  the split repository, register it on Packagist.
+
+## 7. Test strategy
+
+- Suite lives in the package (`src/test/...`), group **`T-B`**; the frozen core spec §6's *"bridge
+  conversion-fidelity contract tests in egl/utils-psr7-bridge CI"* resolves, under ADR-0033, to
+  **this repository's CI** — the split repository has none.
+- **Two-implementation matrix**: every clause runs against `nyholm/psr7` *and* `guzzlehttp/psr7`
+  factories. One implementation would let the contract silently encode that vendor's leniencies;
+  two is the cheapest diversity that catches it.
+- **Every BFR clause maps to at least one named test**, and lands with the planted-defect discipline
+  this project already holds: at implementation (8.2), each refusal and each fidelity clause is
+  probed by planting the defect it claims to catch — the comma-joined `Set-Cookie`, the stream read
+  on a failed upload, the shared stream that breaks BFR-08b — and observing the named test fail.
+- **PR mode** (the `bridge-contract` CI job, self-enabling on the package's `composer.json`
+  existing): inject the monorepo as a path repository in the CI workspace —
+  `composer config repositories.monorepo path ../../ && composer require egl/utils @dev --no-update`
+  — then install and run. Proves the working tree against the contract, which is the same-PR
+  guarantee ADR-0033 chose the monorepo for.
+- **Release mode** (pipeline-only, §6): no path repository; the released core. Both modes must pass
+  for a bridge tag to publish.
+- Static analysis: PHPStan max over the package in both modes; the core's deptrac gains the
+  no-core→bridge rule (8.1).
+
+## Settled-by-default
+
+Small choices settled here so 8.2 does not relitigate them: URI construction goes through the
+injected `UriFactoryInterface` from the core's `uri()` string; temporary files created by BFR-11 are
+owned by the produced `Request`'s process lifetime (no destructor magic — PHP's request model
+already reclaims them, and the bridge documents that CLI consumers clean up explicitly); no numeric
+performance budget is declared for conversion — if one is ever wanted it follows NFR-06's
+methodology rather than being invented here.
+
+## Revision history
+
+| Rev | Date | Change |
+|-----|------|--------|
+| r1 | 2026-08-05 | Commissioned by ADR-0033 (item 7.4): package boundary, independent versioning, publication pipeline, and imported ADR-002's conversion contract as BFR-01…BFR-22. |


### PR DESCRIPTION
Roadmap item **7.4** — the last one. Closes Milestone 7 and RFC-0001's A-8. **No code lands**: the deliverable is the decision, per your instruction. Run at the routed tier (`frontier-reasoning / extra`) after the model switch — first frontier-routed item with no mismatch to record.

## The question under the question

A-8 asked "subtree vs second repository". Packagist resolves a package from a repository whose `composer.json` sits at the **root**, so a second repository exists under *every* option — the open question was whether it is authored or **generated**. Asked that way, the options stop being symmetrical: an authored second repo buys independence the bridge does not want (its purpose is to track the core closely) and pays with cross-repo failure discovery. The generated split keeps a contract-breaking core change failing **in the PR that introduces it**.

## Your corrections, incorporated

- **EADOS struck from the ledger**: it is an external generation tool, not repository governance — "duplicating it" was a phantom cost in my analysis, and ADR-0033 records the correction rather than smoothing it over. The topology survives on the remaining axes: authored-repo count, same-PR vs cross-repo integration, one review flow vs two, generated publication vs duplicated maintenance.
- **Independent versioning by design, not inheritance**: `utils-psr7-bridge-vX.Y.Z` tags here translate to `vX.Y.Z` on the split repo. Signed at the source, verified (ADR-0032's mechanism, reused) before splitting — the split repo's tags are derived artifacts of a verified assertion.

## What lands

| deliverable | where |
|---|---|
| The decision + alternatives + consequences | **ADR-0033** |
| Package boundary (`packages/utils-psr7-bridge/`, own composer.json, `D4np\Utils\Bridge\Psr7\`, tests, static analysis, changelog) | **spec 02 §2–3** |
| Versioning & publication pipeline (signed source tag → verify → release-mode test → split → translated tag; read-only split repo) | **spec 02 §6** |
| ADR-002's conversion contract as testable clauses **BFR-01…BFR-22** | **spec 02 §4–5** |
| CI contract-test design: **two modes** (PR mode = path repo injected in CI workspace only, working tree; release mode = released core from Packagist before any bridge tag ships) + two-implementation matrix (nyholm + guzzle) | **spec 02 §7** |
| Future milestone: **M8** (8.1 scaffold + CI job, 8.2 converters + T-B suite, 8.3 publication pipeline) | ROADMAP + README |

Two contract edges worth your read, because a naive implementation passes everything else while getting them wrong: **multiple `Set-Cookie` headers are refused rather than comma-joined** (RFC 6265 cookie strings contain commas — PSR-7's own `getHeaderLine()` reduction corrupts exactly this one header), and **uploaded files never have their stream touched when `error !== UPLOAD_ERR_OK`**.

One recorded deviation: imported ADR-002 wrote `Request::toPsr7()`, and PHP has no partial classes — core methods naming PSR types would violate NFR-08. The bridge owns the converters; factories are injected at construction.

## Housekeeping, honest rather than tidy

The Spec Coverage Map's **§7 row reopens** (✅ → 🚧, gaining 8.2): the frozen spec names bridge contract tests that do not exist yet, and a closed row would hide named, unfinished work. §8 gains 8.3; §9 closes. M8 versions under the bridge's own tag line — the core's minor-per-milestone rule applies to milestones that change the core package, and the post-M7 **1.0.0 API-freeze review is unaffected**.

## ⚠️ Incident during this item — see the conversation

My first push of this branch accidentally included 1,502 files from an untracked local `.company-reserved/` directory (`git add -A` on a tree I hadn't checked). The branch was force-replaced within minutes and no ref reaches that commit; details and residual-risk note in the session. The commit on this PR is clean — 7 files, docs only.

## Bar

Docs-only. 1299 tests / 2916 assertions green, PHPStan max clean, deptrac 0/0, consistency lint OK (including milestone agreement over the new M8 section), 32 action pins verified upstream.

With this merge, **the negotiated roadmap is complete**: 40 items, 7 milestones, 33 ADRs, two frozen specs. `VERSION` is still `0.0.0` and no tag exists — the release machinery from 7.2/7.3 waits, by design, for you to cut `v0.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
