### PR TITLE
ci(bridge): the publication pipeline, with a ref-shape guard and a non-skippable release mode

### DIFF
--- a/.eados-core/learning/runs/2026-08-05-utils-12.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils-12.yaml
@@ -1,0 +1,33 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}

--- a/.eados-core/learning/runs/2026-08-05-utils-13.yaml
+++ b/.eados-core/learning/runs/2026-08-05-utils-13.yaml
@@ -1,0 +1,33 @@
+# Run record — appended by tools/record_run.py; a fact about a past run, never edited
+# after the fact. `phase` is the delivery phase that produced it (#215).
+slug: "utils"
+date: "2026-08-05"
+phase: "scaffold"
+lang: "php"
+kind: "library"
+outcome: "ok"
+overrides:
+  - key: "governance.capabilities.bench"
+    default: false
+    chosen: true
+  - key: "governance.capabilities.packaging"
+    default: false
+    chosen: true
+  - key: "governance.posture"
+    default: "standard"
+    chosen: "enterprise"
+  - key: "ownership.assignee"
+    default: "@me"
+    chosen: "danielPoloWork"
+  - key: "ownership.default_branch"
+    default: "main"
+    chosen: "master"
+  - key: "spec.provenance"
+    default: "coauthor"
+    chosen: "import"
+  - key: "toolchain.coverage_target"
+    default: 80
+    chosen: 90
+lessons_applied: []
+failures: []
+rubric: {}

