### PR TITLE
docs(plan): negotiate milestones 9-12 from RFC-0002 — 22 routed items

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ setup.
 | 5 | Security | ✅ done |
 | 6 | HTTP, container, errors | ✅ done |
 | 7 | Release engineering & bridge | ✅ done |
-| 8 | PSR-7 bridge (`packages/utils-psr7-bridge`) | ⏳ planned |
+| 8 | PSR-7 bridge (`packages/utils-psr7-bridge`) | ✅ done |
+| 9 | Support & values | ⏳ planned |
+| 10 | Persistence | ⏳ planned |
+| 11 | Http application layer | ⏳ planned |
+| 12 | Security & channels | ⏳ planned |
 
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,11 +10,20 @@ Negotiated at the `plan` phase (2026-08-03) from **RFC-0001** — the only appro
 protocol; scope confirmed in full by the owner. Milestones are **sequential** (solo-owner
 capacity; no parallel streams; no calendar dates by decision).
 
+Extended at a second `plan` pass (2026-08-06) from **RFC-0002**
+([docs/rfc/0002-application-layer-groups-from-legacy-intake.md](docs/rfc/0002-application-layer-groups-from-legacy-intake.md),
+approved 2026-08-05 at PR #49) by the same three-role protocol — all roles worn by the
+session agent, per-artifact authority checked and recorded in the journal; scope = RFC-0002's
+decision in full, owner-confirmed by the RFC approval and the explicit plan instruction.
+**M9–M12 map to core versions `v0.8.0`–`v0.11.0`** (M8 was bridge-scoped and consumed no core
+minor); the standing post-M7 **1.0.0 API-freeze review** may re-map them to 1.x MINORs — the
+items are additive either way, so the mapping shifts without rework.
+
 - **Versioning start:** pre-1.0 milestone-driven — one minor per milestone
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-05 — When the standing pattern is the wrong one](docs/journal/2026/08/2026-08-05-bridge-publish.md).
+  [2026-08-06 — Four milestones from one RFC, and the routes came from the policy](docs/journal/2026/08/2026-08-06-plan-rfc-0002.md).
 
 ## Model & effort routing (advisory)
 
@@ -565,6 +574,121 @@ API-freeze review for the **core** is unaffected by this milestone.
 
 ---
 
