### PR TITLE
feat(bridge): Psr7Bridge converters and the T-B contract suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`Request::queryAll()`, `postAll()`, `cookieAll()` and `uploadedFiles()`** (**ADR-0034**) —
+  whole-collection readers, added because roadmap item 8.2 found spec 02's BFR-04…BFR-07 were not
+  implementable: every core collection reader was key-scoped, only `headers()` returned a whole
+  collection, and a POST body and `$_FILES` were recoverable from nothing else the class exposed.
+  Purely additive, so **no BC break**.
+  **This is not a retreat from ADR-0025.** That rule governs *scalar* reads — `queryString('email')`
+  refuses an array because `(string) ['x']` yields the literal `"Array"`, a value nobody sent. A
+  whole-collection reader promises no conversion and so cannot convert wrongly; the typed accessors
+  keep refusing, unchanged, and a test asserts both behaviours side by side. `headers()` and
+  `file()` already returned raw collections from this class.
+  Each returns a **copy** — PHP arrays are values — so no caller receives mutable access to a
+  request's state. `serverAll()` was deliberately *not* added: nothing in the bridge contract needs
+  it, and everything the core reads from `$_SERVER` is already reachable through `method()`,
+  `uri()`, `isSecure()` and `headers()`.
+
 - **`packages/utils-psr7-bridge/` scaffold** (roadmap item **8.1**, implementing ADR-0033 and
   spec 02 §2) — a complete Composer package with its own manifest, PSR-4 roots
   (`D4np\Utils\Bridge\Psr7\`), PHPStan configuration at max level, README and changelog. **No

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-05 — A rule that looked right and did nothing](docs/journal/2026/08/2026-08-05-bridge-scaffold.md).
+  [2026-08-05 — The contract that could not be implemented](docs/journal/2026/08/2026-08-05-bridge-converters.md).
 
 ## Model & effort routing (advisory)
 
@@ -524,11 +524,24 @@ API-freeze review for the **core** is unaffected by this milestone.
       Running PR mode locally **mutated the committed manifest** exactly as spec §6 forbids, so the
       boundary invariants are asserted from the **core's** suite (runs on every PR, not only when
       the package's job does) — planting the mutations fails two by name.*
-- [ ] 8.2 `Psr7Bridge` converters + the full **T-B** contract suite: every clause of spec 02
+- [x] 8.2 `Psr7Bridge` converters + the full **T-B** contract suite: every clause of spec 02
       §4–§5 (BFR-01…BFR-22) tested against **two** PSR-17 implementations (nyholm/psr7,
       guzzlehttp/psr7), each refusal and fidelity clause probe-verified by planting the defect it
       claims to catch (severity:high — the conversion contract is the package's entire value) —
-      route: standard / high
+      route: standard / high *(session model matched the route)* · **ADR-0034**, **spec 02 r2**.
+      *Blocked at the first line: **BFR-04…BFR-07 were not implementable**. Every core collection
+      reader was key-scoped (`queryString($k)`, `postList($k)`, `cookie($k)`, `file($k)`) and only
+      `headers()` returned a whole collection — POST and `$_FILES` recoverable from nothing else,
+      and re-parsing `uri()`/the `Cookie` header would have introduced a second parsing path beside
+      PHP's own. Put to the maintainer with four alternatives; they chose to widen the core, so
+      `Request` gained `queryAll()`, `postAll()`, `cookieAll()`, `uploadedFiles()` (**ADR-0034**,
+      additive, no BC break, and not a retreat from ADR-0025 — that rule governs **scalar** reads,
+      and a whole-collection reader promises no conversion so it cannot convert wrongly). 65 tests /
+      202 assertions across both implementations. **Five defects planted, all caught on both
+      vendors:** the `Set-Cookie` refusal removed (2 failures), a failed upload's stream opened (2
+      errors), an object parsed body accepted (2), a nested upload tree accepted (2), the body
+      rewind dropped (2). Spec 02 → r2: BFR-07's "lazily wraps `tmp_name`" corrected, since
+      eagerness is the PSR-17 factory's business and neither vendor defers.*
 - [ ] 8.3 Publication pipeline per spec 02 §6: signed-source-tag verification (ADR-0032 reused),
       **release-mode** contract run against the released core, `git subtree split` + translated
       tag push to the read-only split repository; verify the `v*.*.*` / `utils-psr7-bridge-v*`

--- a/docs/adr/0034-whole-collection-readers-on-request.md
+++ b/docs/adr/0034-whole-collection-readers-on-request.md
@@ -1,0 +1,120 @@
+# ADR-0034: Whole-collection readers on `Request`, because a key-scoped reader cannot enumerate
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Deciders:** maintainer (`@danielPoloWork`, who chose this option over three alternatives), agent
+  acting as tech-lead
+- **Related:** ROADMAP item 8.2 · spec FR-13 ·
+  [`docs/specs/02_spec_psr7_bridge.md`](../specs/02_spec_psr7_bridge.md) §3–§4 (the BFR clauses this
+  unblocks) · [ADR-0025](0025-typed-http-wrappers-that-refuse-rather-than-coerce.md) (the
+  refuse-don't-coerce rule this does **not** retreat from) ·
+  [ADR-0033](0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md)
+  (the bridge whose implementation surfaced this) · imported
+  [ADR-002](../../.specs/d4np_php_adr_002_http_psr7.md)
+
+## Context
+
+Item 8.2 set out to implement `Psr7Bridge` against spec 02's contract and stopped immediately:
+**BFR-04, BFR-05, BFR-06 and BFR-07 are not implementable against the core's public API.**
+
+`Request` exposes fifteen public methods, and every collection reader among them is key-scoped:
+`queryString($key)`, `queryList($key)`, `postString($key)`, `postList($key)`, `cookie($key)`,
+`file($key)`. Only `headers()` returns a whole collection. There is no way to *enumerate* the query,
+POST, cookie or uploaded-file collections at all.
+
+Two of the four are not recoverable by any other route:
+
+| collection | recoverable otherwise? |
+|---|---|
+| query | partly — `uri()` carries the query string and could be re-parsed |
+| cookies | partly — the `Cookie` header could be re-parsed |
+| **POST** | **no** — `uri()` does not carry a body |
+| **`$_FILES`** | **no** — `file($key)` needs a key nobody can guess |
+
+And the two "partly"s are worse than they look: re-parsing would introduce a *second* parsing path
+beside the one PHP already ran, which is exactly the hand-rolling this project refuses elsewhere
+(ADR-0021 delegates rich-HTML sanitization for the same reason). A bridge that reconstructed `$_GET`
+from a URI string would silently disagree with the core's own view whenever a server rewrote a
+request.
+
+The maintainer was asked, with the alternatives, and chose to widen the core.
+
+## Decision
+
+`Request` gains four whole-collection readers, each returning its input raw and entire:
+
+```php
+public function queryAll(): array;
+public function postAll(): array;
+public function cookieAll(): array;
+public function uploadedFiles(): array;
+```
+
+### This is not a retreat from ADR-0025
+
+The obvious objection is that a class whose design is "refuse rather than coerce" now hands back
+`mixed` values. The two rules govern different questions.
+
+ADR-0025 is about **scalar** reads. `queryString('email')` refuses an array because a caller asking
+for *one string* has been handed something else, and `(string) ['x']` yields the literal `"Array"` —
+a value nobody sent, indistinguishable from one somebody did. That is a coercion, and it is what
+gets refused.
+
+A whole-collection reader makes no such promise and cannot mislead in that way: a caller asking for
+the entire collection is asking for exactly what arrived, values of every shape included. Nothing is
+converted, so there is nothing to convert *wrongly*. The typed accessors keep refusing, unchanged —
+a test asserts both behaviours side by side so the contrast is stated where someone would otherwise
+read the raw reader as a loophole.
+
+The shape is also not new: `headers()` already returned a whole collection and `file()` already
+returned a raw `$_FILES` entry, both from the same class, both since item 6.1.
+
+### Copies, not views
+
+PHP arrays are values, so each reader hands back a copy and no caller receives mutable access to a
+request's state. This is what makes the bridge's detachment clause (BFR-08) true by construction
+rather than by discipline.
+
+### `uploadedFiles()`, not `filesAll()`
+
+The odd name out, deliberately: there is no `file*()` typed accessor for it to be the "all" version
+*of*, because an uploaded-file abstraction is precisely what RFC-0001 declined to re-implement. The
+name says what it returns rather than implying a family that does not exist.
+
+### No `serverAll()`
+
+Not added, though `$_SERVER` is the fifth constructor argument. Nothing in spec 02's contract needs
+it: PSR-7's `getServerParams()` is not among the core-observable projections BFR-20 round-trips, and
+everything the core reads out of `$_SERVER` is already exposed through `method()`, `uri()`,
+`isSecure()` and `headers()`. Adding it would widen the public surface for no consumer — the API is
+widened by exactly what the blocked clauses required and no further.
+
+## Alternatives Considered
+
+- **One export method** (`Request::toArrays(): array{query,post,server,files,cookies}`) — rejected
+  by the maintainer: a core method existing *for* the bridge is a coupling smell even where it
+  creates no dependency, and it is less useful to ordinary consumers than named readers. Iterating
+  POST keys or logging every query parameter are things a consumer wants without a bridge in sight.
+- **The bridge takes the arrays alongside the `Request`** — rejected: a caller holds a `Request`
+  precisely so they need not handle superglobals, and an omitted argument would mean a silently
+  empty POST. Easy to use wrongly is the failure mode this library exists to avoid.
+- **Reflection over the private properties** — rejected outright: it breaks encapsulation from
+  outside the package and would bind the bridge to the core's field names, which are not public API.
+- **Dropping `requestToPsr7()` and shipping a one-way bridge** — rejected: imported ADR-002 promises
+  bidirectional conversion, and a one-way bridge is a materially smaller product than the one
+  decided.
+
+## Consequences
+
+- Four additive methods on `Request`. **No BC break** — nothing is removed or changed — so this
+  needs no MAJOR under the policy ADR-0031 settled, and lands inside the pre-1.0 line as an
+  addition.
+- Spec 02 §3 gains a note that the bridge depends on these; the clauses themselves are unchanged,
+  because the contract was always right about *what* should convert — only about what the core
+  already exposed.
+- `RequestWholeCollectionTest` pins the parts worth pinning: raw values pass through uncoerced while
+  the typed accessors still refuse; the returned array is a copy; integer keys survive (`?0=zero`
+  produces one, the same fact that made PHPStan reject an `array<string, mixed>` superglobal type at
+  item 6.1).
+- The blocked clauses are now implemented and tested: BFR-04, BFR-05, BFR-06 and BFR-07 pass against
+  both `nyholm/psr7` and `guzzlehttp/psr7`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,3 +49,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0031](0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md) | Run the BC checker outside this package's dependency graph, gate breaks by the bump, and settle the deprecation window | Accepted |
 | [0032](0032-verify-the-tag-before-drafting-and-let-packagist-pull.md) | Verify the tag before a draft exists, ask GitHub about the signature, and let Packagist pull | Accepted |
 | [0033](0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md) | The bridge's source lives in this monorepo; a generated, read-only split repository is only its publication target | Accepted |
+| [0034](0034-whole-collection-readers-on-request.md) | Whole-collection readers on `Request`, because a key-scoped reader cannot enumerate | Accepted |

--- a/docs/journal/2026/08/2026-08-05-bridge-converters.md
+++ b/docs/journal/2026/08/2026-08-05-bridge-converters.md
@@ -1,0 +1,108 @@
+# 2026-08-05 — The contract that could not be implemented
+
+Roadmap item **8.2**. Route `standard / high` → Opus 5, the session model. No mismatch. Isolated
+worktree again.
+
+## Blocked at the first line
+
+I wrote spec 02's conversion contract myself, at item 7.4, and it was wrong in a way that only
+showed when someone tried to implement it. `requestToPsr7()` needs the whole `$_GET`, `$_POST`,
+`$_COOKIE` and `$_FILES` collections. The core exposes **none** of them:
+
+```
+queryString($key)  queryInt($key)  queryBool($key)  queryList($key)
+postString($key)   postInt($key)   postBool($key)   postList($key)
+cookie($key)       file($key)
+```
+
+Every collection reader is key-scoped. Only `headers()` returns a whole collection. There is no way
+to *enumerate* anything.
+
+Two of the four were partly recoverable — the query string is in `uri()`, cookies are in the
+`Cookie` header — and that route was worse than it looked: it would have introduced a **second
+parsing path** beside the one PHP already ran, disagreeing with the core's own view the moment a
+server rewrote a request. This project delegates rather than hand-rolls for exactly that reason
+(ADR-0021). POST and `$_FILES` were not recoverable at all.
+
+So the item stopped and went to the maintainer with four options. They chose to widen the core:
+`queryAll()`, `postAll()`, `cookieAll()`, `uploadedFiles()` — **ADR-0034**.
+
+The objection worth answering in that ADR is that a class built on "refuse rather than coerce" now
+returns `mixed` values. It does not conflict: ADR-0025 governs **scalar** reads, where
+`(string) ['x']` yields the literal `"Array"` — a value nobody sent. A whole-collection reader
+promises no conversion, so there is nothing for it to convert wrongly. A test asserts both side by
+side, because otherwise the raw reader reads like a loophole in the rule rather than a different
+question.
+
+Worth noting what the process got right: writing the contract before the implementation is what
+*found* this, three items early, as a design question with alternatives instead of a hack discovered
+mid-conversion.
+
+## Five planted defects, all caught, on both vendors
+
+The suite exists for clauses a plausible implementation gets wrong. So each was planted:
+
+| planted | failures |
+|---|---|
+| the `Set-Cookie` multi-header refusal removed | 2 (nyholm + guzzle) |
+| a failed upload's stream opened | 2 errors |
+| an object parsed body accepted | 2 |
+| a nested upload tree accepted | 2 |
+| the body rewind dropped | 2 |
+
+Two of those deserve their own note.
+
+**BFR-18, the `Set-Cookie` join.** PSR-7's `getHeaderLine()` comma-joins, and that is correct for
+every header except this one: RFC 6265 cookie strings contain commas themselves
+(`Expires=Wed, 21 Oct 2026 …`), so joining two produces a string no client can split back. The core
+holds one value per header name and cannot carry the list, so the bridge refuses. Removing the check
+breaks exactly one test and nothing else — which is the point: a naive implementation passes
+everything else while silently corrupting cookies.
+
+**BFR-11's failed upload.** Both vendors' `UploadedFile::getStream()` *throws* when the error code is
+not `UPLOAD_ERR_OK`. So the assertion is inverted and sharp: if the bridge touched that stream the
+test would error, and it does — planting the access produced 2 errors rather than 2 failures.
+
+## What the boundary test caught, which was me
+
+Developing needed the package's dependencies, so I ran the PR-mode recipe locally. It rewrote the
+committed manifest — `egl/utils: "@dev"` plus a `repositories` block — and the full core suite then
+failed on **`BridgePackageBoundaryTest`**, the two assertions item 8.1 wrote for precisely this.
+
+That is the invariant working on its author, one item after it was written, catching the exact
+mutation predicted. `git checkout -- packages/utils-psr7-bridge/composer.json` and it was clean
+again — but without those tests it would have been committed, and the published package would have
+pointed at `../../` for every standalone consumer while everything here stayed green.
+
+## Two corrections to my own spec
+
+**BFR-07's wording.** r1 said the upload stream "lazily wraps" `tmp_name`. Whether a factory opens
+eagerly is the *implementation's* business and neither reference vendor defers, so the clause now
+states what the bridge actually controls: no stream over `tmp_name` is created at all for a failed
+upload.
+
+**No `serverAll()`.** I added exactly the four readers the blocked clauses needed and stopped. PSR-7
+server params are not among the core-observable projections BFR-20 round-trips, and everything the
+core reads out of `$_SERVER` is already reachable through `method()`, `uri()`, `isSecure()` and
+`headers()`. Widening an API by "while I'm here" is how a public surface grows past what anyone
+asked for.
+
+## The `\U` tax, fifth occurrence
+
+Python string literals containing `D4np\Utils\…` raise `SyntaxError: truncated \UXXXXXXXX escape`.
+This is the fifth time this session, and the second time I hit it *after* recording the lesson. The
+rule is simple and I keep reaching past it: **use the Edit tool for PHP, never Python string
+matching.** Recording it again, in the item where I finally started following it mid-task rather
+than after.
+
+## Bar
+
+Core: 1312 tests / 2973 assertions green. Package: 65 tests / 202 assertions across both PSR-17
+implementations. PHPStan max clean in both trees, deptrac 0/0, PHP-CS-Fixer clean, consistency lint
+OK, 34 action pins verified upstream.
+
+## Next
+
+**8.3** — the publication pipeline: signed-source-tag verification, release-mode contract run
+against the released core, subtree split and translated tag. It needs a core release to exist, so
+its real first run waits on `v0.7.0`.

--- a/docs/specs/02_spec_psr7_bridge.md
+++ b/docs/specs/02_spec_psr7_bridge.md
@@ -6,7 +6,7 @@
 > discipline as [`01_spec_utils.md`](01_spec_utils.md): a diverging implementation updates this spec
 > in the same PR, with a revision entry and a rationale.
 
-**Revision r1** — 2026-08-05. See [Revision history](#revision-history).
+**Revision r2** — 2026-08-05. See [Revision history](#revision-history).
 
 ## 1. Scope & non-goals
 
@@ -89,6 +89,14 @@ PSR-17 factory" (imported ADR-002) means *injected*, never discovered or default
 The core `Request` converts to **`ServerRequestInterface`** (not plain `RequestInterface`): it wraps
 superglobals, which is precisely PSR-7's server-side request.
 
+**Core API this depends on (added by [ADR-0034](../adr/0034-whole-collection-readers-on-request.md)).**
+When item 8.2 implemented these clauses, four of them turned out not to be implementable: the core's
+collection readers were all key-scoped, so a whole query, POST, cookie or uploaded-file collection
+could not be *enumerated* at all. POST and `$_FILES` were recoverable from nothing else the class
+exposed. `Request` therefore gained `queryAll()`, `postAll()`, `cookieAll()` and `uploadedFiles()` —
+additively, with no BC break, and without weakening the typed accessors' refusal semantics, which
+govern *scalar* reads and are untouched.
+
 ## 4. Conversion contract — requests
 
 Each clause is a testable obligation; §7 maps them to the suite. "Refused" always means a
@@ -107,9 +115,12 @@ crossing the bridge intact.
 - **BFR-05** — `getParsedBody()` equals the core's POST array.
 - **BFR-06** — `getCookieParams()` equals the core's cookie projection.
 - **BFR-07** — each file the core exposes becomes an `UploadedFileInterface` preserving size, error
-  code (`UPLOAD_ERR_*`, verbatim), client filename and client media type. The stream lazily wraps
-  `tmp_name`; **when `error !== UPLOAD_ERR_OK` the stream is never opened** — PSR-7 permits
-  `getStream()` to throw on a failed upload, and there is nothing valid to read.
+  code (`UPLOAD_ERR_*`, verbatim), client filename and client media type. The stream is created from
+  `tmp_name` through the injected `StreamFactoryInterface`; **when `error !== UPLOAD_ERR_OK` no
+  stream over `tmp_name` is created at all** — PSR-7 permits `getStream()` to throw on a failed
+  upload, and there is nothing valid to read. (r1 said the stream "lazily wraps" `tmp_name`;
+  whether a factory opens eagerly is the implementation's business and neither vendor defers, so the
+  clause states what the bridge controls.)
 - **BFR-08** — **detachment**: mutating a superglobal after conversion does not change the produced
   message. The conversion is a snapshot, not a view.
 
@@ -219,3 +230,4 @@ methodology rather than being invented here.
 | Rev | Date | Change |
 |-----|------|--------|
 | r1 | 2026-08-05 | Commissioned by ADR-0033 (item 7.4): package boundary, independent versioning, publication pipeline, and imported ADR-002's conversion contract as BFR-01…BFR-22. |
+| r2 | 2026-08-05 | Item 8.2, from implementing it. §3 records the four whole-collection readers `Request` gained (ADR-0034) — without them BFR-04–07 were not implementable, since every core collection reader was key-scoped and POST and `$_FILES` were recoverable from nothing else. BFR-07's wording corrected: r1 said the upload stream "lazily wraps" `tmp_name`, but eagerness is the PSR-17 factory's business and neither reference implementation defers, so the clause now states what the bridge controls — that no stream over `tmp_name` is created at all for a failed upload. |

--- a/packages/utils-psr7-bridge/CHANGELOG.md
+++ b/packages/utils-psr7-bridge/CHANGELOG.md
@@ -13,7 +13,22 @@ release does not imply a bridge release, or the reverse.
 
 ### Added
 
+- **`Psr7Bridge`** (roadmap item **8.2**) — bidirectional conversion between the core's HTTP values
+  and PSR-7 messages: `requestToPsr7()`, `requestFromPsr7()`, `responseToPsr7()`,
+  `responseFromPsr7()`. PSR-17 factories are **injected at construction**, never discovered or
+  defaulted.
+  The full **T-B** contract suite implements spec 02 §4–§5 (**BFR-01…BFR-22**) and runs against
+  **both** `nyholm/psr7` and `guzzlehttp/psr7` — 65 tests, 202 assertions. Each refusal and fidelity
+  clause was probe-verified by planting the defect it claims to catch; all five plants failed on
+  both implementations.
+  Two clauses carry the weight, and both refuse rather than corrupt:
+  a response bearing **multiple `Set-Cookie` headers** is refused, because PSR-7's own comma-joining
+  reduction — right for every other header — produces a string no client can split back, cookie
+  values containing commas of their own; and a **failed upload's stream is never touched**, its
+  error code preserved verbatim, since PSR-7 permits `getStream()` to throw there.
+  Requires the core's whole-collection readers (`queryAll()` and friends), added in the same change
+  by ADR-0034.
 - Package scaffold (roadmap item **8.1**): `composer.json`, PSR-4 roots, PHPStan configuration at
   max level, this changelog and the package README — the boundary specified by
   [`docs/specs/02_spec_psr7_bridge.md`](../../docs/specs/02_spec_psr7_bridge.md) §2.
-  No converters yet: they land with their contract suite in item **8.2**, and publication in **8.3**.
+  Publication to Packagist lands in item **8.3**.

--- a/packages/utils-psr7-bridge/phpunit.xml.dist
+++ b/packages/utils-psr7-bridge/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnWarning="true"
+         failOnRisky="true"
+         failOnDeprecation="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="contract">
+            <directory>src/test/php/d4np/utils/bridge/psr7</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src/main/php/d4np/utils/bridge/psr7</directory>
+        </include>
+    </source>
+</phpunit>

--- a/packages/utils-psr7-bridge/src/main/php/d4np/utils/bridge/psr7/Psr7Bridge.php
+++ b/packages/utils-psr7-bridge/src/main/php/d4np/utils/bridge/psr7/Psr7Bridge.php
@@ -1,0 +1,366 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bridge\Psr7;
+
+use D4np\Utils\Http\Request;
+use D4np\Utils\Http\Response;
+use D4np\Utils\Support\HttpException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Message\UriFactoryInterface;
+
+/**
+ * Conversion between `egl/utils` HTTP values and PSR-7 messages (spec 02, imported ADR-002).
+ *
+ * The only sanctioned crossing point between the two vocabularies. The core keeps no PSR-7
+ * dependency and never learns this class exists — deptrac's `Bridge` layer makes a core import a
+ * build failure (ADR-0033).
+ *
+ * **Factories are injected, never discovered.** "Using any PSR-17 factory" means the consumer's:
+ * this class does not guess at an implementation, fall back to one, or ship a default.
+ *
+ * **It converts values, not streams.** A PSR-7 body is read in full to a string and a string
+ * becomes a fresh stream — the lightweight tier this package serves has no streaming ambitions
+ * (spec 02 §1). A message too large to hold in memory belongs to a PSR-15 stack, not here.
+ *
+ * Every refusal throws {@see HttpException} naming what was seen, carrying ADR-0025's
+ * refuse-don't-coerce semantics across the boundary unchanged.
+ */
+final class Psr7Bridge
+{
+    public function __construct(
+        private readonly ServerRequestFactoryInterface $serverRequestFactory,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly UploadedFileFactoryInterface $uploadedFileFactory,
+        private readonly UriFactoryInterface $uriFactory,
+    ) {
+    }
+
+    // ---- requests --------------------------------------------------------------------------------
+
+    /**
+     * A core request as a PSR-7 server request (BFR-01…BFR-08).
+     *
+     * @throws HttpException if an uploaded-file entry is malformed
+     */
+    public function requestToPsr7(Request $request): ServerRequestInterface
+    {
+        $message = $this->serverRequestFactory
+            ->createServerRequest($request->method(), $this->uriOf($request))
+            ->withQueryParams(self::stringKeyed($request->queryAll()))
+            ->withParsedBody($request->postAll())
+            ->withCookieParams(self::stringKeyed($request->cookieAll()))
+            ->withUploadedFiles($this->uploadedFilesOf($request));
+
+        foreach ($request->headers() as $name => $value) {
+            $message = $message->withHeader($name, $value);
+        }
+
+        return $message;
+    }
+
+    /**
+     * A PSR-7 server request as a core request (BFR-09…BFR-12).
+     *
+     * @throws HttpException if the parsed body is an object, or an uploaded-file tree is nested
+     */
+    public function requestFromPsr7(ServerRequestInterface $message): Request
+    {
+        $parsed = $message->getParsedBody();
+
+        // BFR-10. PSR-7 permits `array|object|null`; the core's POST projection is an array, and no
+        // lossless array projection of an arbitrary object exists — `get_object_vars()` would drop
+        // everything non-public and silently succeed.
+        if (is_object($parsed)) {
+            throw new HttpException(sprintf(
+                'Cannot convert a PSR-7 request whose parsed body is an object (%s). The core\'s '
+                . 'POST projection is an array, and projecting an arbitrary object into one loses '
+                . 'whatever is not public. Call withParsedBody() with an array first, deciding for '
+                . 'yourself what the array should contain.',
+                $parsed::class,
+            ));
+        }
+
+        return new Request(
+            query: $message->getQueryParams(),
+            post: is_array($parsed) ? $parsed : [],
+            server: $this->serverParamsOf($message),
+            files: $this->filesArrayOf($message),
+            cookies: $message->getCookieParams(),
+        );
+    }
+
+    // ---- responses -------------------------------------------------------------------------------
+
+    /**
+     * A core response as a PSR-7 response (BFR-13…BFR-16).
+     *
+     * Emits nothing: `Response::send()` is never called, and no header reaches PHP.
+     */
+    public function responseToPsr7(Response $response): ResponseInterface
+    {
+        $message = $this->responseFactory
+            ->createResponse($response->status())
+            ->withBody($this->streamFactory->createStream($response->body()));
+
+        foreach ($response->headers() as $name => $value) {
+            $message = $message->withHeader($name, $value);
+        }
+
+        return $message;
+    }
+
+    /**
+     * A PSR-7 response as a core response (BFR-17…BFR-19).
+     *
+     * @throws HttpException if the message carries more than one `Set-Cookie` header
+     */
+    public function responseFromPsr7(ResponseInterface $message): Response
+    {
+        $response = Response::create($message->getStatusCode(), self::readFully($message->getBody()));
+
+        foreach (array_keys($message->getHeaders()) as $name) {
+            $name = (string) $name;
+
+            // BFR-18, the contract's sharpest edge. `getHeaderLine()` comma-joins, which is right
+            // for every header except this one: RFC 6265 cookie strings contain commas of their own
+            // (`Expires=Wed, 21 Oct 2026 07:28:00 GMT`), so joining two Set-Cookie values produces
+            // a string no client can split back into the cookies that were sent. The core's header
+            // projection is single-valued and cannot carry the list, so this refuses rather than
+            // silently corrupting the one header where the join is wrong.
+            if (strtolower($name) === 'set-cookie' && count($message->getHeader($name)) > 1) {
+                throw new HttpException(sprintf(
+                    'Cannot convert a PSR-7 response carrying %d Set-Cookie headers. Comma-joining '
+                    . 'them — correct for every other header — corrupts them, because cookie '
+                    . 'strings contain commas themselves; and the core response holds one value per '
+                    . 'header name, so the list cannot survive. Send the cookies through your PSR-7 '
+                    . 'stack, or set a single Set-Cookie before converting.',
+                    count($message->getHeader($name)),
+                ));
+            }
+
+            $response = $response->withHeader($name, $message->getHeaderLine($name));
+        }
+
+        return $response;
+    }
+
+    // ---- request helpers -------------------------------------------------------------------------
+
+    /**
+     * The absolute URI for a core request.
+     *
+     * The core reports the request *target* (`REQUEST_URI` — path and query) plus a `Host` header
+     * and a secure flag; PSR-7 wants a URI object. Assembling them here is the whole of the
+     * translation, and the `Host` header is used verbatim because it already carries a port when
+     * there is one.
+     */
+    private function uriOf(Request $request): \Psr\Http\Message\UriInterface
+    {
+        $scheme = $request->isSecure() ? 'https' : 'http';
+        $host = $request->header('host') ?? '';
+        $target = $request->uri();
+
+        // With no Host header there is no authority to build, so the target stands alone: a
+        // relative-reference URI is what PSR-7 implementations accept for that case, and inventing
+        // `localhost` would put a hostname in the message that nobody sent.
+        $uri = $host === '' ? $target : $scheme . '://' . $host . $target;
+
+        return $this->uriFactory->createUri($uri);
+    }
+
+    /**
+     * `$_FILES` entries as `UploadedFileInterface` instances (BFR-07).
+     *
+     * @return array<string, UploadedFileInterface>
+     *
+     * @throws HttpException
+     */
+    private function uploadedFilesOf(Request $request): array
+    {
+        $files = [];
+
+        foreach ($request->uploadedFiles() as $key => $entry) {
+            if (!is_array($entry)) {
+                throw new HttpException(sprintf(
+                    'Uploaded-file entry "%s" is a %s, not the array PHP puts in $_FILES.',
+                    (string) $key,
+                    get_debug_type($entry),
+                ));
+            }
+
+            $error = is_int($entry['error'] ?? null) ? $entry['error'] : UPLOAD_ERR_NO_FILE;
+            $size = is_int($entry['size'] ?? null) ? $entry['size'] : null;
+            $tmpName = is_string($entry['tmp_name'] ?? null) ? $entry['tmp_name'] : '';
+
+            // BFR-07's second half: a failed upload has nothing valid to read, and PSR-7 permits
+            // getStream() to throw for one. Opening `tmp_name` here — which for a failed upload is
+            // usually '' — would turn a reportable error into an I/O failure at conversion time.
+            $stream = $error === UPLOAD_ERR_OK && $tmpName !== ''
+                ? $this->streamFactory->createStreamFromFile($tmpName, 'r')
+                : $this->streamFactory->createStream('');
+
+            $files[(string) $key] = $this->uploadedFileFactory->createUploadedFile(
+                $stream,
+                $size,
+                $error,
+                is_string($entry['name'] ?? null) ? $entry['name'] : null,
+                is_string($entry['type'] ?? null) ? $entry['type'] : null,
+            );
+        }
+
+        return $files;
+    }
+
+    /**
+     * PSR-7 uploaded files as a `$_FILES`-shaped array (BFR-11).
+     *
+     * @return array<string, array<string, mixed>>
+     *
+     * @throws HttpException
+     */
+    private function filesArrayOf(ServerRequestInterface $message): array
+    {
+        $files = [];
+
+        foreach ($message->getUploadedFiles() as $key => $file) {
+            // PSR-7 permits a nested tree here (`getUploadedFiles()` mirrors the input names), and
+            // the core's `file(string $key)` surface is flat. Flattening would invent a key
+            // structure nobody sent, so a nested tree is refused by name.
+            if (!$file instanceof UploadedFileInterface) {
+                throw new HttpException(sprintf(
+                    'Uploaded file "%s" is a nested tree, and the core exposes uploads as a flat '
+                    . 'key => entry map. Flatten it yourself, choosing the key names, rather than '
+                    . 'having this bridge invent them.',
+                    (string) $key,
+                ));
+            }
+
+            $error = $file->getError();
+            $entry = [
+                'name' => $file->getClientFilename() ?? '',
+                'type' => $file->getClientMediaType() ?? '',
+                'size' => $file->getSize() ?? 0,
+                'error' => $error,
+                'tmp_name' => '',
+            ];
+
+            // BFR-11: materialize only a successful upload, and never touch the stream otherwise.
+            if ($error === UPLOAD_ERR_OK) {
+                $entry['tmp_name'] = self::materialize($file);
+            }
+
+            $files[(string) $key] = $entry;
+        }
+
+        return $files;
+    }
+
+    /**
+     * A `$_SERVER`-shaped array carrying everything the core reads back out of one.
+     *
+     * The inverse of `Request::headers()`'s derivation: `content-type` and `content-length` are the
+     * two CGI reports without an `HTTP_` prefix, and the core reads them from either spelling, so
+     * they are written unprefixed to match what a real SAPI would produce.
+     *
+     * @return array<string, mixed>
+     */
+    private function serverParamsOf(ServerRequestInterface $message): array
+    {
+        $uri = $message->getUri();
+        $target = $uri->getPath();
+
+        if ($uri->getQuery() !== '') {
+            $target .= '?' . $uri->getQuery();
+        }
+
+        /** @var array<string, mixed> $server */
+        $server = $message->getServerParams();
+        $server['REQUEST_METHOD'] = $message->getMethod();
+        $server['REQUEST_URI'] = $target;
+
+        if ($uri->getScheme() === 'https') {
+            $server['HTTPS'] = 'on';
+        } else {
+            // Explicitly removed rather than left: a server param inherited from the source message
+            // would otherwise make a plain-http request report itself as secure.
+            unset($server['HTTPS']);
+        }
+
+        foreach ($message->getHeaders() as $name => $_) {
+            $name = (string) $name;
+            $line = $message->getHeaderLine($name);
+            $upper = strtoupper(str_replace('-', '_', $name));
+
+            $server[in_array($upper, ['CONTENT_TYPE', 'CONTENT_LENGTH'], true) ? $upper : 'HTTP_' . $upper] = $line;
+        }
+
+        return $server;
+    }
+
+    // ---- shared helpers --------------------------------------------------------------------------
+
+    /**
+     * A successful upload's bytes on disk, as a path the core's `$_FILES` shape can carry.
+     *
+     * @throws HttpException
+     */
+    private static function materialize(UploadedFileInterface $file): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'd4np-psr7-');
+
+        if ($path === false) {
+            throw new HttpException(
+                'Could not create a temporary file for an uploaded file. The core carries uploads '
+                . 'as $_FILES entries, which name a path on disk, so there is nowhere else to put '
+                . 'the bytes.',
+            );
+        }
+
+        file_put_contents($path, self::readFully($file->getStream()));
+
+        return $path;
+    }
+
+    /**
+     * A PSR-7 stream's whole contents (BFR-19).
+     *
+     * Rewound first when seekable: a stream already read by middleware would otherwise yield an
+     * empty body, which is the failure mode that looks like "the response lost its content".
+     */
+    private static function readFully(\Psr\Http\Message\StreamInterface $stream): string
+    {
+        if ($stream->isSeekable()) {
+            $stream->rewind();
+        }
+
+        return $stream->getContents();
+    }
+
+    /**
+     * PSR-7 keys query and cookie collections by string; PHP's superglobals may carry integer keys
+     * (`?0=zero`). Casting here keeps the produced message well-typed without discarding an entry.
+     *
+     * @param array<array-key, mixed> $values
+     *
+     * @return array<string, mixed>
+     */
+    private static function stringKeyed(array $values): array
+    {
+        $out = [];
+
+        foreach ($values as $key => $value) {
+            $out[(string) $key] = $value;
+        }
+
+        return $out;
+    }
+}

--- a/packages/utils-psr7-bridge/src/test/php/d4np/utils/bridge/psr7/Psr7BridgeTest.php
+++ b/packages/utils-psr7-bridge/src/test/php/d4np/utils/bridge/psr7/Psr7BridgeTest.php
@@ -1,0 +1,613 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bridge\Psr7\Tests;
+
+use D4np\Utils\Bridge\Psr7\Psr7Bridge;
+use D4np\Utils\Http\Request;
+use D4np\Utils\Http\Response;
+use D4np\Utils\Support\HttpException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Spec 02's conversion contract, clause by clause — the **T-B** suite.
+ *
+ * Every test runs against **every PSR-17 implementation installed**, because a contract proven
+ * against one vendor silently encodes that vendor's leniencies. CI pins one implementation per
+ * matrix cell (spec 02 §7); locally both are present and both run.
+ *
+ * The provider **throws** when no implementation is installed rather than yielding nothing: an
+ * empty provider is a suite that passes without testing anything, which is the failure this
+ * project's gates exist to prevent.
+ */
+#[Group('T-B')]
+final class Psr7BridgeTest extends TestCase
+{
+    /** @var list<string> */
+    private array $temporaryFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryFiles as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        $this->temporaryFiles = [];
+    }
+
+    /**
+     * @return iterable<string, array{object}>
+     */
+    public static function factories(): iterable
+    {
+        $found = false;
+
+        if (class_exists(\Nyholm\Psr7\Factory\Psr17Factory::class)) {
+            $found = true;
+            yield 'nyholm' => [new \Nyholm\Psr7\Factory\Psr17Factory()];
+        }
+
+        if (class_exists(\GuzzleHttp\Psr7\HttpFactory::class)) {
+            $found = true;
+            yield 'guzzle' => [new \GuzzleHttp\Psr7\HttpFactory()];
+        }
+
+        if (!$found) {
+            throw new \RuntimeException(
+                'No PSR-17 implementation is installed, so the conversion contract would be '
+                . 'asserted against nothing. Install nyholm/psr7 or guzzlehttp/psr7.',
+            );
+        }
+    }
+
+    private function bridge(object $factory): Psr7Bridge
+    {
+        /**
+         * One object implements all five PSR-17 factory interfaces in both vendors, which is why
+         * the provider can yield a single value.
+         *
+         * @var \Psr\Http\Message\ServerRequestFactoryInterface&\Psr\Http\Message\ResponseFactoryInterface&\Psr\Http\Message\StreamFactoryInterface&\Psr\Http\Message\UploadedFileFactoryInterface&\Psr\Http\Message\UriFactoryInterface $factory
+         */
+        return new Psr7Bridge($factory, $factory, $factory, $factory, $factory);
+    }
+
+    private function temporaryFileContaining(string $contents): string
+    {
+        $path = (string) tempnam(sys_get_temp_dir(), 'd4np-test-');
+        file_put_contents($path, $contents);
+        $this->temporaryFiles[] = $path;
+
+        return $path;
+    }
+
+    // ---- BFR-01…BFR-08: core -> PSR-7, requests --------------------------------------------------
+
+    #[DataProvider('factories')]
+    public function testBfr01TheMethodIsPreserved(object $factory): void
+    {
+        foreach (['GET', 'POST', 'DELETE', 'PATCH'] as $method) {
+            $request = new Request(server: ['REQUEST_METHOD' => $method, 'REQUEST_URI' => '/']);
+
+            self::assertSame($method, $this->bridge($factory)->requestToPsr7($request)->getMethod());
+        }
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr02TheUriCarriesSchemeHostPortPathAndQuery(object $factory): void
+    {
+        $request = new Request(server: [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/a/b?x=1&y=2',
+            'HTTP_HOST' => 'example.test:8443',
+            'HTTPS' => 'on',
+        ]);
+
+        $uri = $this->bridge($factory)->requestToPsr7($request)->getUri();
+
+        self::assertSame('https', $uri->getScheme());
+        self::assertSame('example.test', $uri->getHost());
+        self::assertSame(8443, $uri->getPort());
+        self::assertSame('/a/b', $uri->getPath());
+        self::assertSame('x=1&y=2', $uri->getQuery());
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr02AnInsecureRequestProducesAnHttpScheme(object $factory): void
+    {
+        $request = new Request(server: ['REQUEST_URI' => '/', 'HTTP_HOST' => 'example.test']);
+
+        self::assertFalse($request->isSecure());
+        self::assertSame('http', $this->bridge($factory)->requestToPsr7($request)->getUri()->getScheme());
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr03EveryHeaderAppearsOnTheMessage(object $factory): void
+    {
+        $request = new Request(server: [
+            'REQUEST_URI' => '/',
+            'HTTP_HOST' => 'example.test',
+            'HTTP_X_REQUEST_ID' => 'abc-123',
+            'CONTENT_TYPE' => 'application/json',
+        ]);
+
+        $message = $this->bridge($factory)->requestToPsr7($request);
+
+        foreach ($request->headers() as $name => $value) {
+            self::assertTrue($message->hasHeader($name), "header {$name} is missing");
+            self::assertSame($value, $message->getHeaderLine($name));
+            self::assertCount(1, $message->getHeader($name), 'the core is single-valued per name');
+        }
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr04QueryParamsSurviveIncludingArrays(object $factory): void
+    {
+        $query = ['q' => 'search', 'tag' => ['a', 'b'], 'page' => '2'];
+        $request = new Request(query: $query, server: ['REQUEST_URI' => '/']);
+
+        self::assertSame($query, $this->bridge($factory)->requestToPsr7($request)->getQueryParams());
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr05TheParsedBodyEqualsThePostCollection(object $factory): void
+    {
+        $post = ['email' => 'user@example.test', 'roles' => ['admin', 'editor']];
+        $request = new Request(post: $post, server: ['REQUEST_URI' => '/']);
+
+        self::assertSame($post, $this->bridge($factory)->requestToPsr7($request)->getParsedBody());
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr06CookieParamsSurvive(object $factory): void
+    {
+        $cookies = ['PHPSESSID' => 'abc', 'theme' => 'dark'];
+        $request = new Request(cookies: $cookies, server: ['REQUEST_URI' => '/']);
+
+        self::assertSame($cookies, $this->bridge($factory)->requestToPsr7($request)->getCookieParams());
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr07AnUploadedFileKeepsItsMetadataAndContents(object $factory): void
+    {
+        $path = $this->temporaryFileContaining('file contents here');
+        $request = new Request(
+            server: ['REQUEST_URI' => '/'],
+            files: ['avatar' => [
+                'name' => 'me.png',
+                'type' => 'image/png',
+                'size' => 18,
+                'tmp_name' => $path,
+                'error' => UPLOAD_ERR_OK,
+            ]],
+        );
+
+        $file = $this->bridge($factory)->requestToPsr7($request)->getUploadedFiles()['avatar'];
+        self::assertInstanceOf(UploadedFileInterface::class, $file);
+
+        self::assertSame('me.png', $file->getClientFilename());
+        self::assertSame('image/png', $file->getClientMediaType());
+        self::assertSame(18, $file->getSize());
+        self::assertSame(UPLOAD_ERR_OK, $file->getError());
+        self::assertSame('file contents here', (string) $file->getStream());
+    }
+
+    /**
+     * **BFR-07's second half.** A failed upload has nothing valid to read, and `tmp_name` is
+     * typically `''`. The stream must never be opened — asserted by pointing `tmp_name` at a path
+     * that does not exist: any attempt to open it would raise, so completing without error is the
+     * evidence.
+     */
+    #[DataProvider('factories')]
+    public function testBfr07AFailedUploadsStreamIsNeverOpened(object $factory): void
+    {
+        $request = new Request(
+            server: ['REQUEST_URI' => '/'],
+            files: ['avatar' => [
+                'name' => '',
+                'type' => '',
+                'size' => 0,
+                'tmp_name' => '/nonexistent/path/that/cannot/be/opened',
+                'error' => UPLOAD_ERR_NO_FILE,
+            ]],
+        );
+
+        $file = $this->bridge($factory)->requestToPsr7($request)->getUploadedFiles()['avatar'];
+        self::assertInstanceOf(UploadedFileInterface::class, $file);
+
+        self::assertSame(UPLOAD_ERR_NO_FILE, $file->getError(), 'the error code must survive verbatim');
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function uploadErrors(): iterable
+    {
+        yield 'ini size' => [UPLOAD_ERR_INI_SIZE];
+        yield 'form size' => [UPLOAD_ERR_FORM_SIZE];
+        yield 'partial' => [UPLOAD_ERR_PARTIAL];
+        yield 'no file' => [UPLOAD_ERR_NO_FILE];
+        yield 'no tmp dir' => [UPLOAD_ERR_NO_TMP_DIR];
+        yield 'cant write' => [UPLOAD_ERR_CANT_WRITE];
+        yield 'extension' => [UPLOAD_ERR_EXTENSION];
+    }
+
+    #[DataProvider('uploadErrors')]
+    public function testBfr07EveryUploadErrorCodeSurvivesVerbatim(int $error): void
+    {
+        foreach (self::factories() as [$factory]) {
+            $request = new Request(
+                server: ['REQUEST_URI' => '/'],
+                files: ['f' => ['name' => '', 'type' => '', 'size' => 0, 'tmp_name' => '', 'error' => $error]],
+            );
+
+            $file = $this->bridge($factory)->requestToPsr7($request)->getUploadedFiles()['f'];
+            self::assertInstanceOf(UploadedFileInterface::class, $file);
+            self::assertSame($error, $file->getError());
+        }
+    }
+
+    /**
+     * **BFR-08 — the conversion is a snapshot, not a view.** A message that tracked a superglobal
+     * would change under a caller who touched `$_GET` after converting.
+     */
+    #[DataProvider('factories')]
+    public function testBfr08TheMessageDoesNotTrackLaterSuperglobalChanges(object $factory): void
+    {
+        $_GET = ['a' => 'original'];
+        $_SERVER['REQUEST_URI'] = '/';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $message = $this->bridge($factory)->requestToPsr7(Request::fromGlobals());
+
+        $_GET['a'] = 'mutated';
+        $_GET['b'] = 'added';
+
+        self::assertSame(['a' => 'original'], $message->getQueryParams());
+
+        $_GET = [];
+    }
+
+    // ---- BFR-09…BFR-12: PSR-7 -> core, requests ---------------------------------------------------
+
+    #[DataProvider('factories')]
+    public function testBfr09MultiValuedHeadersReduceByPsr7sOwnRule(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $message = $bridge->requestToPsr7(new Request(server: ['REQUEST_URI' => '/']))
+            ->withHeader('Accept', 'text/html')
+            ->withAddedHeader('Accept', 'application/json');
+
+        self::assertSame('text/html, application/json', $message->getHeaderLine('Accept'));
+        self::assertSame($message->getHeaderLine('Accept'), $bridge->requestFromPsr7($message)->header('accept'));
+    }
+
+    /**
+     * **BFR-10.** PSR-7 permits `array|object|null`; the core's POST projection is an array, and
+     * `get_object_vars()` on an arbitrary object drops everything non-public while appearing to
+     * succeed.
+     */
+    #[DataProvider('factories')]
+    public function testBfr10AnObjectParsedBodyIsRefused(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $message = $bridge->requestToPsr7(new Request(server: ['REQUEST_URI' => '/']))
+            ->withParsedBody(new \stdClass());
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/parsed body is an object/');
+
+        $bridge->requestFromPsr7($message);
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr10ANullParsedBodyBecomesAnEmptyPost(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $message = $bridge->requestToPsr7(new Request(server: ['REQUEST_URI' => '/']))->withParsedBody(null);
+
+        self::assertSame([], $bridge->requestFromPsr7($message)->postAll());
+    }
+
+    /**
+     * **BFR-11.** A successful upload is materialized byte-identically; the core carries uploads as
+     * `$_FILES` entries, which name a path on disk.
+     */
+    #[DataProvider('factories')]
+    public function testBfr11ASuccessfulUploadIsMaterializedByteIdentically(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $bytes = random_bytes(2048);
+        $path = $this->temporaryFileContaining($bytes);
+
+        $message = $bridge->requestToPsr7(new Request(
+            server: ['REQUEST_URI' => '/'],
+            files: ['doc' => [
+                'name' => 'doc.bin', 'type' => 'application/octet-stream',
+                'size' => strlen($bytes), 'tmp_name' => $path, 'error' => UPLOAD_ERR_OK,
+            ]],
+        ));
+
+        $entry = $bridge->requestFromPsr7($message)->file('doc');
+
+        self::assertIsArray($entry);
+        self::assertSame(UPLOAD_ERR_OK, $entry['error']);
+        self::assertIsString($entry['tmp_name']);
+        $this->temporaryFiles[] = $entry['tmp_name'];
+
+        self::assertSame($bytes, file_get_contents($entry['tmp_name']), 'the bytes must be identical');
+        self::assertSame('doc.bin', $entry['name']);
+    }
+
+    /**
+     * **BFR-11's sharp half.** Both vendors' `UploadedFile::getStream()` **throws** when the error
+     * code is not `UPLOAD_ERR_OK` — so if the bridge touched the stream, this would raise. Passing
+     * is the evidence that it did not.
+     */
+    #[DataProvider('factories')]
+    public function testBfr11AFailedUploadsStreamIsNeverTouchedComingBack(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $message = $bridge->requestToPsr7(new Request(
+            server: ['REQUEST_URI' => '/'],
+            files: ['f' => [
+                'name' => 'big.iso', 'type' => 'application/octet-stream',
+                'size' => 0, 'tmp_name' => '', 'error' => UPLOAD_ERR_INI_SIZE,
+            ]],
+        ));
+
+        $entry = $bridge->requestFromPsr7($message)->file('f');
+
+        self::assertIsArray($entry);
+        self::assertSame(UPLOAD_ERR_INI_SIZE, $entry['error']);
+        self::assertSame('', $entry['tmp_name'], 'a failed upload has no file on disk');
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr11ANestedUploadTreeIsRefusedByName(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $path = $this->temporaryFileContaining('x');
+
+        $one = $bridge->requestToPsr7(new Request(
+            server: ['REQUEST_URI' => '/'],
+            files: ['f' => ['name' => 'a', 'type' => '', 'size' => 1, 'tmp_name' => $path, 'error' => UPLOAD_ERR_OK]],
+        ))->getUploadedFiles()['f'];
+        self::assertInstanceOf(UploadedFileInterface::class, $one);
+
+        $message = $bridge->requestToPsr7(new Request(server: ['REQUEST_URI' => '/']))
+            ->withUploadedFiles(['docs' => ['nested' => $one]]);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/nested tree/');
+
+        $bridge->requestFromPsr7($message);
+    }
+
+    /**
+     * **BFR-12.** The bridge transports; the *core's* accessors keep their own refusal semantics
+     * (ADR-0025) when the value is read.
+     */
+    #[DataProvider('factories')]
+    public function testBfr12QueryValuesPassThroughWithoutPreCoercion(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $message = $bridge->requestToPsr7(new Request(server: ['REQUEST_URI' => '/']))
+            ->withQueryParams(['tags' => ['a', 'b'], 'n' => '42']);
+
+        $request = $bridge->requestFromPsr7($message);
+
+        self::assertSame(['tags' => ['a', 'b'], 'n' => '42'], $request->queryAll());
+        self::assertNull($request->queryString('tags'), 'the core still refuses an array as a string');
+        self::assertSame(['a', 'b'], $request->queryList('tags'));
+    }
+
+    /**
+     * **BFR-08b.** A later `with*()` derivative of the source message must not reach back into an
+     * already-converted `Request`.
+     */
+    #[DataProvider('factories')]
+    public function testBfr08bTheProducedRequestIsDetachedFromLaterDerivatives(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $message = $bridge->requestToPsr7(new Request(server: ['REQUEST_URI' => '/']))
+            ->withQueryParams(['a' => 'original']);
+
+        $request = $bridge->requestFromPsr7($message);
+        $message->withQueryParams(['a' => 'mutated']);
+
+        self::assertSame(['a' => 'original'], $request->queryAll());
+    }
+
+    // ---- BFR-13…BFR-16: core -> PSR-7, responses --------------------------------------------------
+
+    #[DataProvider('factories')]
+    public function testBfr13TheStatusIsPreserved(object $factory): void
+    {
+        foreach ([200, 201, 302, 404, 422, 500] as $status) {
+            self::assertSame(
+                $status,
+                $this->bridge($factory)->responseToPsr7(Response::create($status))->getStatusCode(),
+            );
+        }
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr14EveryResponseHeaderAppears(object $factory): void
+    {
+        $response = Response::json(['ok' => true])->withHeader('X-Trace', 'abc');
+        $message = $this->bridge($factory)->responseToPsr7($response);
+
+        foreach ($response->headers() as $name => $value) {
+            self::assertSame($value, $message->getHeaderLine($name));
+            self::assertCount(1, $message->getHeader($name));
+        }
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr15TheBodyIsReadableInFullFromTheStart(object $factory): void
+    {
+        $body = str_repeat('body-', 1000);
+        $stream = $this->bridge($factory)->responseToPsr7(Response::text($body))->getBody();
+
+        self::assertSame(0, $stream->tell(), 'a consumer reading without rewinding must get it all');
+        self::assertSame($body, $stream->getContents());
+    }
+
+    /**
+     * **BFR-16.** Conversion is a value operation. Asserted twice: no output escapes, and the
+     * source never names `send()` — the mechanism, because a future edit could call it in a branch
+     * this test does not reach.
+     */
+    #[DataProvider('factories')]
+    public function testBfr16ConvertingEmitsNothing(object $factory): void
+    {
+        ob_start();
+
+        try {
+            $this->bridge($factory)->responseToPsr7(Response::text('hello'));
+            $emitted = (string) ob_get_clean();
+        } catch (\Throwable $e) {
+            ob_end_clean();
+
+            throw $e;
+        }
+
+        self::assertSame('', $emitted);
+
+        $source = (string) file_get_contents(
+            (string) (new \ReflectionClass(Psr7Bridge::class))->getFileName(),
+        );
+        self::assertStringNotContainsString('->send(', $source, 'the bridge must never send a response');
+    }
+
+    // ---- BFR-17…BFR-19: PSR-7 -> core, responses --------------------------------------------------
+
+    #[DataProvider('factories')]
+    public function testBfr17TheStatusComesBack(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+
+        foreach ([200, 404, 503] as $status) {
+            $message = $bridge->responseToPsr7(Response::create($status));
+            self::assertSame($status, $bridge->responseFromPsr7($message)->status());
+        }
+    }
+
+    /**
+     * **BFR-18 — the contract's sharpest edge.** Comma-joining is right for every header except
+     * `Set-Cookie`, whose values contain commas of their own (`Expires=Wed, 21 Oct …`). A naive
+     * implementation passes every other test here while silently corrupting cookies.
+     */
+    #[DataProvider('factories')]
+    public function testBfr18MultipleSetCookieHeadersAreRefused(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $message = $bridge->responseToPsr7(Response::create(200))
+            ->withHeader('Set-Cookie', 'a=1; Path=/; Expires=Wed, 21 Oct 2026 07:28:00 GMT')
+            ->withAddedHeader('Set-Cookie', 'b=2; Path=/; HttpOnly');
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessageMatches('/Set-Cookie headers/');
+
+        $bridge->responseFromPsr7($message);
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr18ASingleSetCookiePassesThroughUnchanged(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $cookie = 'sid=abc; Path=/; Expires=Wed, 21 Oct 2026 07:28:00 GMT; HttpOnly';
+
+        $message = $bridge->responseToPsr7(Response::create(200))->withHeader('Set-Cookie', $cookie);
+
+        self::assertSame($cookie, $bridge->responseFromPsr7($message)->header('set-cookie'));
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr19AnAlreadyReadBodyIsRewoundNotLost(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $message = $bridge->responseToPsr7(Response::text('the whole body'));
+
+        // What middleware that inspected the body would leave behind.
+        $message->getBody()->getContents();
+
+        self::assertSame('the whole body', $bridge->responseFromPsr7($message)->body());
+    }
+
+    // ---- BFR-20…BFR-22: round-trips ---------------------------------------------------------------
+
+    #[DataProvider('factories')]
+    public function testBfr20ARequestSurvivesTheRoundTrip(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $original = new Request(
+            query: ['q' => 'search', 'tag' => ['a', 'b']],
+            post: ['email' => 'user@example.test'],
+            server: [
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/search?q=search',
+                'HTTP_HOST' => 'example.test',
+                'HTTPS' => 'on',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+            ],
+            cookies: ['sid' => 'abc'],
+        );
+
+        $back = $bridge->requestFromPsr7($bridge->requestToPsr7($original));
+
+        self::assertSame($original->method(), $back->method());
+        self::assertSame($original->uri(), $back->uri());
+        self::assertSame($original->isSecure(), $back->isSecure());
+        self::assertSame($original->queryAll(), $back->queryAll());
+        self::assertSame($original->postAll(), $back->postAll());
+        self::assertSame($original->cookieAll(), $back->cookieAll());
+        self::assertSame($original->headers(), $back->headers());
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr21AResponseSurvivesTheRoundTrip(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $original = Response::json(['id' => 7, 'name' => 'thing'], 201)
+            ->withHeader('X-Trace', 'abc-123')
+            ->withHeader('Cache-Control', 'no-store');
+
+        $back = $bridge->responseFromPsr7($bridge->responseToPsr7($original));
+
+        self::assertSame($original->status(), $back->status());
+        self::assertSame($original->body(), $back->body());
+        self::assertSame($original->headers(), $back->headers());
+    }
+
+    #[DataProvider('factories')]
+    public function testBfr22UploadedBytesSurviveTheFullRoundTrip(object $factory): void
+    {
+        $bridge = $this->bridge($factory);
+        $bytes = random_bytes(4096);
+        $path = $this->temporaryFileContaining($bytes);
+
+        $original = new Request(
+            server: ['REQUEST_URI' => '/'],
+            files: ['payload' => [
+                'name' => 'payload.bin', 'type' => 'application/octet-stream',
+                'size' => strlen($bytes), 'tmp_name' => $path, 'error' => UPLOAD_ERR_OK,
+            ]],
+        );
+
+        $entry = $bridge->requestFromPsr7($bridge->requestToPsr7($original))->file('payload');
+
+        self::assertIsArray($entry);
+        self::assertIsString($entry['tmp_name']);
+        $this->temporaryFiles[] = $entry['tmp_name'];
+
+        self::assertSame($bytes, file_get_contents($entry['tmp_name']));
+        self::assertSame(strlen($bytes), $entry['size']);
+    }
+}

--- a/src/main/php/d4np/utils/Http/Request.php
+++ b/src/main/php/d4np/utils/Http/Request.php
@@ -124,6 +124,72 @@ final class Request
         return self::asStringList($this->post[$key] ?? null);
     }
 
+    // ---- whole-collection readers ----------------------------------------------------------------
+
+    /*
+     * The four methods below return their input **raw and entire**, which is a deliberate exception
+     * to everything the typed accessors above stand for — so it is worth saying why it is not a
+     * retreat from ADR-0025.
+     *
+     * ADR-0025's rule is about *scalar* reads: `queryString('email')` refuses an array rather than
+     * producing the literal `"Array"`, because a caller asking for one string has been handed
+     * something else and coercion would hide that. These methods make no such promise and cannot
+     * mislead in that way — a caller asking for the whole collection is asking for exactly what
+     * arrived, values of every shape included.
+     *
+     * They exist because the PSR-7 bridge (ADR-0033, ADR-0034) must project a whole request across
+     * the boundary, and a key-scoped reader cannot enumerate. `headers()` and `file()` already
+     * returned raw collections before them, so this is the established shape rather than a new one.
+     *
+     * PHP arrays are values: the caller gets a copy, so nothing here hands out a mutable view of
+     * this request's state.
+     */
+
+    /**
+     * The whole query collection, exactly as it arrived.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function queryAll(): array
+    {
+        return $this->query;
+    }
+
+    /**
+     * The whole POST collection, exactly as it arrived.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function postAll(): array
+    {
+        return $this->post;
+    }
+
+    /**
+     * The whole cookie collection, exactly as it arrived.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function cookieAll(): array
+    {
+        return $this->cookies;
+    }
+
+    /**
+     * Every uploaded-file entry, in `$_FILES` shape.
+     *
+     * The counterpart to {@see file()}, which reads one by key. Uploaded files are the one
+     * collection with no typed accessor at all — an uploaded-file abstraction is precisely what
+     * RFC-0001 declined to re-implement — so this returns what PHP produced and the bridge turns it
+     * into `UploadedFileInterface` instances.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function uploadedFiles(): array
+    {
+        return $this->files;
+    }
+
     // ---- request line and headers --------------------------------------------------------------
 
     /**

--- a/src/test/php/d4np/utils/Http/RequestWholeCollectionTest.php
+++ b/src/test/php/d4np/utils/Http/RequestWholeCollectionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http;
+
+use D4np\Utils\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Request`'s whole-collection readers (ADR-0034).
+ *
+ * They exist because the PSR-7 bridge must project an entire request across the boundary and a
+ * key-scoped reader cannot enumerate — `postAll()` and `uploadedFiles()` in particular have no
+ * substitute, since a POST body and `$_FILES` are recoverable from nothing else the class exposes.
+ *
+ * The tests worth having are the ones that pin what these do **not** do: they return raw values,
+ * they do not coerce, and they hand out a copy rather than a view.
+ */
+final class RequestWholeCollectionTest extends TestCase
+{
+    public function testEachReaderReturnsItsCollectionEntire(): void
+    {
+        $request = new Request(
+            query: ['q' => 'search', 'tag' => ['a', 'b']],
+            post: ['email' => 'user@example.test'],
+            server: ['REQUEST_URI' => '/'],
+            files: ['avatar' => ['name' => 'a.png', 'error' => UPLOAD_ERR_OK]],
+            cookies: ['sid' => 'abc'],
+        );
+
+        self::assertSame(['q' => 'search', 'tag' => ['a', 'b']], $request->queryAll());
+        self::assertSame(['email' => 'user@example.test'], $request->postAll());
+        self::assertSame(['sid' => 'abc'], $request->cookieAll());
+        self::assertSame(['avatar' => ['name' => 'a.png', 'error' => UPLOAD_ERR_OK]], $request->uploadedFiles());
+    }
+
+    public function testTheyAreEmptyWhenNothingArrived(): void
+    {
+        $request = new Request();
+
+        self::assertSame([], $request->queryAll());
+        self::assertSame([], $request->postAll());
+        self::assertSame([], $request->cookieAll());
+        self::assertSame([], $request->uploadedFiles());
+    }
+
+    /**
+     * **The distinction from the typed accessors.** `queryString('tag')` refuses an array because a
+     * caller asking for one string was handed something else (ADR-0025). `queryAll()` makes no such
+     * promise: a caller asking for the whole collection is asking for exactly what arrived, values
+     * of every shape included. Asserting both here so the contrast is stated where someone would
+     * otherwise read the raw reader as a loophole.
+     */
+    public function testTheRawReadersDoNotCoerceAndTheTypedOnesStillRefuse(): void
+    {
+        $request = new Request(query: ['tag' => ['a', 'b'], 'n' => 42, 'ok' => null]);
+
+        self::assertSame(['tag' => ['a', 'b'], 'n' => 42, 'ok' => null], $request->queryAll());
+
+        self::assertNull($request->queryString('tag'), 'an array is still refused as a string');
+        self::assertNull($request->queryString('ok'));
+        self::assertSame(['a', 'b'], $request->queryList('tag'));
+    }
+
+    /**
+     * A copy, not a view: PHP arrays are values, and nothing here hands out mutable access to the
+     * request's own state.
+     */
+    public function testTheReturnedArrayIsACopy(): void
+    {
+        $request = new Request(query: ['a' => 'original']);
+
+        $copy = $request->queryAll();
+        $copy['a'] = 'mutated';
+        $copy['b'] = 'added';
+
+        self::assertSame(['a' => 'original'], $request->queryAll());
+    }
+
+    /**
+     * Integer keys survive. `?0=zero` produces an integer key in `$_GET` — the same fact that made
+     * PHPStan reject an `array<string, mixed>` superglobal type back at item 6.1 — and a reader
+     * that quietly dropped or re-indexed them would lose data the caller can see in `$_GET`.
+     */
+    public function testIntegerKeysSurvive(): void
+    {
+        $request = new Request(query: [0 => 'zero', 'a' => 'one']);
+
+        self::assertSame([0 => 'zero', 'a' => 'one'], $request->queryAll());
+    }
+
+    public function testTheyReflectTheSuperglobalsThroughFromGlobals(): void
+    {
+        $_GET = ['g' => '1'];
+        $_POST = ['p' => '2'];
+        $_COOKIE = ['c' => '3'];
+        $_FILES = ['f' => ['name' => 'x', 'error' => UPLOAD_ERR_NO_FILE]];
+
+        $request = Request::fromGlobals();
+
+        self::assertSame(['g' => '1'], $request->queryAll());
+        self::assertSame(['p' => '2'], $request->postAll());
+        self::assertSame(['c' => '3'], $request->cookieAll());
+        self::assertSame(['f' => ['name' => 'x', 'error' => UPLOAD_ERR_NO_FILE]], $request->uploadedFiles());
+
+        $_GET = $_POST = $_COOKIE = $_FILES = [];
+    }
+}


### PR DESCRIPTION
Roadmap item **8.2**.

## Blocked at the first line — and the block was mine

I wrote spec 02's conversion contract at item 7.4, and it was wrong in a way only an implementation could show. `requestToPsr7()` needs the whole `$_GET`/`$_POST`/`$_COOKIE`/`$_FILES` collections. The core exposed **none** of them — every collection reader was key-scoped, only `headers()` returned a whole collection.

Query and cookies were *partly* recoverable (from `uri()` and the `Cookie` header) and that route was worse than it looked: a **second parsing path** beside the one PHP already ran, disagreeing with the core's own view the moment a server rewrote a request. POST and `$_FILES` weren't recoverable at all.

You chose to widen the core, so `Request` gained `queryAll()`, `postAll()`, `cookieAll()`, `uploadedFiles()` — **ADR-0034**, additive, no BC break.

**Why this isn't a retreat from ADR-0025**, since that's the obvious objection: ADR-0025 governs *scalar* reads, where `(string) ['x']` yields the literal `"Array"` — a value nobody sent. A whole-collection reader promises no conversion, so there's nothing for it to convert wrongly. A test asserts both behaviours side by side, or the raw reader reads like a loophole rather than a different question.

I added exactly the four readers the blocked clauses needed. **`serverAll()` was deliberately not added** — nothing in the contract needs it, and everything the core reads from `$_SERVER` is already reachable through `method()`, `uri()`, `isSecure()` and `headers()`.

## Five planted defects, all caught, on both vendors

| planted | result |
|---|---|
| `Set-Cookie` multi-header refusal removed | 2 failures |
| a failed upload's stream opened | 2 **errors** |
| an object parsed body accepted | 2 failures |
| a nested upload tree accepted | 2 failures |
| the body rewind dropped | 2 failures |

**BFR-18** is the one the contract exists for: PSR-7's `getHeaderLine()` comma-joins, which is right for every header *except* `Set-Cookie` — cookie strings contain commas themselves (`Expires=Wed, 21 Oct …`), so joining two produces a string no client can split back. Removing the check breaks exactly one test and nothing else. That's precisely the shape of a defect that ships.

**BFR-11** is inverted and sharp: both vendors' `UploadedFile::getStream()` *throws* when the error code isn't `UPLOAD_ERR_OK`, so planting the access produced **errors**, not failures.

## The boundary test caught me

Developing needed the package's dependencies, so I ran the PR-mode recipe locally. It rewrote the committed manifest — `egl/utils: "@dev"` plus a `repositories` block — and the core suite failed on `BridgePackageBoundaryTest`, the two assertions item 8.1 wrote for exactly this.

The invariant working on its author, one item later, catching the exact mutation predicted. Without it that would have been committed, and the published package would have pointed at `../../` for every standalone consumer while everything here stayed green.

## Spec 02 → r2

**BFR-07's wording corrected**: r1 said the upload stream "lazily wraps" `tmp_name`, but eagerness is the PSR-17 factory's business and neither reference vendor defers — the clause now states what the bridge controls, that no stream over `tmp_name` is created at all for a failed upload. §3 records the core readers the contract depends on.

## Bar

Core **1312 tests / 2973 assertions**; package **65 tests / 202 assertions** across both `nyholm/psr7` and `guzzlehttp/psr7`. PHPStan max clean in both trees, deptrac 0/0, PHP-CS-Fixer clean, consistency lint OK.

`quality / PSR-7 bridge contract` now **runs for real** on both matrix cells — 8.1 shipped it skipping, and this is its first live exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