--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -1,0 +1,160 @@
+name: bridge-release
+
+# Publication pipeline for `egl/utils-psr7-bridge` (spec 02 §6, ADR-0033, ADR-0035).
+#
+# The bridge versions independently of the core: tags here are
+# `utils-psr7-bridge-vMAJOR.MINOR.PATCH`, and the split repository receives a plain
+# `vMAJOR.MINOR.PATCH`, which is what Packagist reads.
+#
+# Nothing is pushed anywhere until three things hold:
+#
+#   1. the tag is annotated, signed, and agrees with the package's changelog;
+#   2. the package passes its contract suite in **release mode** — a clean install resolving
+#      `egl/utils` from Packagist exactly as a consumer would, because the committed constraint is a
+#      claim about *released* core versions and PR-mode evidence (working tree) cannot support it;
+#   3. the split repository and its token are configured.
+#
+# **This pipeline cannot succeed until the core has a release.** `egl/utils: ^0.7` resolves to
+# nothing today, so release mode fails — correctly, and by design rather than by oversight. It is
+# not skipped: skipping would publish a package whose central claim is unverified. The prerequisite
+# check below says so before any work is done.
+
+on:
+  push:
+    tags: ['utils-psr7-bridge-v*']
+  # Available manually so the maintainer can dry-run the gates against an existing tag without
+  # cutting a new one.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'An existing bridge tag to validate (no push happens on a dispatch run)'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bridge-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish ${{ github.event.inputs.tag || github.ref_name }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Resolve which tag this run is about
+        id: tag
+        shell: bash
+        run: |
+          NAME="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          # A dispatch run validates and stops; only a tag push publishes.
+          echo "publishes=${{ github.event_name == 'push' }}" >> "$GITHUB_OUTPUT"
+
+      - name: The tag must be a bridge release tag, and agree with the package
+        id: gate
+        shell: bash
+        run: |
+          # Refuses a core `vX.Y.Z` tag by name. Spec 02 r1 planned to verify with a throwaway tag
+          # that the core workflow's `v*.*.*` glob does not match `utils-psr7-bridge-v*`; an explicit
+          # shape guard in each workflow is strictly better, because it does not depend on GitHub's
+          # matcher staying what it is today (ADR-0035).
+          python3 tools/bridge_release_gate.py --tag "${{ steps.tag.outputs.name }}"
+          VERSION="$(python3 tools/bridge_release_gate.py --tag "${{ steps.tag.outputs.name }}" --print-version)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "The split repository will receive v$VERSION."
+
+      - name: The tag must be annotated and signed
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NAME="${{ steps.tag.outputs.name }}"
+          TYPE="$(git cat-file -t "$NAME")"
+          if [ "$TYPE" != "tag" ]; then
+            echo "::error title=Lightweight tag::$NAME is a $TYPE, not an annotated tag, and cannot carry a signature. Re-create it with 'git tag -a -s'."
+            exit 1
+          fi
+          # ADR-0032's mechanism, reused: GitHub already holds the maintainer's keys, so no key
+          # material reaches this runner and no keyring goes stale on a rotation.
+          SHA="$(gh api "repos/${{ github.repository }}/git/ref/tags/$NAME" --jq '.object.sha')"
+          VERIFIED="$(gh api "repos/${{ github.repository }}/git/tags/$SHA" --jq '.verification.verified')"
+          REASON="$(gh api "repos/${{ github.repository }}/git/tags/$SHA" --jq '.verification.reason')"
+          echo "signature verified: $VERIFIED (reason: $REASON)"
+          if [ "$VERIFIED" != "true" ]; then
+            echo "::error title=Unsigned tag::$NAME reports verified=$VERIFIED, reason '$REASON'. The split repository's own tags are unsigned build artifacts, so this signature is the only authenticity assertion in the chain (ADR-0033 §5)."
+            exit 1
+          fi
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          # The package's floor, which is the core's. A release must install where it claims to.
+          php-version: '8.1'
+          coverage: none
+
+      - name: Release mode — install the package as a consumer would
+        shell: bash
+        run: |
+          # Copied out of the monorepo so no path repository can possibly be in scope: this install
+          # resolves egl/utils from Packagist, which is the claim the committed constraint makes and
+          # the one PR mode cannot test.
+          cp -r packages/utils-psr7-bridge "$RUNNER_TEMP/release-mode"
+          cd "$RUNNER_TEMP/release-mode"
+          rm -rf vendor composer.lock
+
+          if ! composer update --no-interaction --prefer-dist; then
+            echo "::error title=Release mode failed::The package could not be installed from published packages alone. Until egl/utils has a release matching this package's constraint, no bridge version can be published — the constraint would be a claim nobody can satisfy. Cut the core release first."
+            exit 1
+          fi
+
+      - name: Release mode — the contract suite against the released core
+        shell: bash
+        run: |
+          cd "$RUNNER_TEMP/release-mode"
+          vendor/bin/phpunit
+
+      - name: Is the split repository configured?
+        id: split
+        shell: bash
+        run: |
+          if [ -z "${{ vars.BRIDGE_SPLIT_REPO }}" ] || [ -z "${{ secrets.BRIDGE_SPLIT_TOKEN }}" ]; then
+            echo "::error title=Split repository not configured::Publishing needs the variable BRIDGE_SPLIT_REPO (e.g. danielPoloWork/egl-utils-psr7-bridge) and the secret BRIDGE_SPLIT_TOKEN (a token with write access to it). Both are one-time maintainer actions — see docs/workflow/release.md. The gates above all passed; only the push is missing."
+            exit 1
+          fi
+          echo "repo=${{ vars.BRIDGE_SPLIT_REPO }}" >> "$GITHUB_OUTPUT"
+
+      - name: Split the package and push it with the translated tag
+        if: steps.tag.outputs.publishes == 'true'
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.BRIDGE_SPLIT_TOKEN }}
+        run: |
+          VERSION="${{ steps.gate.outputs.version }}"
+          TARGET="${{ steps.split.outputs.repo }}"
+
+          # `subtree split` rewrites the package's history with the package root at the top, which is
+          # what Packagist needs: a repository whose composer.json is at its root.
+          BRANCH="$(git subtree split --prefix=packages/utils-psr7-bridge)"
+          echo "split commit: $BRANCH"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # The split tag is a build artifact of a verified signed source, not an assertion of its
+          # own — the authenticity lives at the monorepo tag checked above (ADR-0033 §5).
+          git tag -a "v$VERSION" "$BRANCH" -m "egl/utils-psr7-bridge v$VERSION (generated from ${{ steps.tag.outputs.name }})"
+
+          git push "https://x-access-token:${TOKEN}@github.com/${TARGET}.git" "$BRANCH:refs/heads/main"
+          git push "https://x-access-token:${TOKEN}@github.com/${TARGET}.git" "refs/tags/v$VERSION"
+
+          echo "::notice title=Published::${TARGET} now carries v$VERSION. Packagist updates itself from that repository's own integration; confirm at https://packagist.org/packages/egl/utils-psr7-bridge."
+
+      - name: Dry run — validated, nothing pushed
+        if: steps.tag.outputs.publishes != 'true'
+        run: echo "::notice title=Dry run::Every gate passed for ${{ steps.tag.outputs.name }}. This was a manual dispatch, so nothing was pushed to the split repository."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: This tag must belong to the core, not the bridge
+        shell: bash
+        run: |
+          # First, and before anything costs an API call. The bridge publishes from
+          # `utils-psr7-bridge-vX.Y.Z` (ADR-0033 §3), and both workflows guard their own ref shape
+          # rather than trusting GitHub's `tags:` glob to have kept the two grammars apart — a
+          # matcher's behaviour is a dependency like any other, and this one cannot be tested
+          # without pushing throwaway tags to a public repository (ADR-0035).
+          if ! printf '%s' "${{ github.ref_name }}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error title=Not a core release tag::${{ github.ref_name }} is not vMAJOR.MINOR.PATCH. A bridge release is utils-psr7-bridge-vMAJOR.MINOR.PATCH and belongs to bridge-release.yml."
+            exit 1
+          fi
+
       - name: The tag must be annotated, not lightweight
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **The PSR-7 bridge's publication pipeline** (**ADR-0035**, spec 02 r3) —
+  `.github/workflows/bridge-release.yml` and `tools/bridge_release_gate.py`, closing Milestone 8.
+  On a `utils-psr7-bridge-vX.Y.Z` tag it verifies the tag is annotated and signed (ADR-0032's
+  GitHub-side mechanism, reused), checks it against the package changelog's `## [X.Y.Z]` heading —
+  a Composer library carries no version constant, so the changelog is what anchors a bridge tag —
+  runs the contract suite in **release mode**, then splits the package and pushes it to the
+  generated split repository as a plain `vX.Y.Z`.
+  **Release mode is never skipped.** This project's standing pattern is to skip a gate that cannot
+  run yet and self-enable later (lesson L-0010), and that is right for a gate that *checks*
+  something and wrong for one that *establishes* something: release mode is the only evidence for
+  the package's central published claim, so skipping it would publish a package nobody has tested
+  against a released core. Consequently **no bridge version can be published until `egl/utils` has
+  a release** — the pipeline fails today, by design, saying exactly that.
+  **Tag-grammar isolation is a guard, not a glob.** Spec r1 planned to verify with a throwaway tag
+  that `v*.*.*` does not match `utils-psr7-bridge-v*`; each workflow now refuses a ref that is not
+  its own shape, which is stronger — it does not depend on GitHub's matcher staying what it is —
+  and pushes no test tag to a public repository. `release.yml` gains that guard as its first step.
+
 - **`Request::queryAll()`, `postAll()`, `cookieAll()` and `uploadedFiles()`** (**ADR-0034**) —
   whole-collection readers, added because roadmap item 8.2 found spec 02's BFR-04…BFR-07 were not
   implementable: every core collection reader was key-scoped, only `headers()` returned a whole

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ capacity; no parallel streams; no calendar dates by decision).
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-05 — The contract that could not be implemented](docs/journal/2026/08/2026-08-05-bridge-converters.md).
+  [2026-08-05 — When the standing pattern is the wrong one](docs/journal/2026/08/2026-08-05-bridge-publish.md).
 
 ## Model & effort routing (advisory)
 
