### PR TITLE
feat(support): six Str additions per FR-31, opening Milestone 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **Six `Str` additions** (spec r3 **FR-31**, RFC-0002; roadmap item **9.1**) —
+  `collapseWhitespace()` (ASCII-scope, UTF-8-safe by construction), `nullIfBlank()`
+  (judges blankness, mutates nothing), `transcode()` (**strict by default** — lossy
+  conversion is an explicit opt-in flag, and a missing `ext-iconv` is a clear refusal
+  rather than silent degradation; unknown encodings are named distinctly from
+  unconvertible data), multibyte-safe `padLeft()`/`padRight()` (PHP 8.3
+  `mb_str_pad()`-compatible semantics; code points counted via PCRE, no mbstring
+  dependency), `shortClassName()` (deterministic `class@anonymous` for anonymous classes —
+  their runtime names embed a platform-shaped file path), and `pascalCase()`
+  (ASCII case mapping, multibyte pass-through, deliberately not idempotent and documented
+  as such). `ext-iconv` joins composer `suggest`.
+
 - **The PSR-7 bridge's publication pipeline** (**ADR-0035**, spec 02 r3) —
   `.github/workflows/bridge-release.yml` and `tools/bridge_release_gate.py`, closing Milestone 8.
   On a `utils-psr7-bridge-vX.Y.Z` tag it verifies the tag is annotated and signed (ADR-0032's

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — Four milestones from one RFC, and the routes came from the policy](docs/journal/2026/08/2026-08-06-plan-rfc-0002.md).
+  [2026-08-06 — The first RFC-0002 item, and three failures that earned their keep](docs/journal/2026/08/2026-08-06-str-additions.md).
 
 ## Model & effort routing (advisory)
 
@@ -580,9 +580,25 @@ The foundation additions RFC-0002's later groups consume (`Str::transcode` feeds
 `RowNormalizer`, `File`'s lock discipline feeds `FileSequence`); pure additive Support
 surface (RFC-0002 FR-27…FR-32).
 
