### PR TITLE
feat(bridge): scaffold the PSR-7 bridge package, its CI job and the layering rule

### DIFF
--- a/.eados-core/learning/runs/2026-08-05-utils-11.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils-11.yaml
@@ -1,0 +1,33 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,3 +454,100 @@ jobs:
           name: backward-compatibility-report
           path: bc-report.md
           if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # The PSR-7 bridge's contract suite, in **PR mode** (ADR-0033, spec 02 §7).
+  #
+  # This is the property the monorepo topology was chosen for: the bridge is tested against the
+  # core **in the working tree**, so a core change that breaks the conversion contract fails in the
+  # pull request that introduces it — not later, in another repository's CI, after it merged.
+  #
+  # The path repository is injected into the CI **workspace only**. Committing it would point the
+  # published package at `../../`, which exists nowhere outside this monorepo, and every standalone
+  # install would fail while nothing here noticed. `BridgePackageBoundaryTest` in the core suite
+  # asserts the committed manifest stays clean — verified: planting the injection fails 2 of its
+  # tests.
+  #
+  # Self-enabling on the package's composer.json (lesson L-0010): item 8.1 ships the scaffold with
+  # no converters and no contract suite, so until 8.2 lands there is nothing to run. The job says
+  # so in a notice rather than passing silently, because a skip and a pass look identical on a
+  # green tick.
+  # ---------------------------------------------------------------------------
+  bridge-contract:
+    name: quality / PSR-7 bridge contract
+    needs: bootstrap
+    if: needs.bootstrap.outputs.ready == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both PSR-17 implementations spec 02 §7 requires: one alone would let the contract
+        # silently encode that vendor's leniencies.
+        psr7: [nyholm, guzzle]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Does the bridge package have anything to run yet?
+        id: pkg
+        shell: bash
+        run: |
+          if [ ! -f packages/utils-psr7-bridge/composer.json ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Bridge package absent::packages/utils-psr7-bridge/composer.json does not exist, so there is nothing to test. This job enables itself when the package lands."
+            exit 0
+          fi
+          if [ -z "$(find packages/utils-psr7-bridge/src/test -name '*Test.php' -print -quit 2>/dev/null)" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Bridge contract suite pending::The package scaffold exists but carries no tests yet. The T-B conversion suite lands with roadmap item 8.2; this job runs it from then on."
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Set up PHP
+        if: steps.pkg.outputs.ready == 'true'
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          # The package's own floor. The bridge must not narrow the core's, and the core supports 8.1.
+          php-version: '8.1'
+          coverage: none
+
+      - name: Resolve the core from the working tree (workspace only — never committed)
+        if: steps.pkg.outputs.ready == 'true'
+        working-directory: packages/utils-psr7-bridge
+        run: |
+          composer config repositories.monorepo path ../../
+          composer require "egl/utils:@dev" --no-update --no-interaction
+          composer update --no-interaction --prefer-dist
+
+      - name: Prove the core really came from this checkout
+        if: steps.pkg.outputs.ready == 'true'
+        working-directory: packages/utils-psr7-bridge
+        shell: bash
+        run: |
+          # Without this, a resolution that quietly fell back to a published egl/utils would make
+          # the whole same-PR guarantee a fiction while every test still passed.
+          TYPE="$(php -r '$l=json_decode(file_get_contents("composer.lock"),true); foreach($l["packages"] as $p){ if($p["name"]==="egl/utils"){ echo $p["dist"]["type"] ?? ($p["source"]["type"] ?? "?"); } }')"
+          echo "egl/utils resolved as: $TYPE"
+          if [ "$TYPE" != "path" ]; then
+            echo "::error title=Core not from the working tree::egl/utils resolved as '$TYPE', not 'path'. The bridge would be tested against a published core instead of the code in this PR, which is the entire property ADR-0033 chose the monorepo for."
+            exit 1
+          fi
+
+      - name: Pin the PSR-17 implementation under test
+        if: steps.pkg.outputs.ready == 'true'
+        working-directory: packages/utils-psr7-bridge
+        run: |
+          composer remove --dev --no-interaction --no-update \
+            ${{ matrix.psr7 == 'nyholm' && 'guzzlehttp/psr7' || 'nyholm/psr7' }}
+          composer update --no-interaction --prefer-dist
+
+      - name: Contract suite (${{ matrix.psr7 }})
+        if: steps.pkg.outputs.ready == 'true'
+        working-directory: packages/utils-psr7-bridge
+        run: vendor/bin/phpunit
+
+      - name: PHPStan (max) over the package
+        if: steps.pkg.outputs.ready == 'true'
+        working-directory: packages/utils-psr7-bridge
+        run: vendor/bin/phpstan analyse --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,14 @@ __pycache__/
 /vendor/
 /.cargo/
 
+# Monorepo packages (ADR-0033). `/vendor/` above is root-anchored and does not reach these.
+# `composer.lock` is deliberately not committed for the packages: they are libraries, and CI's
+# PR mode rewrites the manifest in the workspace anyway (spec 02 §7).
+packages/*/vendor/
+packages/*/composer.lock
+packages/*/.phpunit.cache/
+packages/*/.phpstan.cache/
+
 # Coverage & test artifacts
 /coverage/
 *.gcda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`packages/utils-psr7-bridge/` scaffold** (roadmap item **8.1**, implementing ADR-0033 and
+  spec 02 §2) — a complete Composer package with its own manifest, PSR-4 roots
+  (`D4np\Utils\Bridge\Psr7\`), PHPStan configuration at max level, README and changelog. **No
+  converters yet**: they land with their contract suite in item 8.2, and a stub throwing
+  "not implemented" would be a worse artifact than an empty PSR-4 root.
+  A new **`quality / PSR-7 bridge contract`** CI job runs the package against the core **from the
+  working tree** via a path repository injected into the CI workspace only — the same-PR guarantee
+  ADR-0033 chose the monorepo for. It asserts `egl/utils` resolved with source type `path`, because
+  a quiet fallback to a published core would leave that guarantee a fiction with every test still
+  green. The job self-enables in two stages (absent package → notice; scaffold without tests →
+  notice; a test file appears → it runs), all three branches verified.
+  **`BridgePackageBoundaryTest` lives in the core's suite**, not the package's, because the
+  invariant with the sharpest consequence — no `repositories` entry in the committed manifest —
+  breaks only *standalone* installs of the published package, which nothing in this repository would
+  otherwise notice. Running PR mode locally mutates the manifest exactly that way; planting both
+  mutations fails two of its tests by name.
+  A **deptrac `Bridge` layer** makes a core → `D4np\Utils\Bridge\` dependency a build failure.
+  Verified, and instructively: an unused `use` statement produces **0 violations** — deptrac
+  resolves type dependencies, not imports — while a real type reference produces
+  `Response must not depend on Psr7Bridge`.
+  The package declares `egl/utils: ^0.7` against a core release that **does not exist yet**
+  (`VERSION` is `0.0.0`, no tag), so it is not installable standalone until the core ships `v0.7.0`.
+  That is a true statement of the dependency rather than a placeholder, and the package README says
+  so where someone would otherwise meet it as a resolution error.
+
 - **The PSR-7 bridge packaging decision** (**ADR-0033**, closing Milestone 7 and RFC-0001's A-8) —
   plus [`docs/specs/02_spec_psr7_bridge.md`](docs/specs/02_spec_psr7_bridge.md), the frozen contract
   Milestone 8 implements. **No code lands**: item 7.4's deliverable is the decision.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-05 — The question under the question](docs/journal/2026/08/2026-08-05-bridge-packaging.md).
+  [2026-08-05 — A rule that looked right and did nothing](docs/journal/2026/08/2026-08-05-bridge-scaffold.md).
 
 ## Model & effort routing (advisory)
 
@@ -506,11 +506,24 @@ the core's minor-per-milestone rule (AGENTS.md §11) applies to milestones that 
 package, and the core-side work here (a CI job, docs) is chore-level. The post-M7 `1.0.0`
 API-freeze review for the **core** is unaffected by this milestone.
 
-- [ ] 8.1 Scaffold `packages/utils-psr7-bridge/` per spec 02 §2 (composer.json, PSR-4, quality
+- [x] 8.1 Scaffold `packages/utils-psr7-bridge/` per spec 02 §2 (composer.json, PSR-4, quality
       bar, in-package changelog) + the self-enabling `bridge-contract` CI job (PR mode: path
       repository injected in the CI workspace only; guard on the package's composer.json existing,
       lesson L-0010) + the core deptrac rule that a core → `D4np\Utils\Bridge\` import is a build
-      failure — route: standard / medium
+      failure — route: standard / medium *(session model matched the route)*. *Worked in an
+      isolated `git worktree`, since this checkout is shared with parallel sessions. **The deptrac
+      rule fired on nothing at first:** an unused `use D4np\Utils\Bridge\…` produced **0
+      violations** — deptrac resolves *type dependencies*, not imports — and only a real type
+      reference triggers `Response must not depend on Psr7Bridge`. Third verification this session
+      that itself needed verifying. **`^0.7` is declared against a core release that does not
+      exist** (`VERSION` is `0.0.0`, no tag), so a standalone install genuinely cannot resolve
+      today — kept, because it is true and a weaker constraint would be resolvable and wrong; the
+      README says so. PR mode verified end to end: `egl/utils` resolves with source type **`path`**
+      from the working tree, and the CI job now asserts that type, since a quiet fallback to a
+      published core would make the same-PR guarantee a fiction with every test still green.
+      Running PR mode locally **mutated the committed manifest** exactly as spec §6 forbids, so the
+      boundary invariants are asserted from the **core's** suite (runs on every PR, not only when
+      the package's job does) — planting the mutations fails two by name.*
 - [ ] 8.2 `Psr7Bridge` converters + the full **T-B** contract suite: every clause of spec 02
       §4–§5 (BFR-01…BFR-22) tested against **two** PSR-17 implementations (nyholm/psr7,
       guzzlehttp/psr7), each refusal and fidelity clause probe-verified by planting the defect it

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -81,6 +81,20 @@ deptrac:
           # Doubled backslashes: a PCRE pattern, where a single `\L` would be a regex escape.
           value: ^Psr\\(Log|Container)\\.*
 
+    # The PSR-7 bridge (ADR-0033), whose source lives in `packages/utils-psr7-bridge/` and is
+    # therefore outside `paths` above — deptrac never analyses it. This layer exists to constrain
+    # the *other* direction: it is collected by class name so that a core file importing
+    # `D4np\Utils\Bridge\…` lands in a declared layer, and the empty ruleset entry below then makes
+    # that import a **violation** rather than an "uncovered dependency" nobody reads.
+    #
+    # The dependency direction is one-way by design: the bridge depends on the core's public API,
+    # and the core must never learn that the bridge exists — that is what keeps `psr/http-message`
+    # out of the core's requirements (NFR-08) and the bridge optional (imported ADR-002).
+    - name: Bridge
+      collectors:
+        - type: classLike
+          value: ^D4np\\Utils\\Bridge\\.*
+
     # `Version` sits at the namespace root, in no group — it is a single version constant. Given
     # its own layer rather than left uncollected so that "every production class belongs to a
     # declared layer" stays a fact this config states, rather than an assumption.
@@ -128,3 +142,9 @@ deptrac:
     # A vendored dependency is a leaf here: this repository does not constrain its internals.
     HtmlSanitizer: ~
     Psr: ~
+
+    # No group may reach the bridge. Absent from every ruleset above AND declared empty here, so a
+    # core -> Bridge import is a violation from both directions of deptrac's bookkeeping. This is
+    # the same shape as `Support: ~`, and load-bearing for the same reason: it is what makes the
+    # bridge's optionality a build property rather than a promise in an ADR.
+    Bridge: ~

--- a/docs/journal/2026/08/2026-08-05-bridge-scaffold.md
+++ b/docs/journal/2026/08/2026-08-05-bridge-scaffold.md
@@ -1,0 +1,102 @@
+# 2026-08-05 — A rule that looked right and did nothing
+
+Roadmap item **8.1**, opening Milestone 8. Route `standard / medium` → Opus 5, the session model.
+No mismatch.
+
+First item worked in an **isolated `git worktree`**, per the operational note another session
+recorded: this checkout is shared with parallel sessions, and item 7.4's leak began with untracked
+material appearing in a tree I then staged blind. A worktree cut from `origin/master` cannot
+inherit that.
+
+## The deptrac rule fired on nothing
+
+The item's third deliverable is "a core → `D4np\Utils\Bridge\` import is a build failure". I added
+a `Bridge` layer collected by class name, granted it to nobody, and declared `Bridge: ~`. It read
+correctly against the `Support: ~` precedent it was modelled on.
+
+Then I planted the import:
+
+```php
+use D4np\Utils\Bridge\Psr7\Psr7Bridge;
+```
+
+**0 violations.** The rule did nothing.
+
+deptrac resolves *type dependencies*, not `use` statements — an import nothing references is not a
+dependency, which is defensible and is not what I had assumed. Planting a real reference instead:
+
+```php
+public function probePlant(\D4np\Utils\Bridge\Psr7\Psr7Bridge $bridge): void
+```
+
+```
+DependsOnDisallowedLayer   D4np\Utils\Http\Response must not depend on D4np\Utils\Bridge\Psr7\Psr7Bridge
+Violations  1
+```
+
+The rule is correct. My first probe was not, and had I stopped at it I would have concluded the
+opposite — either "the rule is broken, rewrite it" or, worse, "unused imports are fine, ship it".
+That is the third time this session a verification has needed verifying, after item 7.1's `| tail`
+exit codes and 7.3's `git diff master HEAD` on a checkout where `HEAD` *was* master.
+
+## `^0.7` against a release that does not exist
+
+Spec 02 §2 says the bridge requires "the released core line (e.g. `^0.7`)", never `@dev`. The core
+has **no release**: `VERSION` is `0.0.0` and there is no tag. So a standalone install of this
+package cannot resolve, today, by construction — I checked rather than assuming:
+
+```
+composer update --dry-run
+  → Root composer.json requires egl/utils ^0.7, it could not be found in any version
+```
+
+I kept `^0.7` anyway, because it is *true*: the bridge does require a released core, and the package
+genuinely is not installable until the core ships `v0.7.0` — which is also when item 8.3 first
+publishes it. A weaker constraint would have made the manifest resolvable and wrong. The README says
+so plainly rather than leaving someone to discover it at `composer require`.
+
+PR mode is unaffected and was verified end to end: inject a path repository, relax the constraint in
+the workspace, resolve. 36 packages installed, `egl/utils` resolved with source type **`path`** at
+`dev-worktree-bridge-scaffold-8.1` — the working tree, which is the entire property ADR-0033 chose
+the monorepo for. The CI job asserts that source type explicitly, because a quiet fallback to a
+published core would leave the same-PR guarantee a fiction with every test still green.
+
+## The invariant that breaks something nobody here would see
+
+Running PR mode locally **mutated the committed manifest** — composer wrote `egl/utils: "@dev"` and
+a `repositories` block into it. Exactly what spec §6 forbids committing, arrived at by simply
+following the spec's own CI recipe.
+
+That is the shape of the risk: the injection is correct in the workspace and catastrophic in the
+repository. A committed path repository pointing at `../../` resolves perfectly inside the monorepo
+and nowhere else, so every standalone `composer require egl/utils-psr7-bridge` would fail while
+nothing in this repository noticed.
+
+So the boundary assertions live in the **core's** suite, not the package's: the package's tests run
+only when its job runs, and this invariant needs checking on every PR from today. Planting the two
+mutations fails two of them by name.
+
+## What 8.1 deliberately does not ship
+
+No converters, and no contract suite — those are 8.2, and a stub `Psr7Bridge` throwing "not
+implemented" would be a worse artifact than an empty PSR-4 root. The CI job self-enables in two
+stages accordingly: absent package → notice; scaffold present but no `*Test.php` → notice; a test
+file appears → it runs. All three branches exercised locally.
+
+`composer.lock` is not committed for the package. It is a library, and PR mode rewrites the manifest
+in the workspace anyway; the root `.gitignore`'s `/vendor/` is root-anchored and would not have
+covered `packages/*/vendor/`, so those rules are added explicitly.
+
+## Bar
+
+1306 tests / 2955 assertions green (up from 1299). PHPStan max clean — it caught every
+`json_decode()` result being `mixed` in the new test, which is fair and now narrowed once in a
+helper rather than cast at seven call sites. deptrac 0/0, PHP-CS-Fixer clean, consistency lint OK,
+34 action pins verified upstream.
+
+## Next
+
+**8.2** — the converters and the T-B contract suite: BFR-01…BFR-22 against both `nyholm/psr7` and
+`guzzlehttp/psr7`, each refusal probe-verified by planting the defect it claims to catch. The two
+clauses worth the most care are already written down: the multi-`Set-Cookie` refusal, and never
+touching a failed upload's stream.

--- a/packages/utils-psr7-bridge/CHANGELOG.md
+++ b/packages/utils-psr7-bridge/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — `egl/utils-psr7-bridge`
+
+All notable changes to this package, following
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) and
+[Semantic Versioning 2.0.0](https://semver.org/).
+
+**This package versions independently of `egl/utils`** (ADR-0033 §3). Its releases are cut from
+package-scoped tags in the monorepo — `utils-psr7-bridge-vMAJOR.MINOR.PATCH` — which the publication
+pipeline translates into plain `vMAJOR.MINOR.PATCH` tags on the generated split repository. A core
+release does not imply a bridge release, or the reverse.
+
+## [Unreleased]
+
+### Added
+
+- Package scaffold (roadmap item **8.1**): `composer.json`, PSR-4 roots, PHPStan configuration at
+  max level, this changelog and the package README — the boundary specified by
+  [`docs/specs/02_spec_psr7_bridge.md`](../../docs/specs/02_spec_psr7_bridge.md) §2.
+  No converters yet: they land with their contract suite in item **8.2**, and publication in **8.3**.

--- a/packages/utils-psr7-bridge/README.md
+++ b/packages/utils-psr7-bridge/README.md
@@ -1,0 +1,81 @@
+# egl/utils-psr7-bridge
+
+Bidirectional conversion between [`egl/utils`](https://github.com/danielPoloWork/egl-util-php)'
+HTTP values (`D4np\Utils\Http\Request`, `Response`) and PSR-7 messages, using any PSR-17 factory.
+
+> **Status: scaffold.** Roadmap item 8.1 laid down this package; the converters and their contract
+> suite land in **8.2**, and publication to Packagist in **8.3**. The package is not yet installable
+> standalone — see [Installing](#installing).
+
+## Why this package exists
+
+`egl/utils` ships `Request`/`Response` as typed, security-defaulted facades over superglobals, with
+**no HTTP dependencies** — the target audience includes framework-less and legacy PHP applications
+where superglobals are the reality (imported ADR-002).
+
+PSR-7 plus PSR-15 middleware is how interoperable PHP HTTP code is written. Rather than force
+stream semantics on someone who wants `$request->postString('email')`, or maintain a second PSR-7
+implementation, the two vocabularies meet **here and only here**: this bridge is the sanctioned
+crossing point, and the core never depends on it.
+
+## Installing
+
+```bash
+composer require egl/utils-psr7-bridge
+```
+
+**Not yet possible.** This package requires `egl/utils: ^0.7`, and the core has not cut its first
+release — `VERSION` is still `0.0.0` with no tag. That is a true statement of the dependency, not a
+placeholder: the package becomes installable when the core publishes `v0.7.0`, which is also when
+item 8.3 first publishes this one. Until then it is developed and tested inside the monorepo, where
+CI resolves the core from the working tree (spec 02 §7).
+
+You also need a PSR-17 factory implementation — any of them:
+
+```bash
+composer require nyholm/psr7        # or guzzlehttp/psr7, or your framework's
+```
+
+## Usage
+
+The converters arrive in item 8.2. The shape is fixed by
+[`docs/specs/02_spec_psr7_bridge.md`](../../docs/specs/02_spec_psr7_bridge.md) §3: factories are
+**injected once at construction** — the bridge never discovers or defaults one — and the four
+conversions are `requestToPsr7`, `requestFromPsr7`, `responseToPsr7`, `responseFromPsr7`.
+
+Note the deviation from imported ADR-002's literal `Request::toPsr7()`: PHP has no partial classes,
+so methods on the core `Request` would put PSR interfaces in the *core's* signatures and
+requirements, which its dependency policy (NFR-08) forbids. The bridge owns the converters.
+
+## Conversion contract
+
+Fidelity is specified as numbered, testable clauses — **BFR-01…BFR-22** in
+[spec 02 §4–§5](../../docs/specs/02_spec_psr7_bridge.md) — and each is tested against **two**
+PSR-17 implementations, because one would silently encode that vendor's leniencies.
+
+Two clauses are worth knowing before you use the bridge, because both are places where a
+reasonable-looking implementation is wrong:
+
+- **A response bearing multiple `Set-Cookie` headers is refused, not comma-joined.** PSR-7's own
+  `getHeaderLine()` reduction is correct for every other header and corrupts this one: RFC 6265
+  cookie strings contain commas (`Expires=Wed, 21 Oct …`), so joining them produces something no
+  client can parse back. The core's header projection is single-valued, so the bridge refuses
+  rather than mangling.
+- **A failed upload's stream is never opened.** Where `error !== UPLOAD_ERR_OK`, the error code is
+  preserved verbatim and no read is attempted — PSR-7 permits `getStream()` to throw there, and
+  there is nothing valid to read anyway.
+
+Refusals throw `D4np\Utils\Support\HttpException` naming what was seen, carrying the core's
+refuse-don't-coerce semantics (ADR-0025) across the boundary unchanged.
+
+## Development
+
+This package's canonical source lives in the `egl-util-php` **monorepo** under
+`packages/utils-psr7-bridge/` (**ADR-0033**). If you are reading this in the standalone
+`egl/utils-psr7-bridge` repository, that repository is **generated and read-only**: it exists as
+the Packagist publication target and accepts no commits or pull requests. Contribute in the
+monorepo.
+
+## Licence
+
+MIT, as the core.

--- a/packages/utils-psr7-bridge/composer.json
+++ b/packages/utils-psr7-bridge/composer.json
@@ -1,0 +1,49 @@
+{
+    "name": "egl/utils-psr7-bridge",
+    "description": "Bidirectional conversion between egl/utils HTTP values and PSR-7 messages, using any PSR-17 factory",
+    "license": "MIT",
+    "type": "library",
+    "keywords": [
+        "psr-7",
+        "psr-17",
+        "bridge",
+        "http",
+        "interop"
+    ],
+    "authors": [
+        {
+            "name": "Daniel Polo"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "egl/utils": "^0.7",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^2.0"
+    },
+    "require-dev": {
+        "guzzlehttp/psr7": "^2.6",
+        "nyholm/psr7": "^1.8",
+        "phpstan/phpstan": "^2.2",
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "D4np\\Utils\\Bridge\\Psr7\\": "src/main/php/d4np/utils/bridge/psr7/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "D4np\\Utils\\Bridge\\Psr7\\Tests\\": "src/test/php/d4np/utils/bridge/psr7/"
+        }
+    },
+    "config": {
+        "platform": {
+            "php": "8.1.34"
+        },
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/packages/utils-psr7-bridge/phpstan.neon.dist
+++ b/packages/utils-psr7-bridge/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+    level: max
+    paths:
+        - src/main/php/d4np/utils/bridge/psr7
+        - src/test/php/d4np/utils/bridge/psr7
+    tmpDir: .phpstan.cache
+    treatPhpDocTypesAsCertain: false
+    # Analysed against this package's own vendor/, which contains the core (from the monorepo path
+    # repository in PR mode, or the released tag in release mode — spec 02 §7). Both modes therefore
+    # type-check the bridge against the exact core it will run with, rather than against a copy.

--- a/packages/utils-psr7-bridge/src/main/php/d4np/utils/bridge/psr7/.gitkeep
+++ b/packages/utils-psr7-bridge/src/main/php/d4np/utils/bridge/psr7/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder so git tracks this PSR-4 root before roadmap item 8.2 lands the converters.

--- a/packages/utils-psr7-bridge/src/test/php/d4np/utils/bridge/psr7/.gitkeep
+++ b/packages/utils-psr7-bridge/src/test/php/d4np/utils/bridge/psr7/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder so git tracks this PSR-4 test root before roadmap item 8.2 lands the T-B suite.

--- a/src/test/php/d4np/utils/BridgePackageBoundaryTest.php
+++ b/src/test/php/d4np/utils/BridgePackageBoundaryTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `packages/utils-psr7-bridge/` boundary, asserted from the core's suite (ADR-0033, spec 02 §2).
+ *
+ * **Why these live here rather than in the package's own suite.** The package's tests run only when
+ * its CI job runs, and the invariant with the sharpest consequence — no `repositories` entry in the
+ * committed manifest — breaks something nobody in this repository would ever see: a *standalone*
+ * install of the published split package. A path repository pointing at `../../` resolves perfectly
+ * inside the monorepo and is unresolvable everywhere else. So it is checked on every PR, from the
+ * core suite, which always runs.
+ *
+ * These are file assertions, not imports: the core must never depend on the bridge, and deptrac's
+ * `Bridge` layer makes that a build failure (verified — planting a real type reference produces
+ * `Response must not depend on Psr7Bridge`).
+ */
+final class BridgePackageBoundaryTest extends TestCase
+{
+    private const PACKAGE = 'packages/utils-psr7-bridge';
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function manifest(): array
+    {
+        $path = self::path('composer.json');
+        self::assertFileExists($path, 'the bridge package manifest is missing');
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    private static function path(string $relative): string
+    {
+        return dirname(__DIR__, 5) . '/' . self::PACKAGE . '/' . $relative;
+    }
+
+    /**
+     * The core's manifest, for the comparisons that only mean something against it.
+     *
+     * @return array<string, mixed>
+     */
+    private static function coreManifest(): array
+    {
+        $decoded = json_decode(
+            (string) file_get_contents(dirname(__DIR__, 5) . '/composer.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * One top-level section of a manifest, narrowed to an array.
+     *
+     * Decoded JSON is `mixed` all the way down, and PHPStan at max is right to insist: a manifest
+     * whose `require` is not an array is a manifest this test cannot reason about, and asserting
+     * that once here beats casting at every call site.
+     *
+     * @param array<string, mixed> $manifest
+     *
+     * @return array<string, mixed>
+     */
+    private static function section(array $manifest, string $key): array
+    {
+        $value = $manifest[$key] ?? null;
+        self::assertIsArray($value, "the manifest's `{$key}` section is missing or not an object");
+
+        /** @var array<string, mixed> $value */
+        return $value;
+    }
+
+    /**
+     * **The one that protects consumers.** Spec 02 §6: the committed manifest never carries a
+     * `repositories` entry. CI's PR mode injects a path repository into the *workspace* so the
+     * contract suite runs against the working tree — and if that injection were ever committed, the
+     * published package would point at `../../`, which exists only inside this monorepo. Every
+     * standalone `composer require egl/utils-psr7-bridge` would fail, and nothing in this
+     * repository would notice.
+     */
+    public function testTheCommittedManifestHasNoRepositoriesEntry(): void
+    {
+        self::assertArrayNotHasKey(
+            'repositories',
+            self::manifest(),
+            'a committed `repositories` entry breaks every standalone install of the published '
+            . 'package while resolving fine inside the monorepo — see spec 02 §6',
+        );
+    }
+
+    /**
+     * The core is required by a released constraint, never `@dev`. `@dev` in the committed file
+     * would publish a package pinned to a moving target.
+     */
+    public function testTheCoreIsRequiredByAReleasedConstraint(): void
+    {
+        $require = self::section(self::manifest(), 'require');
+        self::assertArrayHasKey('egl/utils', $require, 'the bridge must declare its core dependency');
+
+        $constraint = $require['egl/utils'];
+        self::assertIsString($constraint);
+        self::assertStringNotContainsString('@dev', $constraint, 'spec 02 §2: never `@dev` committed');
+        self::assertStringNotContainsString('dev-', $constraint);
+    }
+
+    /**
+     * The bridge must not narrow the core's runtime floor: a consumer on PHP 8.1 can use the core,
+     * so they can use the bridge.
+     */
+    public function testTheBridgeDoesNotNarrowTheCoresPhpFloor(): void
+    {
+        $bridge = self::section(self::manifest(), 'require');
+        $core = self::section(self::coreManifest(), 'require');
+
+        self::assertSame($core['php'] ?? null, $bridge['php'] ?? null, 'the floors must agree');
+    }
+
+    /**
+     * PSR-7 and PSR-17 are the bridge's dependencies and must never appear in the core's — that is
+     * NFR-08's "no third-party implementation dependencies in the core", and the entire reason the
+     * bridge is a separate package (imported ADR-002).
+     */
+    public function testThePsrHttpDependenciesBelongToTheBridgeAndNotTheCore(): void
+    {
+        $bridge = self::section(self::manifest(), 'require');
+        self::assertArrayHasKey('psr/http-message', $bridge);
+        self::assertArrayHasKey('psr/http-factory', $bridge);
+
+        $core = self::section(self::coreManifest(), 'require');
+        self::assertArrayNotHasKey('psr/http-message', $core);
+        self::assertArrayNotHasKey('psr/http-factory', $core);
+    }
+
+    /**
+     * The namespace nests under `D4np\Utils\` so consumers read one vendor namespace; Composer
+     * resolves the longest PSR-4 prefix, so this maps to the package and everything else under
+     * `D4np\Utils\` stays the core's.
+     */
+    public function testThePsr4RootsMatchTheSpecifiedLayout(): void
+    {
+        $manifest = self::manifest();
+
+        self::assertSame(
+            ['D4np\\Utils\\Bridge\\Psr7\\' => 'src/main/php/d4np/utils/bridge/psr7/'],
+            self::section($manifest, 'autoload')['psr-4'] ?? null,
+        );
+        self::assertSame(
+            ['D4np\\Utils\\Bridge\\Psr7\\Tests\\' => 'src/test/php/d4np/utils/bridge/psr7/'],
+            self::section($manifest, 'autoload-dev')['psr-4'] ?? null,
+        );
+
+        self::assertDirectoryExists(self::path('src/main/php/d4np/utils/bridge/psr7'));
+        self::assertDirectoryExists(self::path('src/test/php/d4np/utils/bridge/psr7'));
+    }
+
+    /**
+     * The scaffold ships the quality bar and the package's own changelog — the boundary spec 02 §2
+     * calls "a complete Composer package", not a directory with a manifest in it.
+     */
+    public function testTheScaffoldIsACompletePackage(): void
+    {
+        self::assertFileExists(self::path('README.md'));
+        self::assertFileExists(self::path('CHANGELOG.md'));
+        self::assertFileExists(self::path('phpstan.neon.dist'));
+    }
+
+    /**
+     * The package name is the one RFC-0001 mapped imported ADR-002's `d4np/php-psr7-bridge` to, and
+     * the one item 8.3 will register on Packagist. A rename after publication is a new package.
+     */
+    public function testThePackageIsNamedAsPublished(): void
+    {
+        self::assertSame('egl/utils-psr7-bridge', self::manifest()['name'] ?? null);
+    }
+}


### PR DESCRIPTION
Roadmap item **8.1**, opening Milestone 8 and implementing ADR-0033.

Worked in an isolated `git worktree` — this checkout is shared with parallel sessions, and item 7.4's leak began with untracked material appearing in a tree I then staged blind.

## A rule that looked right and did nothing

The item's third deliverable is "a core → `D4np\Utils\Bridge\` import is a build failure". I added a `Bridge` layer, granted it to nobody, declared `Bridge: ~` — correct against the `Support: ~` precedent it was modelled on. Then planted the import:

```php
use D4np\Utils\Bridge\Psr7\Psr7Bridge;
```
```
Violations  0
```

**deptrac resolves type dependencies, not `use` statements.** An import nothing references is not a dependency — defensible, and not what I assumed. With a real reference:

```
DependsOnDisallowedLayer  D4np\Utils\Http\Response must not depend on D4np\Utils\Bridge\Psr7\Psr7Bridge
```

The rule is correct; my first probe was not. Stopping there gives either "the rule is broken, rewrite it" or "unused imports are fine, ship it". Third verification this session that itself needed verifying, after 7.1's `| tail` exit codes and 7.3's `git diff master HEAD` where `HEAD` *was* `master`.

## `^0.7` against a release that does not exist

Spec 02 §2 requires a released constraint, never `@dev`. **The core has no release** — `VERSION` is `0.0.0`, no tag — so a standalone install cannot resolve today. Verified:

```
Root composer.json requires egl/utils ^0.7, it could not be found in any version
```

Kept anyway, because it is *true*: the bridge does require a released core, and the package is genuinely not installable until `v0.7.0` — which is also when 8.3 first publishes it. A weaker constraint would be resolvable and wrong. The package README says so where someone would otherwise meet it as a resolution error.

**PR mode verified end to end**: path repository injected, constraint relaxed in the workspace, 36 packages installed, `egl/utils` resolved with source type **`path`**. The CI job asserts that source type, because a quiet fallback to a published core would leave the same-PR guarantee a fiction with every test still green.

## The invariant that breaks something nobody here would see

Running PR mode locally **mutated the committed manifest** — composer wrote `egl/utils: "@dev"` and a `repositories` block into it, exactly what spec §6 forbids committing, arrived at by following the spec's own CI recipe.

That is the risk's shape: correct in the workspace, catastrophic in the repository. A committed path repository pointing at `../../` resolves perfectly inside the monorepo and nowhere else. So `BridgePackageBoundaryTest` lives in the **core's** suite, which runs on every PR rather than only when the package's job does. Planting both mutations fails two of its tests by name.

## What 8.1 deliberately does not ship

No converters, no contract suite — those are 8.2, and a stub `Psr7Bridge` throwing "not implemented" would be a worse artifact than an empty PSR-4 root. The CI job self-enables in two stages (absent package → notice; scaffold without tests → notice; a test appears → it runs); all three branches exercised locally.

## Bar

1306 tests / 2955 assertions green (was 1299). PHPStan max clean — it caught every `json_decode()` result being `mixed` in the new test, fair, now narrowed once in a helper rather than cast at seven call sites. deptrac 0/0, PHP-CS-Fixer clean, consistency lint OK, 34 action pins verified upstream.

**Expect `quality / PSR-7 bridge contract` to skip** on this PR with a "contract suite pending" notice — correct, since 8.1 ships no tests for it to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