@@ -542,12 +542,26 @@ API-freeze review for the **core** is unaffected by this milestone.
       errors), an object parsed body accepted (2), a nested upload tree accepted (2), the body
       rewind dropped (2). Spec 02 → r2: BFR-07's "lazily wraps `tmp_name`" corrected, since
       eagerness is the PSR-17 factory's business and neither vendor defers.*
-- [ ] 8.3 Publication pipeline per spec 02 §6: signed-source-tag verification (ADR-0032 reused),
+- [x] 8.3 Publication pipeline per spec 02 §6: signed-source-tag verification (ADR-0032 reused),
       **release-mode** contract run against the released core, `git subtree split` + translated
       tag push to the read-only split repository; verify the `v*.*.*` / `utils-psr7-bridge-v*`
       tag-grammar isolation with a real tag before the first publication; one-time maintainer
       actions documented (create the split repo, register `egl/utils-psr7-bridge` on Packagist)
-      (severity:high — supply-chain surface) — route: standard / high
+      (severity:high — supply-chain surface) — route: standard / high *(session model matched the
+      route)* · **ADR-0035**, **spec 02 r3**. *Two details could not be built as written, for
+      opposite reasons. **Tag-grammar isolation**: r1 planned to verify GitHub's glob with a
+      throwaway tag — a side effect on a public repository to establish a fact that expires the day
+      GitHub changes its matcher. Both workflows now **guard their own ref shape** and refuse a tag
+      that is not theirs, which is stronger and makes the glob irrelevant; verified in both
+      directions locally. **Release mode**: the standing L-0010 pattern says skip-and-self-enable
+      when a gate cannot run yet, and that is **wrong here** — release mode is the only evidence for
+      the package's central published claim, so skipping would not defer a check, it would publish
+      an unverified package. It is a hard requirement, so **no bridge version can be published until
+      the core has a release**; the failure says exactly that. `bridge_release_gate.py` anchors a
+      bridge tag to the package changelog's `## [X.Y.Z]`, since a Composer library carries no
+      version constant for `release_gate.py` to check. **Most of this pipeline has never run and
+      cannot until a core release exists** — third item running (7.2, 7.3, 8.3) whose first real run
+      is its first real use; named in the ADR, not implied to be fine.*
 
 ---
 