+## Milestone 9 — Support & values (`v0.8.0`) · size: M
+
+The foundation additions RFC-0002's later groups consume (`Str::transcode` feeds
+`RowNormalizer`, `File`'s lock discipline feeds `FileSequence`); pure additive Support
+surface (RFC-0002 FR-27…FR-32).
+
+- [ ] 9.1 `Str` additions: `collapseWhitespace()`, `nullIfBlank()`, `transcode()` (strict by
+      default, lossy opt-in), multibyte-safe `padLeft()`/`padRight()`, `shortClassName()`,
+      `pascalCase()` (RFC-0002 FR-31) — size: S · route: fast / low
+- [ ] 9.2 `Lookup`: immutable code→label map with an explicit missing-key policy — `label()`
+      throws, `labelOr()`/`tryLabel()` for the tolerant reads; replaces silent sentinel
+      strings (RFC-0002 FR-30) — size: XS · route: fast / low
+- [ ] 9.3 `Url` value object: parse/normalize/build, query composition, **scheme-downgrade
+      refusal on rebuild** (RFC-0002 FR-27) (security) — size: S ·
+      route: frontier-reasoning / extra · ADR (URL scheme policy)
+- [ ] 9.4 `Csv` streaming write/read + `Delimiter` enum + `CsvSerializable`; typed failures
+      (never boolean), atomic write via `File`; formula-guard **opt-in, default off**, both
+      flag states tested (RFC-0002 FR-28/FR-29; T-08) (security) — size: M ·
+      route: frontier-reasoning / extra · ADR (formula-guard default)
+- [ ] 9.5 `FileSequence`: rolling lock-guarded counter with an explicit cap policy
+      (`SequenceExhaustedException`, never a silent wrap) + T-14 multi-process concurrency
+      suite (RFC-0002 FR-32; T-14) (severity:medium — concurrency/atomicity) — size: S ·
+      route: standard / medium
+- [ ] 9.6 phpbench: NFR-12 (Csv streaming) + NFR-10 (FileSequence) wired into the ADR-0030
+      same-runner harness (RFC-0002) (step:optimize) — size: S · route: fast / medium
+
+---
+
+## Milestone 10 — Persistence (`v0.9.0`) · size: L
+
+RFC-0002's centerpiece: the layer that makes value-interpolated SQL a library-impossible
+shape (the surveyed estate measured 199 interpolation sites against 0 bound parameters).
+First two named cross-group deptrac edges (RFC-0002 P-1).
+
+- [ ] 10.1 `Database\SqlStatement`: immutable SQL+binds value; connection-side execution
+      accepts **only** statements — text never travels without its parameters
+      (RFC-0002 FR-33) (security — the protected floor) — size: S ·
+      route: frontier-reasoning / extra · ADR (statement-only execution)
+- [ ] 10.2 `Persistence\RowNormalizer` policy object (strict/lossy transcode, trim,
+      empty→`null`) + T-15 policy table + the `Persistence` deptrac layer (edge to Support
+      only at this point) (RFC-0002 FR-36; T-15) (severity:medium) — size: S ·
+      route: standard / medium
+- [ ] 10.3 `Persistence\Repository` base gateway (`fetchAll`/`fetchOne`/`execute`/
+      `withTransaction`; rows normalized then hydrated via the shared Hydrator; every failure
+      throws — no sentinel returns) + the two named cross-group edges
+      (Persistence→Database, Persistence→Dto) proved by planted violations
+      (RFC-0002 FR-34, P-1) (severity:high; adr — the layering-rule extension) — size: M ·
+      route: frontier-reasoning / extra · ADR (Persistence layering edges)
+- [ ] 10.4 `Persistence\TableGateway`: Table Data Gateway over `QueryBuilder` —
+      select/insert/update/delete with allowlisted identifiers and bound values by
+      construction + patterns-catalogue adoption entry (RFC-0002 FR-35) (security) —
+      size: M · route: frontier-reasoning / extra · ADR (pattern adoption)
+- [ ] 10.5 T-13 injection suite over the gateway/statement paths: ADR-0017's 29-payload
+      corpus re-run through `Repository`/`TableGateway`, placeholder-only text asserted at
+      the PDO boundary via the `QueryLog` fixture (RFC-0002 T-13) (security) — size: M ·
+      route: frontier-reasoning / extra
+- [ ] 10.6 phpbench: NFR-09 gateway-vs-hand-written-PDO ratio (`bench_ratio_gate` pattern,
+      ADR-0011 precedent) (RFC-0002) (step:optimize) — size: S · route: fast / medium
+
+---
+
+## Milestone 11 — Http application layer (`v0.10.0`) · size: M
+
+The console-side trio: client, router, envelope (RFC-0002 FR-37…FR-39).
+
+- [ ] 11.1 `HttpClient`: stream-context transport (no ext-curl), JSON/raw bodies, **TLS
+      verification on by default**, explicit connect/read timeouts, typed
+      `HttpClientException`; deliberately not PSR-18 (RFC-0002 FR-37) (security) — size: M ·
+      route: frontier-reasoning / extra · ADR (transport TLS/timeout policy)
+- [ ] 11.2 `Router`: method+path matcher with `{param}` extraction, **404-vs-405 with
+      `Allow`**, callable handlers; stated non-goals (no middleware, no cache, no attribute
+      discovery) + T-11 matrix + Front Controller catalogue adoption + the endpoint-kernel
+      pattern doc (RFC-0002 FR-38; T-11) (adr — pattern adoption) — size: M ·
+      route: frontier-reasoning / extra · ADR
+- [ ] 11.3 `ApiEnvelope`: readonly envelope value, fixed JSON shape (`status`, `code`,
+      `messages`, `data`), outcome constructors (ok/created/updated/deleted/empty/invalid/
+      notFound/failed/caught); message strings caller-supplied, `Result`-mapping stays a
+      documented app-side pattern (RFC-0002 FR-39) (severity:medium — consumer-visible API
+      shape) — size: S · route: standard / medium
+- [ ] 11.4 T-07 `HttpClient` behavioural suite against a live `php -S` origin (timeout,
+      refusal and error-taxonomy paths; T-03's process discipline) (RFC-0002 T-07)
+      (security) — size: M · route: frontier-reasoning / extra
+- [ ] 11.5 phpbench: NFR-11 (router dispatch at 50 routes; envelope build) (RFC-0002)
+      (step:optimize) — size: XS · route: fast / medium
+
+---
+
+## Milestone 12 — Security & channels (`v0.11.0`) · size: M
+
+AEAD crypto, PSR-3 channel composition, and the Mail group (RFC-0002 FR-40…FR-44).
+
+- [ ] 12.1 `Crypto` + `SecretKey`: AES-256-GCM, versioned `v1.` base64url token, `decrypt()`
+      **throws** `CryptoException` on any failure (wrong key, tamper, malformed token);
+      ext-openssl suggested with constructor refusal when absent (ADR-0021/ADR-0022
+      pattern); `#[SensitiveParameter]` on secret-bearing signatures (RFC-0002 FR-40)
+      (security) — size: M · route: frontier-reasoning / extra · ADR (AEAD replaces
+      unauthenticated CBC)
+- [ ] 12.2 T-09 crypto suite: tamper/wrong-key/truncation vectors, nonce uniqueness across
+      10⁵ tokens, version-prefix handling (RFC-0002 T-09) (security) — size: S ·
+      route: frontier-reasoning / extra
+- [ ] 12.3 Logging channels: `Level` enum (PSR-3 mapping + ordering), `LevelFilteredLogger`,
+      `MultiLogger`, `LoggerFactory` (one config array → channel map), PSR-3-pure (no
+      Monolog dependency, NFR-08) + T-12 routing matrix + NFR-14 bench
+      (RFC-0002 FR-41/FR-42; T-12) (severity:medium) — size: M · route: standard / medium
+- [ ] 12.4 `Mail` group: `EmailAddress` (validated), `MailMessage` (**CR/LF/NUL in
+      header-bound values refused at construction**), `Mailer` + `NativeMailer` (explicit
+      constructor config, no global `ini_set`), `MailException`, the Mail deptrac layer
+      (Support-only edge) + T-10 header-injection corpus (RFC-0002 FR-43/FR-44; T-10)
+      (security) — size: M · route: frontier-reasoning / extra · ADR (header-injection
+      refusal + transport non-goals)
+- [ ] 12.5 phpbench: NFR-13 (crypto 1 KiB round-trip) (RFC-0002) (step:optimize) — size: XS ·
+      route: fast / medium
+
+---
+
 ## Spec Coverage Map
 
 Tracks which spec section is fulfilled by which roadmap item(s). Sections follow the frozen
@@ -574,11 +698,11 @@ Legend: ⏳ not started · 🚧 in progress · ✅ done · ❎ N/A.
 | Spec § | Requirement | Roadmap items | Status |
 |--------|-------------|---------------|--------|
 | §1 | Objective & design philosophy | 1.1, 1.6 | ✅ |
-| §2 | Functional items 1–25 (+9b) | 2.1–2.5, 3.1–3.3, 4.1–4.3, 5.1–5.3, 6.1–6.2, 6.4–6.5 | ✅ |
-| §3 | Architecture & layering (deptrac) | 1.1, 1.6, 2.1, 2.5 | ✅ |
-| §4 | NFR budgets & benchmark methodology | 3.5, 4.5, 5.5, 6.4, 7.1 | ✅ |
-| §5 | Security test criteria | 4.4, 5.4, 5.5, 6.3 | ✅ |
-| §6 | API example / public interface | 1.6, 3.1 | ✅ |
-| §7 | Verification & test strategy (r2) | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3, 8.2 | 🚧 |
+| §2 | Functional items 1–25 (+9b); r3 adds FR-27–44 (RFC-0002) | 2.1–2.5, 3.1–3.3, 4.1–4.3, 5.1–5.3, 6.1–6.2, 6.4–6.5; 9.1–9.5, 10.1–10.4, 11.1–11.3, 12.1, 12.3–12.4 | 🚧 |
+| §3 | Architecture & layering (deptrac); r3 adds Persistence/Mail + named edges | 1.1, 1.6, 2.1, 2.5, 10.2–10.3, 12.4 | 🚧 |
+| §4 | NFR budgets & benchmark methodology; r3 adds NFR-09–14 | 3.5, 4.5, 5.5, 6.4, 7.1, 9.6, 10.6, 11.5, 12.5 | 🚧 |
+| §5 | Security test criteria; r3 adds T-08/09/10/13 | 4.4, 5.4, 5.5, 6.3, 9.4, 10.5, 11.4, 12.2, 12.4 | 🚧 |
+| §6 | API example / public interface | 1.6, 3.1, 10.3–10.4, 11.3 | 🚧 |
+| §7 | Verification & test strategy (r3) | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3, 8.2, 9.5, 10.2, 10.5, 11.2, 11.4, 12.2–12.3 | 🚧 |
 | §8 | CI/CD & release engineering | 1.4, 1.7, 7.1–7.3, 8.3 | 🚧 |
-| §9 | Decision log (imported + seeded ADRs) | 2.1, 5.3, 7.4 | ✅ |
+| §9 | Decision log (imported + seeded ADRs); r3 items carrying ADRs | 2.1, 5.3, 7.4, 9.3–9.4, 10.1, 10.3–10.4, 11.1–11.2, 12.1, 12.4 | 🚧 |

--- a/docs/journal/2026/08/2026-08-06-plan-rfc-0002.md
+++ b/docs/journal/2026/08/2026-08-06-plan-rfc-0002.md
@@ -1,0 +1,55 @@
+# 2026-08-06 — Four milestones from one RFC, and the routes came from the policy
+
+The `plan` phase, second pass, run on the owner's instruction the evening RFC-0002 was
+approved (PR #49). The negotiation protocol's three roles were all worn by the session
+agent — which is exactly the situation the per-artifact authority checks exist for, so each
+hat was verified before its artifact was touched: `producer` → `ROADMAP.md` (OK; and
+DENIED for `README.md`, correctly), `tech-lead` → `docs/specs/01_spec_utils.md` (OK),
+`enterprise-architect` → `orchestrator/project.yaml`, `README.md`, the journal (OK). The
+denial is worth recording: the authority model distinguished the hats even when one agent
+wears them all.
+
+## The negotiation, compressed honestly
+
+**Priorities (product-manager):** Persistence carries the business case — the surveyed
+estate's 199 interpolation sites against 0 bound parameters is the live risk — but
+**engineering dependency reorders it second**: `RowNormalizer` consumes `Str::transcode`,
+`FileSequence` consumes `File`'s lock discipline, so Support & values goes first as M9.
+Then M10 Persistence, M11 the Http application layer, M12 Security & channels. Sequential,
+solo-owner capacity, no dates — unchanged from the first pass.
+
+**Sizes and routes (tech-lead):** 22 items, XS–M each, milestones M/L/M/M. Routes were not
+asserted from memory: `route_advice.py --labels` resolved each signal set offline —
+`security → frontier-reasoning/extra`, `adr → frontier-reasoning/extra`,
+`severity:medium → standard/medium`, `severity:high → standard/high`, floor `fast/low`,
+`step:optimize → fast/medium`. Ten of twenty-two items carry the security floor, which is
+what an RFC born from an injection survey should look like.
+
+**Reconciliation (producer):** M9–M12 map to core `v0.8.0`–`v0.11.0` — M8 was bridge-scoped
+and consumed no core minor. The standing post-M7 **1.0.0 API-freeze review** is deliberately
+left able to re-map these to 1.x MINORs; every item is additive, so the mapping shifts
+without rework. Scope is RFC-0002's decision in full: the owner confirmed it by approving
+the RFC and instructing the plan run, and their cut right remains live at PR review.
+
+## What changed where
+
+`ROADMAP.md` (+M9–M12, preamble note, Spec Coverage Map extended — seven rows go 🚧, which
+is the honest cost of a spec that just grew); `docs/specs/01_spec_utils.md` → **r3**
+(FR-27…FR-44, NFR-09…14, T-07…15, the two named layering edges — additive, no existing
+requirement changed); `README.md` milestone table (+9–12, and M8 flipped to done — it was
+stale, all three 8.x items being checked); `orchestrator/project.yaml` `manifest_rev` 6,
+`refs.rfcs` + RFC-0002, `refs.milestones` + M8–M12 (M8 was missing from the refs ledger;
+housekeeping done under the state-writer hat and said out loud here).
+
+## The gate, and the one that cannot fire
+
+`traceability.py` (roadmap-covers-rfcs) passes for RFC-0001 + RFC-0002. The phase ledger
+itself stays untouched: the machine sits at `scaffold` with `→ audit` as its only legal
+move, so there is no `plan → scaffold` checkpoint to propose from here — the second time
+this gap is recorded rather than papered over (RFC-0002 Consequences said it first). The
+owner routes the formal phase; the artifacts the plan phase owes are all delivered.
+
+## Lesson
+
+Resolve routes with the policy tool even when you are sure — agreement is cheap to prove
+and disagreement is exactly the information you need before the roadmap hardens it.

--- a/docs/specs/01_spec_utils.md
+++ b/docs/specs/01_spec_utils.md
@@ -3,7 +3,7 @@
 > Rendered from the intake interview (Phase 5). Frozen contract: diverging implementation
 > updates this spec in the same PR or adds an ADR superseding the relevant section.
 
-**Revision r2** — 2026-08-05. See [Revision history](#revision-history).
+**Revision r3** — 2026-08-06. See [Revision history](#revision-history).
 
 ## 1. Objective & Business Context
 
@@ -36,6 +36,32 @@ Provide EGL PHP projects (framework-based and native/legacy) with a modern utili
 - FR-25 Json: encode()/decode() with JSON_THROW_ON_ERROR; library JsonException wraps and rethrows PHP's native \JsonException (RFC-0001 R-7)
 - FR-26 Exception hierarchy: UtilsException <- DatabaseException, HydrationException (<- UnknownKeyException, TypeMismatchException, MissingKeyException), HttpException, FileException, JsonException
 
+**r3 addendum (RFC-0002)** — normative detail in
+[RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md); one error-model rule
+spans all of it: **no silent sentinel returns** — every new failure path throws a typed
+exception in the FR-26 hierarchy (new: CsvException, SequenceExhaustedException,
+HttpClientException, RouteNotFoundException, MethodNotAllowedException, CryptoException,
+MailException).
+
+- FR-27 Url: parse/normalize/build value object; refuses scheme downgrade on rebuild; query composition without hand-concatenation
+- FR-28 Csv + Delimiter enum: streaming write/read, typed failures (never boolean), atomic write via File; formula-guard opt-in (default off — input-mutilation lesson, spec §1)
+- FR-29 CsvSerializable: csvHeader()/csvRow() contract; reflective default documented via ClassMetadata
+- FR-30 Lookup: immutable code→label map; label() throws on a missing key, labelOr()/tryLabel() tolerant
+- FR-31 Str additions: collapseWhitespace(), nullIfBlank(), transcode() (strict default, lossy opt-in), multibyte-safe padLeft()/padRight(), shortClassName(), pascalCase()
+- FR-32 FileSequence: rolling flock-guarded counter with an explicit cap (SequenceExhaustedException); never wraps silently
+- FR-33 SqlStatement (Database): immutable SQL+params value — the only shape connection-side execution accepts; hand-written dialect SQL always travels with its binds
+- FR-34 Repository (Persistence): fetchAll/fetchOne/execute/withTransaction; rows normalized (FR-36) then hydrated via the shared Hydrator; every failure throws DatabaseException
+- FR-35 TableGateway (Persistence): Table Data Gateway over QueryBuilder — identifiers allowlisted, values bound, by construction
+- FR-36 RowNormalizer (Persistence): strict/lossy charset transcode + trim + empty→null as one explicit, testable policy object
+- FR-37 HttpClient: stream-context transport (no ext-curl), JSON/raw bodies, TLS verification on by default, explicit connect/read timeouts, HttpClientException; deliberately not PSR-18 (native wrappers + optional bridge, RFC-0001 Alt. #3)
+- FR-38 Router: method+path matching with {param} extraction; 404 vs 405 with Allow; callable handlers; non-goals: middleware, route caching, attribute discovery
+- FR-39 ApiEnvelope: readonly envelope (status, code, messages, data) with outcome constructors (ok/created/updated/deleted/empty/invalid/notFound/failed/caught); message strings caller-supplied — localization stays app-side
+- FR-40 Crypto + SecretKey: AES-256-GCM, versioned v1. base64url compact token; decrypt() throws CryptoException on any failure; ext-openssl suggested with constructor refusal when absent; #[SensitiveParameter] on secret-bearing signatures (inert on the 8.1 floor, effective 8.2+)
+- FR-41 Level + LevelFilteredLogger: backed enum mapping to PSR-3 level strings with ordering; min-level PSR-3 decorator
+- FR-42 MultiLogger + LoggerFactory: PSR-3 fan-out over N loggers; one config array → channel map; no Monolog dependency (NFR-08)
+- FR-43 EmailAddress + MailMessage: validated address value object; readonly message; CR/LF/NUL in any header-bound value refused at construction (SMTP header-injection defense)
+- FR-44 Mailer + NativeMailer: transport interface + mail() implementation configured explicitly via constructor (no global ini_set); failures throw MailException; non-goal: an SMTP client implementation
+
 
 ## 3. Non-Functional Requirements
 
@@ -50,6 +76,16 @@ Provide EGL PHP projects (framework-based and native/legacy) with a modern utili
 - NFR-06 Benchmark methodology: phpbench, 10 iterations x 100 revs, 5% retry threshold, PHP 8.3 CLI with OPcache+JIT off, reference machine Ryzen 7 5800X, harness in bench/, nightly CI; regression > 10% fails
 - NFR-07 Quality gates: PHPUnit line coverage >= 90%; Infection mutation score >= 70% on Security/Database/Dto namespaces; PHPStan max level; deptrac layer rules; composer-normalize; composer audit; roave/backward-compatibility-check on release PRs
 - NFR-08 Dependency policy: no third-party implementation dependencies in the core (php>=8.1 + ext-pdo + ext-fileinfo; interface-only psr/container and psr/log excepted — RFC-0001 R-3 correction); symfony/html-sanitizer and the PSR-7 bridge are optional
+
+**r3 addendum (RFC-0002)** — advisory until first measured under the NFR-06/ADR-0030 harness:
+
+- NFR-09 Repository/TableGateway: fetch + normalize + hydrate 100 rows <= 1.5x a hand-written PDO loop doing the same work
+- NFR-10 FileSequence::next() <= 200 us on local disk, lock included
+- NFR-11 Router dispatch <= 5 us against a 50-route table; ApiEnvelope construction <= 2 us
+- NFR-12 Csv: 10 000 x 10 write <= 150 ms, memory O(row) (streaming, never a full-table buffer)
+- NFR-13 Crypto: 1 KiB encrypt+decrypt round-trip <= 60 us
+- NFR-14 Logger fan-out: a level-suppressed record costs <= 0.5 us
+- Declared unbudgeted (NFR-05's rationale): HttpClient and NativeMailer latency — network/MTA-dominated; their budgets are the T-07/T-10 correctness suites
 
 
 ## 4. Logical Architecture & Core Algorithm
@@ -71,6 +107,14 @@ deptrac layer globs are defined against that exact tree (RFC-0001 A-9). Mixed-ve
 (package egl/utils, namespace D4np\Utils\) is a recorded maintainer decision (RFC-0001
 Alternatives #5) and must be stated in composer.json and the README.
 
+**r3 (RFC-0002):** two groups join the component view — **Persistence** (`Repository`,
+`TableGateway`, `RowNormalizer`, consuming `Database\SqlStatement`) and **Mail**
+(Support-only edge) — plus additions inside Support/Database/Http/Security/Errors. The
+dependency rule gains its **first two named cross-group edges**, `Persistence→Database` and
+`Persistence→Dto`, allowlisted in deptrac, proved by planted violations, and recorded by ADR
+at implementation (RFC-0002 P-1; ADR-0021's named-layer precedent). The `Result`→`ApiEnvelope`
+mapping is deliberately app-side glue: an `Http→Errors` import would breach the rule.
+
 ## 5. Public Interface
 
 <!-- The API contract (the design "api" fold): each operation with its payload shapes, the error
@@ -86,10 +130,25 @@ Consumers import via `use D4np\Utils\Dto\DataTransferObject;`. The public surfac
 - D4np\Utils\Errors\ — Result::map/flatMap/orElseThrow, PSR-3 Logger, ExceptionHandler
 - D4np\Utils\Support\ — Str::slug/uuid/random, File::write/read/mime, Env::get, Json::encode/decode, UtilsException hierarchy
 
+r3 (RFC-0002) additions:
+
+- D4np\Utils\Persistence\ — Repository (fetchAll/fetchOne/execute/withTransaction), TableGateway (select/insert/update/delete), RowNormalizer
+- D4np\Utils\Mail\ — EmailAddress, MailMessage, Mailer, NativeMailer
+- D4np\Utils\Database\ — + SqlStatement · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, Str additions (FR-31)
+
 
 ## 6. Verification & Test Strategy
 
 Five suites (spec s7): T-01 DTO hydration matrix (nested, collections, nullables, enums, strict/lenient, withers, missing-key cases per RFC-0001 R-4); T-02 injection suite (fuzzed value payloads reach the driver only as bound parameters via query-log assertion; identifier injection throws DatabaseException; LIKE-wildcard escapes); T-03 session/CSRF integration against a real php -S process (cookie flags HttpOnly/Secure/SameSite, session id changes across regenerate() and the pre-rotation identifier ceases to resolve, constant-time comparison verified by mechanism assertion per ADR-0026 §7 — positively, that `hash_equals()` is the comparator on every secret-comparison path, and negatively, that `==`, `===`, `strcmp()`, `strncmp()` and equivalents are absent from those paths — cross-session token rejection); T-04 transaction semantics (exception -> rollback -> rethrow; savepoint nesting); T-05 property tests (Json round-trips, Str::slug idempotence, Env boolean coercion table). Plus: OWASP XSS cheat-sheet corpus per Escaper context (snapshot suite); DOM-bypass corpus for richText(); Hash argon2id/bcrypt-fallback matrix; bridge conversion-fidelity contract tests in egl/utils-psr7-bridge CI (imported ADR-002). CI proves failure via the NFR-07 gate set.
+
+**r3 (RFC-0002)** adds nine suites: T-07 HttpClient against a live `php -S` origin (T-03's
+process discipline); T-08 Csv property/round-trip + formula-guard corpus, both flag states;
+T-09 Crypto vectors — tamper, wrong key, truncation, nonce uniqueness across 10^5 tokens,
+version-prefix handling; T-10 mail header-injection corpus; T-11 router matrix
+(404/405/Allow/params); T-12 logger routing matrix; T-13 gateway/statement injection —
+ADR-0017's 29-payload corpus re-run through Repository/TableGateway with the
+placeholder-only PDO-boundary assertion; T-14 FileSequence under concurrent processes (no
+duplicates, cap enforced); T-15 RowNormalizer policy table.
 
 Toolchain: built with Composer (PSR-4 autoload), tested with PHPUnit (Pest optional), checked with
 PHPStan max level (type soundness); PCOV for coverage, coverage target ≥ 90% line. Every functional and
@@ -102,6 +161,7 @@ non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.y
 |-----|------|--------|
 | r1 | 2026-08-03 | Frozen from the imported `.specs/d4np-php.md` v2.0 via RFC-0001 (naming mapping A-7). |
 | r2 | 2026-08-05 | §6/T-03: the `hash_equals` **timing test** is replaced by a **mechanism assertion**. Rationale below; see [ADR-0027](../adr/0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md). |
+| r3 | 2026-08-06 | §2–§6: the RFC-0002 surface — FR-27…FR-44, NFR-09…NFR-14, suites T-07…T-15, the Persistence/Mail groups and the two named layering edges. Additive; no existing requirement changed. Source: [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) (approved 2026-08-05, PR #49); roadmap: M9–M12. |
 
 ### r2 rationale — why T-03 asserts a mechanism instead of measuring time
 

--- a/orchestrator/project.yaml
+++ b/orchestrator/project.yaml
@@ -9,7 +9,7 @@
 # .eados-core/orchestrator/project.yaml.template
 
 schema_version: 1
-manifest_rev: 5
+manifest_rev: 6
 domain: software             # Q0.4 development target -> .eados-core/orchestrator/domains/software.yaml
 
 delivery_state:
@@ -18,7 +18,7 @@ delivery_state:
     - { from: init, to: design, gates: ['manifest-valid'], at: 2026-08-03, confirmed_by: danielPoloWork, gate_results: { manifest-valid: OK } }
     - { from: design, to: plan, gates: ['rfc-approved'], at: 2026-08-03, confirmed_by: danielPoloWork, gate_results: { rfc-approved: OK } }
     - { from: plan, to: scaffold, gates: ['roadmap-covers-rfcs'], at: 2026-08-03, confirmed_by: danielPoloWork, gate_results: { roadmap-covers-rfcs: OK } }
-  refs: { rfcs: ['RFC-0001'], milestones: ['M1', 'M2', 'M3', 'M4', 'M5', 'M6', 'M7'], prs: [1], releases: [] }
+  refs: { rfcs: ['RFC-0001', 'RFC-0002'], milestones: ['M1', 'M2', 'M3', 'M4', 'M5', 'M6', 'M7', 'M8', 'M9', 'M10', 'M11', 'M12'], prs: [1], releases: [] }
 
 identity:
   project_name:    "egl-util-php"        # carried from the existing GitHub repository


### PR DESCRIPTION
## Summary

The **plan phase, second pass**: RFC-0002 (approved at #49) becomes four negotiated
milestones — **M9 Support & values (`v0.8.0`), M10 Persistence (`v0.9.0`), M11 Http
application layer (`v0.10.0`), M12 Security & channels (`v0.11.0`)** — 22 pre-numbered,
routed items, plus spec 01 → **r3** and the manifest cross-links.

## Motivation

`/eados plan`, run on the owner's instruction immediately after RFC-0002's approval. The
negotiation protocol ran with all three roles worn by the session agent and **per-artifact
authority checked** (producer → ROADMAP; tech-lead → spec; enterprise-architect → README,
manifest, journal — the producer was correctly DENIED on README, which is the model
working). Routes were resolved **offline against the `os/routing` policy** with
`route_advice.py`, not asserted from memory: `security → frontier-reasoning/extra`,
`adr → frontier-reasoning/extra`, `severity:medium → standard/medium`, floor `fast/low`,
`step:optimize → fast/medium`. Ten of twenty-two items carry the security floor — the
expected shape for an RFC born from an injection survey (199 interpolation sites, 0 bound
parameters).

Ordering is dependency-honest: Persistence carries the business case but consumes M9
(`Str::transcode` → `RowNormalizer`; `File` locking → `FileSequence`), so Support & values
goes first and the live-risk milestone lands as early as its dependencies allow.

## Changes

- **ROADMAP.md** — preamble note for the second plan pass; M9–M12 with 22 items, each
  referencing RFC-0002 and carrying size + route; Spec Coverage Map extended (seven rows go
  🚧 — the honest cost of a spec that just grew); latest-journal pointer.
- **docs/specs/01_spec_utils.md → r3** — FR-27…FR-44, NFR-09…NFR-14 (plus the two declared
  unbudgeted surfaces), suites T-07…T-15, the Persistence/Mail architecture delta with the
  two named layering edges. **Additive; no existing requirement changed.**
- **orchestrator/project.yaml** — `manifest_rev` 6; `refs.rfcs` + RFC-0002;
  `refs.milestones` + M8–M12 (M8 was missing from the refs ledger — housekeeping under the
  state-writer hat, stated rather than slipped in).
- **README.md** — milestone table + rows 9–12; M8's stale "⏳ planned" corrected to
  "✅ done" (all three 8.x items are checked).
- **docs/journal/2026/08/2026-08-06-plan-rfc-0002.md** — the session checkpoint, including
  the full negotiation record.

**Versioning note:** M9–M12 assume the pre-1.0 minor-per-milestone line continues (M8 was
bridge-scoped and consumed no core minor). The standing **post-M7 1.0.0 API-freeze review**
can re-map them to 1.x MINORs — every item is additive, so the mapping shifts without
rework. That review remains the owner's call and is deliberately not scheduled here.

**Governance note (recorded, not resolved):** the phase ledger sits at `scaffold`, whose
only legal move is `→ audit` — there is no `plan → scaffold` checkpoint to propose from
here. Second time recorded (RFC-0002's Consequences said it first); the owner routes the
formal phase.

## Design Patterns

- None adopted in this PR (planning artifacts only). The roadmap **schedules** two adoptions
  with their ADRs and catalogue entries: *Table Data Gateway* (item 10.4) and *Front
  Controller* (item 11.2), per §8's ADR+code discipline.

## Verification

- [x] `python .eados-core/tools/traceability.py ROADMAP.md RFC-0001 RFC-0002` —
      **roadmap-covers-rfcs OK** (RFC-0001 → M1–M7; RFC-0002 → M9–M12)
- [x] `python tools/consistency_lint.py` passes (spec-map, README↔ROADMAP milestones, ADR
      index, all invariants)
- [x] Leak-gate grep over the staged diff: zero matches for estate identifiers
- [ ] Build matrix / unit tests / formatter / static analysis — N/A, no code in this PR

## Documentation Impact

- [x] README.md updated (milestone table)
- [x] ROADMAP.md updated (this PR's deliverable)
- [ ] ADR — none; the RFC-0002 ADRs land with their implementation items (six are scheduled)
- [ ] docs/patterns/README.md — unchanged (adoptions scheduled, not performed)
- [x] Spec updated — r3, additive
- [ ] CHANGELOG.md — unchanged (no user-visible library change)
- [x] PR metadata — assignee (owner); label `documentation`; **no milestone** (phase work,
      #48 precedent). After merge, the GitHub milestones `v0.8.0`–`v0.11.0` get seeded from
      the ROADMAP per `github-setup.md` §5, and M9's first item PR carries `v0.8.0`.

## Lesson

Lesson: resolve routes with the policy tool even when you are sure — agreement is cheap to
prove, and disagreement is exactly the information you need before the roadmap hardens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