-- [ ] 9.1 `Str` additions: `collapseWhitespace()`, `nullIfBlank()`, `transcode()` (strict by
+- [x] 9.1 `Str` additions: `collapseWhitespace()`, `nullIfBlank()`, `transcode()` (strict by
       default, lossy opt-in), multibyte-safe `padLeft()`/`padRight()`, `shortClassName()`,
-      `pascalCase()` (RFC-0002 FR-31) — size: S · route: fast / low
+      `pascalCase()` (RFC-0002 FR-31) — size: S · route: fast / low *(run at frontier;
+      mismatch recorded)*. *Three of the item's own first-run test failures each taught
+      something now pinned from both sides: `str_pad('héllo', 7)` emits **7 bytes rendering
+      as 6 characters** (the byte-count defect these methods exist to fix); `pascalCase()`
+      is **deliberately not idempotent** (an already-Pascal input is one word — `strtolower`
+      flattens it, asserted as documented behavior); and an anonymous class's runtime name
+      embeds the defining **file path, backslash-separated on Windows**, so
+      `shortClassName()` answers the literal `class@anonymous` instead of a
+      platform-dependent path fragment. `transcode()` distinguishes unknown-encoding from
+      unconvertible-data by probing the pair on the empty string (iconv reports both as
+      `false`); ext-iconv is `suggest`ed with the ADR-0021/0022 refusal pattern — the guard
+      branch is probe-verified, not permanently tested (5.2's standing precedent). Padding
+      follows PHP 8.3 `mb_str_pad()` semantics (native migration stays behavior-neutral),
+      counting code points via PCRE — no mbstring dependency. **No new exception type:**
+      strict `transcode()` failures throw `UtilsException` with precise messages — spec r3's
+      exception enumeration is the contract; a finer type waits for a consumer who needs the
+      distinct catch.*
 - [ ] 9.2 `Lookup`: immutable code→label map with an explicit missing-key policy — `label()`
       throws, `labelOr()`/`tryLabel()` for the tolerant reads; replaces silent sentinel
       strings (RFC-0002 FR-30) — size: XS · route: fast / low

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "symfony/html-sanitizer": "^6.4"
     },
     "suggest": {
+        "ext-iconv": "Required by Str::transcode() (spec r3 FR-31); also improves Str::slug() transliteration when ext-intl is absent. transcode() raises a clear UtilsException if called without it, rather than degrading silently.",
         "symfony/html-sanitizer": "Required by Sanitizer::richText() to sanitize user-authored HTML (spec FR-09b). Not needed unless you render untrusted markup; richText() raises a clear UtilsException if it is called without this installed, rather than returning the input unsanitized."
     },
     "minimum-stability": "stable",

--- a/docs/journal/2026/08/2026-08-06-str-additions.md
+++ b/docs/journal/2026/08/2026-08-06-str-additions.md
@@ -1,0 +1,55 @@
+# 2026-08-06 — The first RFC-0002 item, and three failures that earned their keep
+
+Roadmap item **9.1**, opening Milestone 9 — the first code shipped under RFC-0002. Route
+`fast / low`; run at frontier because that is the session the maintainer had open
+(mismatch recorded via `record_run.py`, the item 4.6 precedent in the other direction).
+
+## Six methods, one philosophy
+
+`collapseWhitespace()`, `nullIfBlank()`, `transcode()`, `padLeft()`/`padRight()`,
+`shortClassName()`, `pascalCase()` — each a generalization of something the surveyed estate
+does today with silent failure modes. The recurring inversion: **loss is opt-in, never
+default** (`transcode()` throws where the legacy pipeline ran `//IGNORE` unconditionally;
+padding refuses invalid UTF-8 rather than miscounting it).
+
+## The three first-run failures, kept as documentation
+
+Writing tests before trusting them paid three times in one run:
+
+1. `str_pad('héllo', 7)` returns **7 bytes that render as 6 characters** — my own pin of
+   the native defect had the arithmetic backwards. The test now asserts both counts
+   side by side, bytes and code points.
+2. `pascalCase()` is **not idempotent**, and cannot be while it normalizes case:
+   an already-Pascal input has no separators, so it is one word and `strtolower` flattens
+   it. The wrong move would have been forcing idempotence; the right one was asserting the
+   non-idempotence as documented behavior, from both sides (provider case + explicit test).
+3. An anonymous class's runtime name embeds a NUL byte and **the defining file path** —
+   backslash-separated on Windows — so "tail after the last `\`" returns a different
+   fragment per platform. `shortClassName()` now answers the literal `class@anonymous`,
+   one deterministic value everywhere; found only because this suite ran on Windows.
+
+## Decisions worth one line each
+
+`transcode()` probes the encoding pair on the empty string first, so unknown-encoding and
+unconvertible-data failures — which `iconv()` reports identically — stay distinguishable in
+the message. `ext-iconv` is `suggest`ed with the ADR-0021/ADR-0022 refusal pattern; the
+refusal branch is probe-verified, not permanently tested (5.2's standing precedent — this
+environment cannot unload the extension). Padding follows PHP 8.3 `mb_str_pad()` semantics
+so a future floor bump migrates without behavior change, counting code points via PCRE and
+keeping mbstring out of the dependency graph. No new exception type: spec r3's exception
+enumeration is the contract, and strict `transcode()` throws `UtilsException` with precise
+messages until a consumer needs a finer catch.
+
+## Gates
+
+Full suite 1373 tests green (61 new; 7 pre-existing environment skips — no coverage driver
+locally, so the 90% floor is CI's to certify). PHPStan max clean (after raising the local
+128M memory limit — an environment lesson, not a code one). PHP-CS-Fixer clean. deptrac:
+0 violations, 0 uncovered. `composer normalize` clean with the new `suggest` entry.
+`consistency_lint` green. Leak-gate: zero estate tokens in the staged diff.
+
+## Lesson
+
+A test that fails on first run is doing its job — all three failures here were the tests
+teaching me the platform's actual behavior, and each became an assertion the next reader
+cannot un-know.

--- a/src/main/php/d4np/utils/Support/Str.php
+++ b/src/main/php/d4np/utils/Support/Str.php
@@ -7,7 +7,9 @@ namespace D4np\Utils\Support;
 use InvalidArgumentException;
 
 /**
- * String utilities: URL-friendly slugs, UUIDs, and CSPRNG tokens (spec §2 items 19–21).
+ * String utilities: URL-friendly slugs, UUIDs, CSPRNG tokens (spec §2 items 19–21), and the
+ * FR-31 additions — whitespace collapsing, blank-to-null, charset transcoding, multibyte-safe
+ * padding, class-name and case helpers (spec r3, RFC-0002).
  */
 final class Str
 {
@@ -106,6 +108,220 @@ final class Str
         }
 
         return $token;
+    }
+
+    /**
+     * Trims the value and collapses every internal run of whitespace to a single space.
+     *
+     * Whitespace here is the ASCII set (`space`, `\t`, `\n`, `\r`, `\f`, vertical tab) — the
+     * bytes `trim()` and PCRE's un-flagged `\s` agree on. That byte-oriented match is
+     * deliberately **UTF-8-safe without a `u` flag**: every byte of a multibyte UTF-8 sequence
+     * is `>= 0x80`, so an ASCII-set match can never split one. Unicode spaces (NBSP, U+2028…)
+     * pass through untouched; a caller who needs those normalized transcodes or replaces them
+     * explicitly first, rather than this method guessing.
+     */
+    public static function collapseWhitespace(string $value): string
+    {
+        return preg_replace('/\s+/', ' ', trim($value)) ?? '';
+    }
+
+    /**
+     * `null` when the value is `null` or contains nothing but whitespace; the value itself,
+     * **unmodified**, otherwise.
+     *
+     * Blankness is judged by `trim()`, but the non-blank return is deliberately not trimmed —
+     * this method answers exactly one question ("is there content?") and mutates nothing, so it
+     * composes without surprises: `Str::nullIfBlank(Str::collapseWhitespace($x))` is the
+     * common cleanup pipeline, each step doing its one job.
+     */
+    public static function nullIfBlank(?string $value): ?string
+    {
+        if ($value === null || trim($value) === '') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Converts `$value` from `$from` to `$to` (default UTF-8) via `iconv`.
+     *
+     * **Strict by default**: input the source encoding cannot parse, or characters the target
+     * cannot represent, throw a {@see UtilsException} — silently dropping bytes is data loss,
+     * and data loss must be opted into, never defaulted into (the same honesty rule as
+     * `Escaper`'s U+FFFD substitution, ADR-0019). Pass `$lossy = true` to drop what the target
+     * cannot represent (`//IGNORE`).
+     *
+     * `ext-iconv` is a **suggested** dependency: on a build without it this method refuses
+     * with a clear message rather than degrading (the `Sanitizer::richText()` /
+     * `Hash` fail-fast pattern, ADR-0021/ADR-0022). It is not `require`d because nothing else
+     * in the core needs it and NFR-08 keeps the dependency floor where it is.
+     *
+     * @throws UtilsException when `ext-iconv` is absent, when an encoding name is unknown, or
+     *                        — in strict mode — when the value does not survive conversion
+     *                        losslessly
+     */
+    public static function transcode(
+        string $value,
+        string $from,
+        string $to = 'UTF-8',
+        bool $lossy = false,
+    ): string {
+        if (!function_exists('iconv')) {
+            throw new UtilsException(
+                'Str::transcode() requires ext-iconv, which is not loaded. Install/enable '
+                . 'ext-iconv (composer.json lists it under "suggest").',
+            );
+        }
+
+        // Probe the encoding pair on the empty string first: iconv() signals "unknown
+        // encoding" and "unconvertible input" identically (false + a notice), and the empty
+        // string can only fail for the first reason — so the two failures stay distinguishable
+        // in the message.
+        if (@iconv($from, $to, '') === false) {
+            throw new UtilsException(sprintf(
+                'Str::transcode(): unknown encoding in pair "%s" -> "%s".',
+                $from,
+                $to,
+            ));
+        }
+
+        $target = $lossy ? $to . '//IGNORE' : $to;
+        $result = @iconv($from, $target, $value);
+
+        if ($result === false) {
+            throw new UtilsException(sprintf(
+                'Str::transcode(): value is not losslessly convertible from "%s" to "%s" '
+                . '(invalid byte sequence or unrepresentable character). '
+                . 'Pass $lossy = true to drop unrepresentable characters explicitly.',
+                $from,
+                $to,
+            ));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Left-pads to `$length` **characters** (Unicode code points), not bytes.
+     *
+     * `str_pad()` counts bytes, so it under-pads any multibyte string — `str_pad('héllo', 7)`
+     * adds one space, not two. This method counts code points via PCRE (always available; no
+     * `ext-mbstring` dependency) and follows the semantics of PHP 8.3's `mb_str_pad()`, so a
+     * consumer on a newer floor can migrate to the native function without a behavior change:
+     * a `$length` at or below the current character count returns the value unchanged, and an
+     * empty `$pad` is refused.
+     *
+     * @throws InvalidArgumentException if `$pad` is empty, or `$value`/`$pad` is not valid UTF-8
+     */
+    public static function padLeft(string $value, int $length, string $pad = ' '): string
+    {
+        return self::pad($value, $length, $pad, STR_PAD_LEFT);
+    }
+
+    /**
+     * Right-pads to `$length` **characters** (Unicode code points), not bytes.
+     *
+     * See {@see self::padLeft()} for the semantics; only the side differs.
+     *
+     * @throws InvalidArgumentException if `$pad` is empty, or `$value`/`$pad` is not valid UTF-8
+     */
+    public static function padRight(string $value, int $length, string $pad = ' '): string
+    {
+        return self::pad($value, $length, $pad, STR_PAD_RIGHT);
+    }
+
+    /**
+     * The class name after the final namespace separator — `D4np\Utils\Support\Str` → `Str`.
+     *
+     * Accepts an object (its concrete class is used) or any backslash-separated name; the
+     * string form is **not** required to name a loaded class, so the helper works on names
+     * from configuration or logs without autoloading anything. An anonymous class returns the
+     * literal `class@anonymous`: its runtime name embeds a NUL byte and the defining file
+     * path, which is platform-shaped — one deterministic answer beats a fragment of a path.
+     *
+     * @throws InvalidArgumentException if the string is empty or ends in a separator (no name
+     *                                   remains after the final `\`)
+     */
+    public static function shortClassName(object|string $class): string
+    {
+        $name = is_object($class) ? get_class($class) : $class;
+
+        // Anonymous-class runtime names embed a NUL byte and the defining FILE PATH — which
+        // contains backslashes on Windows, so naive last-separator surgery would return a
+        // platform-dependent fragment. One deterministic answer on every platform instead.
+        if (str_starts_with($name, 'class@anonymous')) {
+            return 'class@anonymous';
+        }
+
+        $position = strrpos($name, '\\');
+        $short = $position === false ? $name : substr($name, $position + 1);
+
+        if ($short === '') {
+            throw new InvalidArgumentException(sprintf(
+                'shortClassName(): "%s" carries no class name after the final "\\".',
+                $name,
+            ));
+        }
+
+        return $short;
+    }
+
+    /**
+     * PascalCase from words separated by whitespace, underscores, or hyphens —
+     * `"order line"` / `"order_line"` / `"ORDER-LINE"` → `OrderLine`.
+     *
+     * Case mapping is ASCII-only (`strtolower`/`ucwords`): multibyte characters pass through
+     * unchanged rather than being half-mapped byte by byte. Word boundaries are the three
+     * separator classes named above — an already-PascalCase input is therefore a single word
+     * and comes back with only its first letter guaranteed uppercase, not re-split.
+     */
+    public static function pascalCase(string $value): string
+    {
+        $worded = preg_replace('/[\s_\-]+/', ' ', trim($value)) ?? '';
+
+        return str_replace(' ', '', ucwords(strtolower($worded)));
+    }
+
+    /**
+     * The shared engine behind {@see self::padLeft()} / {@see self::padRight()}: mb_str_pad()
+     * semantics over PCRE code-point counting, so the promise ("characters, not bytes") holds
+     * with no extension dependency.
+     */
+    private static function pad(string $value, int $length, string $pad, int $side): string
+    {
+        if ($pad === '') {
+            throw new InvalidArgumentException('$pad must not be empty.');
+        }
+
+        $valueChars = self::countCodePoints($value, '$value');
+        $deficit = $length - $valueChars;
+
+        if ($deficit <= 0) {
+            return $value;
+        }
+
+        $padChars = self::countCodePoints($pad, '$pad');
+        $repeated = str_repeat($pad, (int) ceil($deficit / $padChars));
+        $codePoints = preg_split('//u', $repeated, -1, PREG_SPLIT_NO_EMPTY);
+        $padding = implode('', array_slice($codePoints === false ? [] : $codePoints, 0, $deficit));
+
+        return $side === STR_PAD_LEFT ? $padding . $value : $value . $padding;
+    }
+
+    /**
+     * Code points in `$value`, throwing (with the offending parameter named) on invalid UTF-8 —
+     * a padder that miscounts mojibake would pad it wrongly and silently.
+     */
+    private static function countCodePoints(string $value, string $parameter): int
+    {
+        $count = preg_match_all('/./su', $value);
+
+        if ($count === false) {
+            throw new InvalidArgumentException(sprintf('%s is not valid UTF-8.', $parameter));
+        }
+
+        return $count;
     }
 
     private static function transliterateToAscii(string $value): string

--- a/src/test/php/d4np/utils/Support/StrCollapseWhitespaceTest.php
+++ b/src/test/php/d4np/utils/Support/StrCollapseWhitespaceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Str::collapseWhitespace()` — spec r3 FR-31 (RFC-0002).
+ *
+ * The load-bearing claims: every ASCII whitespace run becomes one space, the ends are
+ * trimmed, and multibyte content is never split — the ASCII-set match cannot touch UTF-8
+ * continuation bytes, which is why the method needs no `u` flag and no mbstring.
+ */
+final class StrCollapseWhitespaceTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function collapseCases(): iterable
+    {
+        yield 'already collapsed' => ['a b c', 'a b c'];
+        yield 'internal runs of spaces' => ['a    b     c', 'a b c'];
+        yield 'tabs and newlines collapse to one space' => ["a\t\tb\r\nc", 'a b c'];
+        yield 'leading and trailing whitespace trimmed' => ["  \t a b \n ", 'a b'];
+        yield 'mixed run collapses to a single space' => ["a \t \n b", 'a b'];
+        yield 'empty string stays empty' => ['', ''];
+        yield 'whitespace-only becomes empty' => [" \t\r\n ", ''];
+        yield 'multibyte content preserved intact' => ["  café \t naïve  ", 'café naïve'];
+        yield 'NBSP is content, not whitespace (documented ASCII scope)' => ["a\u{00A0}b", "a\u{00A0}b"];
+    }
+
+    #[DataProvider('collapseCases')]
+    public function testCollapse(string $input, string $expected): void
+    {
+        self::assertSame($expected, Str::collapseWhitespace($input));
+    }
+
+    public function testIdempotent(): void
+    {
+        $once = Str::collapseWhitespace("  a \t b\n\nc  ");
+
+        self::assertSame($once, Str::collapseWhitespace($once));
+    }
+}

--- a/src/test/php/d4np/utils/Support/StrNullIfBlankTest.php
+++ b/src/test/php/d4np/utils/Support/StrNullIfBlankTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Str::nullIfBlank()` — spec r3 FR-31 (RFC-0002).
+ *
+ * Two claims, tested separately: blank collapses to `null`, and non-blank comes back
+ * **unmodified** — the method answers "is there content?" and never trims, so it composes
+ * with `collapseWhitespace()` without double-mutation.
+ */
+final class StrNullIfBlankTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string|null}>
+     */
+    public static function blankCases(): iterable
+    {
+        yield 'null' => [null];
+        yield 'empty string' => [''];
+        yield 'spaces only' => ['   '];
+        yield 'mixed ASCII whitespace only' => [" \t\r\n "];
+    }
+
+    #[DataProvider('blankCases')]
+    public function testBlankBecomesNull(?string $input): void
+    {
+        self::assertNull(Str::nullIfBlank($input));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function contentCases(): iterable
+    {
+        yield 'plain word' => ['x'];
+        yield 'zero is content' => ['0'];
+        yield 'content with surrounding whitespace stays untrimmed' => ['  padded  '];
+        yield 'multibyte content' => ['café'];
+        yield 'NBSP counts as content (ASCII blankness scope)' => ["\u{00A0}"];
+    }
+
+    #[DataProvider('contentCases')]
+    public function testContentComesBackUnmodified(string $input): void
+    {
+        self::assertSame($input, Str::nullIfBlank($input));
+    }
+}

--- a/src/test/php/d4np/utils/Support/StrPadTest.php
+++ b/src/test/php/d4np/utils/Support/StrPadTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Str;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Str::padLeft()` / `Str::padRight()` — spec r3 FR-31 (RFC-0002).
+ *
+ * The reason these exist: `str_pad()` counts **bytes**, so multibyte strings under-pad —
+ * exactly the defect the first data-provider case pins. Semantics follow PHP 8.3's
+ * `mb_str_pad()` (at-or-below length is a no-op; empty pad refused) so a consumer on a newer
+ * floor can migrate to the native function without behavior change.
+ */
+final class StrPadTest extends TestCase
+{
+    public function testStrPadUnderPadsMultibyteWhichIsWhyThisExists(): void
+    {
+        // 'héllo' is 5 characters but 6 bytes. Asked for 7, str_pad() counts bytes: it emits
+        // 7 BYTES — which render as only 6 characters, one short. padLeft() emits 7 characters.
+        $native = str_pad('héllo', 7);
+
+        self::assertSame(7, strlen($native));
+        self::assertSame(6, preg_match_all('/./su', $native));
+        self::assertSame('  héllo', Str::padLeft('héllo', 7));
+        self::assertSame(7, preg_match_all('/./su', Str::padLeft('héllo', 7)));
+    }
+
+    /**
+     * @return iterable<string, array{string, int, string, string}>
+     */
+    public static function padLeftCases(): iterable
+    {
+        yield 'ascii' => ['42', 5, '0', '00042'];
+        yield 'multibyte value counts code points' => ['héllo', 7, ' ', '  héllo'];
+        yield 'multibyte pad slices by code points' => ['x', 4, 'ãb', 'ãbãx'];
+        yield 'length equal to value is a no-op' => ['abc', 3, '0', 'abc'];
+        yield 'length below value is a no-op' => ['abc', 2, '0', 'abc'];
+        yield 'negative length is a no-op' => ['abc', -1, '0', 'abc'];
+        yield 'empty value pads fully' => ['', 3, 'ab', 'aba'];
+    }
+
+    #[DataProvider('padLeftCases')]
+    public function testPadLeft(string $value, int $length, string $pad, string $expected): void
+    {
+        self::assertSame($expected, Str::padLeft($value, $length, $pad));
+    }
+
+    /**
+     * @return iterable<string, array{string, int, string, string}>
+     */
+    public static function padRightCases(): iterable
+    {
+        yield 'ascii' => ['42', 5, '0', '42000'];
+        yield 'multibyte value counts code points' => ['héllo', 7, ' ', 'héllo  '];
+        yield 'multibyte pad slices by code points' => ['x', 4, 'ãb', 'xãbã'];
+        yield 'no-op at length' => ['abc', 3, '0', 'abc'];
+    }
+
+    #[DataProvider('padRightCases')]
+    public function testPadRight(string $value, int $length, string $pad, string $expected): void
+    {
+        self::assertSame($expected, Str::padRight($value, $length, $pad));
+    }
+
+    public function testEmptyPadIsRefused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$pad must not be empty');
+
+        Str::padLeft('x', 5, '');
+    }
+
+    public function testInvalidUtf8ValueIsRefusedNotMiscounted(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$value is not valid UTF-8');
+
+        Str::padLeft("\xC3\x28", 5);
+    }
+
+    public function testInvalidUtf8PadIsRefusedWhenPaddingIsNeeded(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$pad is not valid UTF-8');
+
+        Str::padRight('x', 5, "\xC3\x28");
+    }
+}

--- a/src/test/php/d4np/utils/Support/StrPascalCaseTest.php
+++ b/src/test/php/d4np/utils/Support/StrPascalCaseTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Str::pascalCase()` — spec r3 FR-31 (RFC-0002).
+ *
+ * Word boundaries are whitespace, underscores, and hyphens; case mapping is ASCII-only with
+ * multibyte characters passing through un-mangled (half-mapping bytes would corrupt them).
+ */
+final class StrPascalCaseTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function pascalCases(): iterable
+    {
+        yield 'space separated' => ['order line', 'OrderLine'];
+        yield 'underscore separated' => ['order_line', 'OrderLine'];
+        yield 'hyphen separated' => ['order-line', 'OrderLine'];
+        yield 'mixed separators and runs' => ['order -_ line  item', 'OrderLineItem'];
+        yield 'uppercase input is normalized' => ['ORDER LINE', 'OrderLine'];
+        yield 'single word' => ['order', 'Order'];
+        yield 'already PascalCase is one word, first letter kept upper' => ['OrderLine', 'Orderline'];
+        yield 'digits ride along' => ['line 2 item', 'Line2Item'];
+        yield 'surrounding separators trimmed' => ['  _order line_  ', 'OrderLine'];
+        yield 'empty stays empty' => ['', ''];
+        yield 'multibyte passes through unmangled' => ['café menu', 'CaféMenu'];
+    }
+
+    #[DataProvider('pascalCases')]
+    public function testPascalCase(string $input, string $expected): void
+    {
+        self::assertSame($expected, Str::pascalCase($input));
+    }
+
+    public function testDeliberatelyNotIdempotent(): void
+    {
+        // Documented, not accidental: an already-PascalCase input has no separators, so it is
+        // ONE word — strtolower flattens its internals before ucwords recapitalizes the first
+        // letter. Re-running the function is therefore not a no-op, and the provider's
+        // 'already PascalCase' case pins the same fact from the other side.
+        self::assertSame('Orderlineitem', Str::pascalCase(Str::pascalCase('order line item')));
+    }
+}

--- a/src/test/php/d4np/utils/Support/StrShortClassNameTest.php
+++ b/src/test/php/d4np/utils/Support/StrShortClassNameTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Str;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * `Str::shortClassName()` — spec r3 FR-31 (RFC-0002).
+ *
+ * String inputs are deliberately not required to name a loaded class (names arrive from
+ * configuration and logs), so the contract is pure string surgery plus a refusal when no
+ * name remains after the final separator.
+ */
+final class StrShortClassNameTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{object|string, string}>
+     */
+    public static function nameCases(): iterable
+    {
+        yield 'fully qualified name' => [Str::class, 'Str'];
+        yield 'global name passes through' => ['ArrayObject', 'ArrayObject'];
+        yield 'leading separator only' => ['\\ArrayObject', 'ArrayObject'];
+        yield 'not-a-loaded-class string is fine' => ['Acme\Generated\ReportRow', 'ReportRow'];
+        yield 'object instance uses its concrete class' => [new stdClass(), 'stdClass'];
+    }
+
+    #[DataProvider('nameCases')]
+    public function testShortName(object|string $input, string $expected): void
+    {
+        self::assertSame($expected, Str::shortClassName($input));
+    }
+
+    public function testAnonymousClassYieldsTheLiteralAnonymousMarker(): void
+    {
+        // The runtime name embeds a NUL byte and the defining FILE PATH — backslash-separated
+        // on Windows — so tail-after-last-separator would be a platform-dependent path
+        // fragment. The contract is one deterministic answer on every platform.
+        self::assertSame('class@anonymous', Str::shortClassName(new class () {}));
+    }
+
+    public function testEmptyStringIsRefused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Str::shortClassName('');
+    }
+
+    public function testTrailingSeparatorIsRefused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('no class name after the final');
+
+        Str::shortClassName('Acme\\Namespace\\');
+    }
+}