--- a/docs/adr/0035-guard-the-ref-shape-rather-than-trust-a-glob-and-never-skip-release-mode.md
+++ b/docs/adr/0035-guard-the-ref-shape-rather-than-trust-a-glob-and-never-skip-release-mode.md
@@ -1,0 +1,115 @@
+# ADR-0035: Guard the ref shape rather than trust a glob, and never skip release mode
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 8.3 (closes Milestone 8) ·
+  [`docs/specs/02_spec_psr7_bridge.md`](../specs/02_spec_psr7_bridge.md) §6 (the pipeline this
+  implements, amended to r3 here) ·
+  [ADR-0033](0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md)
+  §3 and §5 (independent versioning; the authenticity chain) ·
+  [ADR-0032](0032-verify-the-tag-before-drafting-and-let-packagist-pull.md) (the signature
+  mechanism reused) · [ADR-0031](0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md)
+  (the skip-on-a-declared-condition precedent this one deliberately does **not** follow)
+
+## Context
+
+Item 8.3 builds the pipeline ADR-0033 §6 specified: verify a signed bridge tag, prove the package
+installs and passes against the **released** core, split `packages/utils-psr7-bridge/` and push it
+to the generated repository with a translated tag.
+
+Two of its details could not be built as written, for opposite reasons — one because the plan was
+unverifiable, one because the plan was verifiable and would have been wrong.
+
+## Decision
+
+### 1. Each workflow guards its own ref shape; the glob is not trusted
+
+Spec 02 r1 said item 8.3 would *"verify with a real tag"* that the core's `tags: ["v*.*.*"]` filter
+does not match `utils-psr7-bridge-v*`. That plan has two faults. Testing a glob means pushing a
+throwaway tag to a public repository and deleting it — a side effect on the artifact this project
+treats as uncorrectable. And a verified glob is verified only until GitHub changes its matcher; the
+result would be a fact with an expiry date nobody is watching.
+
+So both workflows refuse a ref that is not theirs, by name and first:
+
+- `release.yml` requires `^v[0-9]+\.[0-9]+\.[0-9]+$` before any other step;
+- `bridge-release.yml` requires `^utils-psr7-bridge-v(\d+)\.(\d+)\.(\d+)$`, in
+  `tools/bridge_release_gate.py`.
+
+This is **stronger** than what was planned, not a retreat from it: whatever the glob does, a tag
+reaching the wrong workflow is refused rather than processed. The matcher's behaviour stops being a
+dependency. Verified locally in both directions — each gate refuses the other's tag, and
+`v0.7`/`v0.7.0-rc1` are refused too.
+
+### 2. Release mode is a hard requirement and is never skipped
+
+This project has a standing pattern, from lesson L-0010 and applied at ADR-0031 and item 8.1: when a
+gate cannot run yet, skip it on a declared condition and self-enable later. It is the right shape
+for a *check*.
+
+It is the wrong shape here, and the distinction is worth stating because the precedent points the
+other way. Release mode is not a check that happens to be unavailable — it is the **only** evidence
+for the package's central published claim, that `egl/utils: ^0.7` resolves and works. Skipping it
+does not defer a check; it **publishes an unverified package**. A skipped gate on a pull request
+costs a later discovery. A skipped gate here costs a release that cannot be corrected in place.
+
+So: no release, no publication. Today `egl/utils: ^0.7` resolves to nothing — the core has no tag —
+and the pipeline therefore **cannot succeed at all**. That is correct, not an oversight, and the
+failure says so in the words a maintainer needs: *cut the core release first*.
+
+### 3. Prerequisites fail early and name themselves
+
+The split repository and its push token are one-time maintainer actions. When they are missing the
+job fails with what to configure and where, and says explicitly that the gates passed and only the
+push is absent — because a tag has already been pushed by then, and "it failed" without "here is
+what is missing" is a bad thing to hand someone mid-release.
+
+### 4. A `workflow_dispatch` dry run
+
+The pipeline can be run manually against an existing tag; it validates everything and pushes
+nothing. Given how much of this machinery cannot be exercised until a real release exists (§ below),
+a way to run the gates without cutting a version is worth its handful of lines.
+
+### 5. The changelog anchors a bridge tag, because nothing else can
+
+`release_gate.py` anchors a core tag to the `VERSION` constant. The bridge has no such constant —
+a Composer library does not carry its own version, by design — so `bridge_release_gate.py` anchors
+the tag to the `## [X.Y.Z]` heading in the package's own changelog, the one place its version is
+written down. It also re-checks, on the exact tagged tree, the two manifest invariants
+`BridgePackageBoundaryTest` checks on pull requests: no `repositories` entry, no `@dev` core
+constraint. Duplication on purpose — that tree is the artifact that gets published.
+
+## Alternatives Considered
+
+- **Pushing a throwaway tag to verify the glob**, as spec r1 planned — rejected in §1: a side effect
+  on a public repository to establish a fact with an expiry date, when an explicit guard makes the
+  fact unnecessary.
+- **Skipping release mode until the core ships** (the L-0010 shape) — rejected in §2. It is the
+  right pattern for a check and the wrong one for the sole evidence behind a published claim.
+- **Loosening the core constraint so release mode passes today** (`*`, or `>=0.0.0`) — rejected: it
+  would make the pipeline green by making the package's claim meaningless.
+- **Publishing with `GITHUB_TOKEN`** — not possible: it cannot write to another repository. A
+  scoped token is required, which is why the split repository is a configured prerequisite rather
+  than something this workflow can arrange for itself.
+- **Signing the split repository's tags in CI** — rejected, consistent with ADR-0032: a CI-held key
+  would make the pipeline, not the maintainer, the identity a release asserts. The split tags stay
+  build artifacts of a verified signed source.
+
+## Consequences
+
+- `.github/workflows/bridge-release.yml`; `tools/bridge_release_gate.py`; an early ref-shape guard
+  in `release.yml`. 36 action pins across four workflows verified upstream.
+- **The gate is proven to fail before being trusted** (lesson L-0008), five cases with verified exit
+  codes: a complete fixture passes and prints the translated version; a tag whose changelog heading
+  is missing, a core tag reaching the bridge gate, a committed `repositories` entry and a `@dev`
+  core constraint all exit 1. The core gate refuses a bridge tag symmetrically.
+- Spec 02 → **r3**: §6's "verifies with a real tag" is replaced by the guard, and the release-mode
+  requirement is stated as non-skippable.
+- **Most of this pipeline has never run, and cannot until a core release exists.** The signature
+  check, the release-mode install, the subtree split and the cross-repository push are all
+  unexercised — the third item in a row (7.2, 7.3, now 8.3) shipping machinery whose first real run
+  is its first real use. What *can* be tested away from a tag has been: the gate's five cases, both
+  ref-shape guards, the YAML, the pins. Named here rather than implied to be fine.
+- Milestone 8 closes. The bridge is written, contract-tested against two PSR-17 implementations, and
+  ready to publish the moment the core has a version to depend on.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,3 +50,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0032](0032-verify-the-tag-before-drafting-and-let-packagist-pull.md) | Verify the tag before a draft exists, ask GitHub about the signature, and let Packagist pull | Accepted |
 | [0033](0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md) | The bridge's source lives in this monorepo; a generated, read-only split repository is only its publication target | Accepted |
 | [0034](0034-whole-collection-readers-on-request.md) | Whole-collection readers on `Request`, because a key-scoped reader cannot enumerate | Accepted |
+| [0035](0035-guard-the-ref-shape-rather-than-trust-a-glob-and-never-skip-release-mode.md) | Guard the ref shape rather than trust a glob, and never skip release mode | Accepted |

--- a/docs/journal/2026/08/2026-08-05-bridge-publish.md
+++ b/docs/journal/2026/08/2026-08-05-bridge-publish.md
@@ -1,0 +1,89 @@
+# 2026-08-05 — When the standing pattern is the wrong one
+
+Roadmap item **8.3**, closing Milestone 8. Route `standard / high` → Opus 5, the session model. No
+mismatch. Isolated worktree.
+
+Two details of my own spec could not be built as written, for opposite reasons: one was
+unverifiable, one was verifiable and wrong.
+
+## The plan that would have cost a side effect for an expiring fact
+
+Spec 02 r1 said 8.3 would *"verify with a real tag"* that the core's `tags: ["v*.*.*"]` filter does
+not match `utils-psr7-bridge-v*`. I wrote that at 7.4 and it sounded like diligence.
+
+It has two faults. Testing a glob means pushing a throwaway tag to a public repository and deleting
+it — a side effect on the one artifact this project treats as uncorrectable, to establish a fact. And
+the fact expires: a verified glob is verified only until GitHub changes its matcher, and nobody is
+watching for that.
+
+So both workflows guard their own ref shape instead, first, before anything costs an API call:
+
+```
+release.yml            ^v[0-9]+\.[0-9]+\.[0-9]+$
+bridge_release_gate.py ^utils-psr7-bridge-v\d+\.\d+\.\d+$
+```
+
+Whatever the glob does, a tag reaching the wrong workflow is refused by name. The matcher stops
+being a dependency. Verified locally in both directions — each gate refuses the other's tag, and
+`v0.7` and `v0.7.0-rc1` are refused too.
+
+That is a case where the *stronger* answer was also the cheaper one, and I only found it by asking
+what pushing the tag would actually buy.
+
+## The standing pattern, and why it does not apply here
+
+This project has a reflex, from lesson L-0010 and applied twice recently — at ADR-0031's BC gate and
+item 8.1's bridge job: **when a gate cannot run yet, skip it on a declared condition and self-enable
+later.** It is a good pattern and I reached for it again.
+
+It is wrong here, and the reasoning is worth writing down because the precedent points the other way.
+
+Release mode installs the package resolving `egl/utils` from Packagist, exactly as a consumer would.
+It is not a check that happens to be unavailable — it is the **only** evidence for the package's
+central published claim, that its core constraint resolves and works. Skipping a check defers a
+discovery. Skipping *this* publishes a package whose claim nobody has tested, to a repository that
+cannot be corrected in place.
+
+So it is a hard requirement, and the consequence is blunt: **no bridge release is possible until the
+core has one.** `egl/utils: ^0.7` resolves to nothing today. The pipeline cannot succeed, by design
+rather than by oversight, and its failure message says *cut the core release first*.
+
+The general shape: a skip is right for a gate that *checks* something, and wrong for a gate that
+*establishes* something. I do not think I would have separated those two without having applied the
+pattern wrongly first and noticing what it would have published.
+
+## What anchors a bridge tag
+
+`release_gate.py` anchors a core tag to the `VERSION` constant. The bridge has none — a Composer
+library does not carry its own version, by design — so there was nothing analogous to check against.
+
+The changelog is the answer: `## [X.Y.Z]` in the package's own `CHANGELOG.md` is the one place its
+version is written down, which makes it the one thing a tag can be anchored to. The gate also
+re-checks, on the exact tagged tree, the two manifest invariants `BridgePackageBoundaryTest` checks
+on pull requests. Duplication on purpose: that tree is the artifact that gets published, and after
+8.2 I have direct evidence those invariants catch real mutations — they caught mine.
+
+## The honest state of it
+
+**Most of this has never run and cannot until a core release exists.** The signature check, the
+release-mode install, the subtree split, the cross-repository push: all unexercised. That is the
+third item in a row — 7.2's BC gate, 7.3's tag verification, now this — shipping machinery whose
+first real run will be its first real use.
+
+What can be tested away from a tag has been: the gate's five cases with verified exit codes, both
+ref-shape guards, the YAML, 36 action pins across four workflows. The rest is named in ADR-0035
+rather than implied to be fine. A `workflow_dispatch` dry run exists so the gates can be exercised
+against a tag without cutting a version — small mitigation, worth its lines given how much waits.
+
+## Bar
+
+1312 tests / 2973 assertions green; the bridge package's 65 / 202 across both PSR-17
+implementations. PHPStan max clean, deptrac 0/0, PHP-CS-Fixer clean, consistency lint OK, 36 action
+pins verified upstream.
+
+## Next
+
+**Milestone 8 is complete, and so is every planned item.** What remains is not on any roadmap: the
+first core release (`VERSION` is still `0.0.0` and no tag exists), the post-M7 **1.0.0 API-freeze
+review**, and then the bridge's own first publication — which the core release unblocks. All three
+are the maintainer's to sequence.

--- a/docs/specs/02_spec_psr7_bridge.md
+++ b/docs/specs/02_spec_psr7_bridge.md
@@ -6,7 +6,7 @@
 > discipline as [`01_spec_utils.md`](01_spec_utils.md): a diverging implementation updates this spec
 > in the same PR, with a revision entry and a rationale.
 