--- a/src/test/php/d4np/utils/Support/StrTranscodeTest.php
+++ b/src/test/php/d4np/utils/Support/StrTranscodeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Str;
+use D4np\Utils\Support\UtilsException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Str::transcode()` — spec r3 FR-31 (RFC-0002): strict by default, lossy by explicit opt-in.
+ *
+ * The legacy pipeline this generalizes ran `iconv(..., '...//IGNORE', ...)` unconditionally —
+ * silent data loss on every unrepresentable character. The contract under test is the
+ * inversion: loss **throws** unless the caller asked for it in the signature.
+ *
+ * The ext-iconv-absent refusal branch is NOT covered here: this suite's environment has
+ * iconv loaded and `function_exists()` cannot be unloaded in-process. The branch was
+ * probe-verified during development (the `Sanitizer::richText()` precedent, ADR-0021 — its
+ * missing-dependency path has the same standing gap, recorded rather than faked).
+ */
+final class StrTranscodeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!function_exists('iconv')) {
+            self::markTestSkipped('ext-iconv is not loaded in this environment.');
+        }
+    }
+
+    public function testLegacyLatin9RoundTripsToUtf8(): void
+    {
+        // 0xA4 is the euro sign in ISO-8859-15 — the surveyed estate's exact daily case.
+        self::assertSame('€', Str::transcode("\xA4", 'ISO-8859-15'));
+    }
+
+    public function testAsciiPassesThroughAnyPair(): void
+    {
+        self::assertSame('plain', Str::transcode('plain', 'ISO-8859-1', 'UTF-8'));
+    }
+
+    public function testStrictThrowsOnUnrepresentableTarget(): void
+    {
+        $this->expectException(UtilsException::class);
+        $this->expectExceptionMessage('not losslessly convertible');
+
+        // The euro sign has no ISO-8859-1 codepoint; strict mode must refuse, not drop.
+        Str::transcode('price: 5€', 'UTF-8', 'ISO-8859-1');
+    }
+
+    public function testStrictThrowsOnInvalidInputBytes(): void
+    {
+        $this->expectException(UtilsException::class);
+        $this->expectExceptionMessage('not losslessly convertible');
+
+        // 0xC3 0x28 is a malformed UTF-8 sequence (lead byte with an invalid continuation).
+        Str::transcode("\xC3\x28", 'UTF-8', 'ISO-8859-1');
+    }
+
+    public function testLossyDropsUnrepresentableCharactersOnExplicitOptIn(): void
+    {
+        self::assertSame('price: 5', Str::transcode('price: 5€', 'UTF-8', 'ISO-8859-1', lossy: true));
+    }
+
+    public function testUnknownEncodingIsNamedDistinctlyFromDataFailures(): void
+    {
+        $this->expectException(UtilsException::class);
+        $this->expectExceptionMessage('unknown encoding');
+
+        Str::transcode('x', 'NOT-A-CHARSET');
+    }
+
+    public function testEmptyStringTranscodesToEmptyString(): void
+    {
+        self::assertSame('', Str::transcode('', 'ISO-8859-15'));
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item **9.1** — the first code under RFC-0002, opening **Milestone 9 (`v0.8.0`)**:
six `Str` additions (spec r3 **FR-31**) — `collapseWhitespace()`, `nullIfBlank()`,
`transcode()`, multibyte-safe `padLeft()`/`padRight()`, `shortClassName()`, `pascalCase()`
— 61 new tests, `ext-iconv` added to composer `suggest`.

## Motivation

Spec r3 FR-31 (RFC-0002; approved #49, planned #50). Each method generalizes something the
surveyed legacy estate does today with silent failure modes, under one inversion the RFC
made a rule: **loss is opt-in, never default**. `transcode()` throws where the legacy
pipeline ran `//IGNORE` unconditionally (17 copies of that pipeline exist in the estate);
padding refuses invalid UTF-8 rather than miscounting it.