-**Revision r2** — 2026-08-05. See [Revision history](#revision-history).
+**Revision r3** — 2026-08-05. See [Revision history](#revision-history).
 
 ## 1. Scope & non-goals
 
@@ -188,9 +188,16 @@ crossing the bridge intact.
 - The committed `composer.json` **never contains a `repositories` entry**: a path repository
   pointing outside the package would break every standalone install of the split package. PR mode
   injects it in the CI workspace only (§7).
-- Tag-grammar isolation: core `v*.*.*` workflows do not match `utils-psr7-bridge-v*` tags and vice
-  versa. Documented GitHub pattern semantics; **item 8.3 verifies with a real tag before the first
-  publication.**
+- Tag-grammar isolation: **each workflow guards its own ref shape** and refuses a tag that is not
+  its own — `release.yml` requires `^v[0-9]+\.[0-9]+\.[0-9]+$`, `bridge_release_gate.py` requires
+  `^utils-psr7-bridge-v\d+\.\d+\.\d+$`. r1 planned to verify GitHub's `tags:` glob with a throwaway
+  tag; the guards are stronger and make the glob's behaviour irrelevant, so no such tag is pushed
+  (ADR-0035 §1).
+- **Release mode is never skipped.** It is the only evidence for the package's central published
+  claim — that its core constraint resolves and works — so an unavailable release mode blocks
+  publication rather than being deferred the way an unavailable *check* would be (ADR-0035 §2).
+  Consequently no bridge version can be published until `egl/utils` has a release matching the
+  committed constraint.
 - One-time maintainer actions, mirroring `docs/workflow/release.md`'s prerequisites section: create
   the split repository, register it on Packagist.
 
@@ -231,3 +238,4 @@ methodology rather than being invented here.
 |-----|------|--------|
 | r1 | 2026-08-05 | Commissioned by ADR-0033 (item 7.4): package boundary, independent versioning, publication pipeline, and imported ADR-002's conversion contract as BFR-01…BFR-22. |
 | r2 | 2026-08-05 | Item 8.2, from implementing it. §3 records the four whole-collection readers `Request` gained (ADR-0034) — without them BFR-04–07 were not implementable, since every core collection reader was key-scoped and POST and `$_FILES` were recoverable from nothing else. BFR-07's wording corrected: r1 said the upload stream "lazily wraps" `tmp_name`, but eagerness is the PSR-17 factory's business and neither reference implementation defers, so the clause now states what the bridge controls — that no stream over `tmp_name` is created at all for a failed upload. |
+| r3 | 2026-08-05 | Item 8.3, from building the pipeline. §6: tag-grammar isolation becomes an explicit **ref-shape guard in each workflow** rather than a throwaway tag verifying GitHub's glob — stronger, and it removes a side effect on a public repository (ADR-0035 §1). Release mode is stated as **never skipped**: it is the only evidence for the package's central published claim, so its unavailability blocks publication rather than deferring a check (ADR-0035 §2). |

--- a/docs/workflow/release.md
+++ b/docs/workflow/release.md
@@ -54,6 +54,30 @@ working copy and has no tag to compare against. `git tag -a v0.2.0` on a tree wh
 says `0.1.0` produces a release that installs as one version and reports itself as another, and
 nothing inside the tree disagrees with itself — so no lint notices.
 
+### Releasing the PSR-7 bridge
+
+`egl/utils-psr7-bridge` versions **independently** of the core (ADR-0033 §3). Its releases are cut
+from package-scoped tags here and published to a generated, read-only split repository:
+
+```bash
+git tag -a -s utils-psr7-bridge-v0.1.0 -m "<headline>"
+git push origin utils-psr7-bridge-v0.1.0
+```
+
+`.github/workflows/bridge-release.yml` then verifies the tag is annotated and signed, checks it
+against `packages/utils-psr7-bridge/CHANGELOG.md`'s `## [X.Y.Z]` heading (a Composer library carries
+no version constant, so the changelog is what anchors the tag), runs the contract suite in **release
+mode**, splits the package and pushes it as a plain `vX.Y.Z`.
+
+Two things to know before cutting one:
+
+- **The core must be released first.** Release mode installs the package resolving `egl/utils` from
+  Packagist, exactly as a consumer would. That is the only evidence for the constraint the package
+  publishes, so it is never skipped — which means a bridge release is impossible until a core
+  version matching its constraint exists (ADR-0035 §2).
+- **`workflow_dispatch` is a dry run.** Running the workflow manually against an existing tag
+  validates everything and pushes nothing.
+
 ### One-time maintainer prerequisites
 
 Both are the maintainer's, not the agent's, and the first release cannot succeed without them.
@@ -67,6 +91,17 @@ Both are the maintainer's, not the agent's, and the first release cannot succeed
    each tag push, which is why no Packagist token lives in this repository. The workflow prints the
    package URL to confirm after publishing; it deliberately does not call the Packagist API, since
    that would both duplicate the integration and cross the agent-vs-human line below.
+3. **For the bridge only** — a **split repository** and a token that can write to it:
+   - create the repository (e.g. `danielPoloWork/egl-utils-psr7-bridge`), empty, and treat it as
+     **read-only**: it is generated, and accepts no commits or pull requests;
+   - set the repository variable `BRIDGE_SPLIT_REPO` to its `owner/name`;
+   - set the secret `BRIDGE_SPLIT_TOKEN` to a token with write access to it — `GITHUB_TOKEN` cannot
+     write to another repository, which is why this one is needed;
+   - register `egl/utils-psr7-bridge` on Packagist, pointing at the split repository.
+
+   Until the variable and secret exist, `bridge-release.yml` fails at its prerequisite step and says
+   what is missing — after the gates have passed, so the message distinguishes "not configured" from
+   "the release is bad".
 
 ## Boundary
 

--- a/packages/utils-psr7-bridge/CHANGELOG.md
+++ b/packages/utils-psr7-bridge/CHANGELOG.md
@@ -13,6 +13,15 @@ release does not imply a bridge release, or the reverse.
 
 ### Added
 
+- Publication pipeline (roadmap item **8.3**, **ADR-0035**): this package is released from a signed
+  `utils-psr7-bridge-vX.Y.Z` tag in the monorepo, verified and contract-tested against the
+  **released** core before anything is pushed, then split to the generated repository as `vX.Y.Z`.
+  **The first release waits on the core.** Release mode resolves `egl/utils` from Packagist exactly
+  as a consumer would, and the core has no release yet — so no version of this package can be
+  published until it does. That is enforced rather than assumed.
+  When cutting a version, add its `## [X.Y.Z]` heading here: it is what the release gate anchors the
+  tag to, since a Composer library carries no version constant of its own.
+
 - **`Psr7Bridge`** (roadmap item **8.2**) — bidirectional conversion between the core's HTTP values
   and PSR-7 messages: `requestToPsr7()`, `requestFromPsr7()`, `responseToPsr7()`,
   `responseFromPsr7()`. PSR-17 factories are **injected at construction**, never discovered or

--- a/tools/bridge_release_gate.py
+++ b/tools/bridge_release_gate.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Daniel Polo
+"""Validate a bridge release tag against the package it will publish — spec 02 §6, ADR-0035.
+
+The bridge versions independently of the core (ADR-0033 §3): tags in this monorepo are
+`utils-psr7-bridge-vMAJOR.MINOR.PATCH`, translated to a plain `vMAJOR.MINOR.PATCH` on the generated
+split repository. That independence is the reason this gate exists and cannot be
+`release_gate.py`: the core's gate anchors a tag to the `VERSION` constant, and the bridge has no
+such constant — a Composer library does not carry its own version, by design.
+
+So what anchors a bridge tag to the tree it points at is its **changelog**. `## [X.Y.Z]` in the
+package's own `CHANGELOG.md` is the one place the version is written down, which makes it the one
+thing a tag can be checked against.
+
+    python tools/bridge_release_gate.py --tag utils-psr7-bridge-v0.1.0
+
+Checks, all of which must hold:
+
+1. the tag is exactly `utils-psr7-bridge-vMAJOR.MINOR.PATCH` — the **shape guard**, which is also
+   what keeps the two tag grammars from crossing (see below);
+2. the package's `CHANGELOG.md` carries a `## [X.Y.Z]` heading for that version;
+3. the committed manifest has **no `repositories` entry** — a path repository pointing at `../../`
+   resolves inside the monorepo and nowhere else, so publishing one breaks every standalone install;
+4. the core constraint is a released one, never `@dev`.
+
+Checks 3 and 4 duplicate `BridgePackageBoundaryTest`, deliberately. That test runs on pull requests;
+this runs on the **exact tagged tree**, which is the artifact that gets published and the one that
+cannot be corrected in place afterwards.
+
+**On tag-grammar isolation.** Spec 02 r1 said item 8.3 would verify with a real tag that the core's
+`v*.*.*` workflow does not match `utils-psr7-bridge-v*`. Pushing a throwaway tag to a public
+repository to test a glob is a poor trade, and a verified glob is still only verified until GitHub
+changes its matcher. Both workflows instead **guard their ref shape explicitly** — this tool for the
+bridge, and `release_gate.py`'s `^v\\d+\\.\\d+\\.\\d+$` for the core — so a tag reaching the wrong
+workflow is refused by name rather than silently processed. The behaviour no longer depends on the
+glob at all.
+
+**Absence is failure**, as in every sibling gate: a missing changelog, an unparseable manifest or a
+tag that does not match exits non-zero.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+TAG = re.compile(r"^utils-psr7-bridge-v(\d+)\.(\d+)\.(\d+)$")
+PACKAGE = os.path.join("packages", "utils-psr7-bridge")
+
+
+class GateError(Exception):
+    """A condition that must fail the gate rather than be reported as a finding."""
+
+
+def read(root, *parts):
+    path = os.path.join(root, *parts)
+    if not os.path.isfile(path):
+        raise GateError(f"{'/'.join(parts)} does not exist")
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def check(root, tag):
+    """The version being released, and every problem found."""
+    match = TAG.match(tag)
+    if match is None:
+        raise GateError(
+            f'"{tag}" is not a bridge release tag. The grammar is '
+            "utils-psr7-bridge-vMAJOR.MINOR.PATCH (ADR-0033 §3); a core release is vMAJOR.MINOR.PATCH "
+            "and belongs to release.yml. Refusing by name rather than trusting a workflow glob to "
+            "have kept the two apart."
+        )
+
+    version = ".".join(match.groups())
+    problems = []
+
+    # The changelog is what anchors the tag: a Composer library carries no version of its own.
+    changelog = read(root, PACKAGE, "CHANGELOG.md")
+    if f"## [{version}]" not in changelog:
+        problems.append(
+            f"{PACKAGE}/CHANGELOG.md has no `## [{version}]` heading. That heading is the only "
+            "place this package's version is written down, so without it the tag is anchored to "
+            "nothing and a reader cannot tell what the release contains."
+        )
+
+    try:
+        manifest = json.loads(read(root, PACKAGE, "composer.json"))
+    except json.JSONDecodeError as exc:
+        raise GateError(f"{PACKAGE}/composer.json is not valid JSON: {exc}") from exc
+
+    if not isinstance(manifest, dict):
+        raise GateError(f"{PACKAGE}/composer.json is not a JSON object")
+
+    if "repositories" in manifest:
+        problems.append(
+            "the committed manifest carries a `repositories` entry. A path repository resolves "
+            "inside this monorepo and nowhere else, so publishing it would break every standalone "
+            "install while nothing here noticed. CI injects it in the workspace only (spec 02 §7)."
+        )
+
+    require = manifest.get("require")
+    if not isinstance(require, dict):
+        problems.append("the committed manifest has no `require` section")
+    else:
+        constraint = require.get("egl/utils")
+        if not isinstance(constraint, str):
+            problems.append("the committed manifest does not require egl/utils")
+        elif "@dev" in constraint or "dev-" in constraint:
+            problems.append(
+                f'the core constraint is "{constraint}". Publishing a package pinned to a moving '
+                "target gives consumers a version that means nothing (spec 02 §2)."
+            )
+
+    return version, problems
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Validate a bridge release tag against the package it publishes."
+    )
+    ap.add_argument("--tag", required=True, help="the pushed tag, e.g. utils-psr7-bridge-v0.1.0")
+    ap.add_argument(
+        "--root",
+        default=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        help="repository root to inspect (defaults to this file's repository)",
+    )
+    ap.add_argument(
+        "--print-version",
+        action="store_true",
+        help="on success, print only the bare X.Y.Z — the tag the split repository receives",
+    )
+    args = ap.parse_args(argv)
+
+    try:
+        version, problems = check(args.root, args.tag)
+    except GateError as exc:
+        print(f"bridge-release gate: FAIL\n\n  {exc}", file=sys.stderr)
+        return 1
+
+    if problems:
+        print(f"bridge-release gate: FAIL — {len(problems)} problem(s) with {args.tag}:", file=sys.stderr)
+        for problem in problems:
+            print(f"\n  - {problem}", file=sys.stderr)
+        print(
+            "\nA published package cannot be corrected in place. Fix the tree, delete the "
+            "unpublished tag, and re-tag.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.print_version:
+        print(version)
+    else:
+        print(
+            f"bridge-release gate: OK — {args.tag} publishes as v{version}; the changelog names it, "
+            "and the manifest is free of a path repository and of a @dev core constraint."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Roadmap item **8.3**, closing Milestone 8 — and with it every planned roadmap item.

Two details of my own spec could not be built as written, for opposite reasons: one was unverifiable, one was verifiable and wrong.

## The plan that cost a side effect for an expiring fact

Spec 02 r1 said 8.3 would *"verify with a real tag"* that the core's `tags: ["v*.*.*"]` filter doesn't match `utils-psr7-bridge-v*`. I wrote that at 7.4 and it sounded like diligence. It has two faults: testing a glob means pushing a throwaway tag to a **public** repository, a side effect on the one artifact this project treats as uncorrectable — and the fact expires the day GitHub changes its matcher, with nobody watching.

Both workflows now guard their own ref shape, first, before anything costs an API call:

```
release.yml             ^v[0-9]+\.[0-9]+\.[0-9]+$
bridge_release_gate.py  ^utils-psr7-bridge-v\d+\.\d+\.\d+$
```

Whatever the glob does, a tag reaching the wrong workflow is refused **by name**. Verified locally in both directions — each gate refuses the other's tag, and `v0.7` / `v0.7.0-rc1` too. The stronger answer was also the cheaper one.

## Where the standing pattern was the wrong one

This project has a reflex from lesson L-0010, applied at ADR-0031's BC gate and item 8.1's bridge job: *when a gate cannot run yet, skip it and self-enable later.* I reached for it again, and it's wrong here.

Release mode installs the package resolving `egl/utils` from Packagist, as a consumer would. It isn't a check that happens to be unavailable — it's the **only** evidence for the package's central published claim. Skipping a check defers a discovery; skipping this one **publishes a package nobody has tested**, to a repository that can't be corrected in place.

So it's a hard requirement, and the consequence is blunt: **no bridge release is possible until the core has one.** `egl/utils: ^0.7` resolves to nothing today, the pipeline cannot succeed, and its failure says *cut the core release first*.

The distinction worth keeping: **a skip is right for a gate that *checks* something and wrong for one that *establishes* something.**

## Gate proven to fail before being trusted

| case | exit |
|---|---|
| complete fixture | 0, prints the translated version |
| changelog heading missing | 1 |
| a core tag at the bridge gate | 1 |
| committed `repositories` entry | 1 |
| `@dev` core constraint | 1 |

`bridge_release_gate.py` anchors a bridge tag to the package changelog's `## [X.Y.Z]` — a Composer library carries no version constant for `release_gate.py` to check.

## The honest state of it

**Most of this pipeline has never run and cannot until a core release exists** — the signature check, the release-mode install, the subtree split, the cross-repository push. That's the third item running (7.2, 7.3, 8.3) shipping machinery whose first real run is its first real use. What can be tested away from a tag has been: the gate's five cases, both ref-shape guards, the YAML, 36 pins across four workflows. A `workflow_dispatch` dry run lets you exercise the gates against a tag without cutting a version.

## What you need to configure (documented in `docs/workflow/release.md`)

- a **split repository**, empty and treated as read-only;
- repository variable **`BRIDGE_SPLIT_REPO`** (`owner/name`);
- secret **`BRIDGE_SPLIT_TOKEN`** with write access to it — `GITHUB_TOKEN` cannot write to another repository;
- Packagist registration for `egl/utils-psr7-bridge`, pointing at the split repo.

Missing configuration fails *after* the gates pass, so the message distinguishes "not configured" from "the release is bad".

## Bar

1312 tests / 2973 assertions; the bridge package's 65 / 202 across both PSR-17 implementations. PHPStan max clean, deptrac 0/0, PHP-CS-Fixer clean, consistency lint OK, 36 action pins verified upstream.

Also included: the **item 8.2 run record**, which I never wrote — I went from opening PR #47 straight to watching CI and skipped the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