## Changes

- `Str::collapseWhitespace()` — trims and collapses ASCII whitespace runs; UTF-8-safe **by
  construction** (ASCII-set matching cannot split multibyte sequences), documented scope.
- `Str::nullIfBlank()` — blank→`null`, non-blank returned **unmodified**; composes with
  `collapseWhitespace()` without double-mutation.
- `Str::transcode()` — strict by default (invalid input bytes *or* unrepresentable target
  characters throw `UtilsException`); `$lossy = true` opts into `//IGNORE`; unknown
  encodings are named **distinctly** from data failures by probing the pair on the empty
  string (iconv reports both as `false`). `ext-iconv` is **suggested**, with the
  ADR-0021/ADR-0022 constructor-refusal pattern when absent.
- `Str::padLeft()` / `padRight()` — pad by **code points**, not bytes (`str_pad('héllo', 7)`
  emits 7 bytes rendering as 6 characters — pinned in the suite from both sides). Semantics
  follow PHP 8.3's `mb_str_pad()` so a future floor bump migrates behavior-neutrally;
  counting via PCRE keeps mbstring out of the dependency graph.
- `Str::shortClassName()` — tail after the final `\`; accepts objects and non-loaded names;
  anonymous classes answer the literal **`class@anonymous`** (their runtime names embed a
  NUL byte and the defining *file path*, backslash-separated on Windows — a naive tail would
  be platform-dependent; found because this suite ran on Windows).
- `Str::pascalCase()` — whitespace/underscore/hyphen word boundaries, ASCII case mapping,
  multibyte pass-through; **deliberately not idempotent** and asserted as such (an
  already-Pascal input is one word; `strtolower` flattens it).
- composer.json: `ext-iconv` in `suggest` (normalized); CHANGELOG entry; ROADMAP 9.1
  flipped with its completion note; session journal.

**No new exception type**: strict `transcode()` failures throw `UtilsException` with
precise messages — spec r3's exception enumeration is the contract, and a finer type waits
for a consumer who needs the distinct catch (recorded in the item note).

**Honest gap** (5.2's standing precedent): the ext-iconv-absent refusal branch is
probe-verified, not permanently tested — this environment cannot unload the extension.

**Route note:** item routed `fast / low`; run at frontier (the session the maintainer had
open) — mismatch recorded via `record_run.py`.

## Design Patterns

- None — straightforward implementation. (The tiered-optional-extension shape reuses
  `Str::slug()`'s existing precedent; the refusal pattern is ADR-0021/ADR-0022's.)

## Verification

- [x] Full suite green locally: **1373 tests, 3044 assertions** (61 new; 7 pre-existing
      environment skips — no coverage driver on this machine, so the ≥90% floor is CI's to
      certify per AGENTS §6.4)
- [x] `PHPStan (max level)` — No errors
- [x] `PHP-CS-Fixer (PSR-12)` — clean
- [x] `deptrac` — 0 violations, 0 uncovered
- [x] `composer normalize --dry-run` — clean with the new `suggest` entry
- [x] `python tools/consistency_lint.py` — OK
- [x] Leak-gate grep over the staged diff — zero estate tokens
- [ ] CI matrix (8.1/8.2/8.3) + coverage floor — this PR's checks

## Documentation Impact

- [ ] README.md — unchanged (public-surface listing lives in the spec; README names groups,
      not methods)
- [x] ROADMAP.md — 9.1 flipped with its completion note; latest-journal pointer updated
- [ ] ADR — none needed (no non-trivial design decision beyond recorded precedents; the
      milestone's ADR-carrying items are 9.3/9.4)
- [ ] docs/patterns/README.md — unchanged
- [x] Spec — no drift: FR-31 implemented as written in r3
- [x] CHANGELOG.md — `[Unreleased] / Added` entry
- [x] PR metadata — assignee (owner), label `enhancement` (feat), milestone **v0.8.0**

## Lesson

Lesson: a test that fails on first run is doing its job — all three first-run failures here
were the platform teaching real behavior (byte-vs-codepoint counts, case-mapping
non-idempotence, anonymous-class names embedding platform paths), and each became an
assertion the next reader cannot un-know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
