### PR TITLE
feat(support): a Url value that refuses the downgrade and the laundered character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`D4np\Utils\Support\Url`** and **`InvalidUrlException`** (spec r4 **FR-27**, RFC-0002;
+  roadmap item **9.3**; **ADR-0036**) — an immutable absolute-URL value: parse, inspect,
+  recompose, compose queries. Three refusals, each a defect from the intake:
+  **control characters are rejected up front** (probed: `parse_url()` does not reject them,
+  it rewrites each to `_`, so a CRLF payload parses "clean" with components that differ
+  from the input); **a scheme downgrade is refused** (`https`→`http`, `wss`→`ws`,
+  `ftps`/`sftp`→`ftp`; an unknown target scheme is allowed through — a recorded limit); and
+  **a `null` query value is refused at any depth** (`http_build_query()` drops it silently).
+  An untouched query is preserved **byte-exact** so signatures computed over a URL survive;
+  composition encodes per RFC 3986, not as an HTML form. `userInfo()` reports credentials
+  truthfully and `withoutUserInfo()` strips them for logging.
+
 - **`D4np\Utils\Support\Lookup`** (spec r3 **FR-30**, RFC-0002; roadmap item **9.2**) — an
   immutable code→label map with an explicit missing-key policy: `label()` throws
   `OutOfBoundsException`, `labelOr()` substitutes a caller-supplied default, `tryLabel()`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — A lookup that refuses to lie](docs/journal/2026/08/2026-08-06-lookup.md).
+  [2026-08-06 — The parser that launders](docs/journal/2026/08/2026-08-06-url.md).
 
 ## Model & effort routing (advisory)
 
@@ -608,9 +608,32 @@ surface (RFC-0002 FR-27…FR-32).
       distinct catch. `array_key_exists()`, not `??`/`isset()`, is the presence check
       throughout: a code deliberately mapped to `''` must read as present, which `??` would
       silently treat as absent — pinned by its own test.*
-- [ ] 9.3 `Url` value object: parse/normalize/build, query composition, **scheme-downgrade
+- [x] 9.3 `Url` value object: parse/normalize/build, query composition, **scheme-downgrade
       refusal on rebuild** (RFC-0002 FR-27) (security) — size: S ·
-      route: frontier-reasoning / extra · ADR (URL scheme policy)
+      route: frontier-reasoning / extra *(run at standard tier; mismatch recorded)* ·
+      **ADR-0036**, **spec r4**. ***The probe changed the item.*** *`parse_url()` does not
+      reject control characters — it **launders** them, rewriting each to `_`, so
+      `https://example.com\n/evil` parses successfully with the host `example.com_`. Code
+      that validates the parsed components and then forwards the original string is checking
+      a value the caller never sent, and CR/LF is exactly the payload that matters once a URL
+      reaches a request line. Refused up front instead, in `parse()` and in every wither, so
+      **input and parsed value are the same string**. `FILTER_VALIDATE_URL` would have caught
+      that one case and was rejected on its own probe: it also rejects valid IDN hosts. Two
+      more probe findings shaped the class: `parse_url('not a url')` **succeeds**
+      (`['path' => …]`), so absoluteness is checked separately; and `http_build_query()`
+      **drops null values silently**, so they are refused — **PHPStan found that guard
+      incomplete**, since the acceptable value shape is recursive and cannot be typed
+      honestly, which made the runtime walk the whole enforcement; it now descends and names
+      the offender's dotted path. The downgrade refusal is the second line of defence and the
+      weaker one — the object **carries** its scheme through every recomposition, making the
+      estate's actual defect (rebuilding with a hardcoded `http://`) structurally unreachable.
+      Recorded limit: an **unknown** target scheme is allowed through, with a test pinning it.
+      An untouched query is preserved **byte-exact** — re-encoding one nobody edited would
+      invalidate any signature over it. 82 tests; **suite proved non-vacuous with 11 planted
+      defects**, all caught. The pre-existing `ExceptionHierarchyTest` registry caught
+      `InvalidUrlException` joining the family — the completeness guard doing its job — and
+      spec r3's exception enumeration, which had not anticipated the type, is amended to r4
+      rather than left to drift.*
 - [ ] 9.4 `Csv` streaming write/read + `Delimiter` enum + `CsvSerializable`; typed failures
       (never boolean), atomic write via `File`; formula-guard **opt-in, default off**, both
       flag states tested (RFC-0002 FR-28/FR-29; T-08) (security) — size: M ·

--- a/docs/adr/0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md
+++ b/docs/adr/0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md
@@ -1,0 +1,176 @@
+# ADR-0036: Refuse the scheme downgrade, and refuse the characters `parse_url()` launders
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 9.3 · spec r3 FR-27, r4 (exception enumeration) ·
+  [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) §Decision (`Support`
+  additions) · [ADR-0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md)
+  (name the assumption an escaper cannot verify) ·
+  [ADR-0025](0025-typed-http-wrappers-that-refuse-rather-than-coerce.md) (refuse rather than
+  coerce; CR/LF refused at set time; `array-key`, not `string`) ·
+  [ADR-0021](0021-delegate-rich-html-and-escape-like-wildcards-with-a-portable-character.md)
+  (a portable refusal over a per-driver spelling)
+
+## Context
+
+FR-27 asks for a URL value object with "parse/normalize/build, query composition,
+**scheme-downgrade refusal on rebuild**". The clause exists because of a specific estate
+helper: it decomposed a URL and rebuilt it as `"http://{$host}{$path}"` — a hardcoded
+scheme. Every `https` address it touched came back plaintext, and the query and fragment
+were dropped on the way.
+
+Four things were probed against PHP 8.3.1 before the class was designed. **Two changed it.**
+
+| probe | result |
+|---|---|
+| `parse_url("https://example.com\n/evil")` | **succeeds**, host `example.com_` — the newline is rewritten to `_`, not rejected |
+| `parse_url('not a url')` | **succeeds**, `['path' => 'not a url']` |
+| `filter_var('https://exämple.com/', FILTER_VALIDATE_URL)` | **false** — rejects valid internationalized hosts |
+| `http_build_query(['a' => '1', 'b' => null])` | `a=1` — the null entry vanishes with no signal |
+
+The first is the finding that matters. `parse_url()` does not reject C0 control characters;
+it **launders** them, substituting `_` for each. So a CRLF payload produces a parse that
+looks clean, with components that differ from the string that was supplied. Any code that
+validates the parsed result and then forwards the *original* string is inspecting a value
+the caller never sent — and CR/LF is precisely the payload that matters when a URL reaches
+a request line or a `Location` header.
+
+The second says that "did `parse_url()` succeed?" cannot answer "is this a URL?".
+
+The third rules out the obvious shortcut: `FILTER_VALIDATE_URL` would have caught the
+newline case, but it also rejects legitimate IDN hosts, so adopting it as the gate trades
+a real security check for a real correctness bug.
+
+## Decision
+
+### 1. Refuse C0 controls and DEL before `parse_url()` sees them
+
+`Url::parse()` rejects `[\x00-\x1F\x7F]` up front, and every wither applies the same guard
+to what it is given. The invariant this buys is worth stating plainly: **the input and the
+parsed value are the same string**. Nothing is silently rewritten, so a validation performed
+on the components is a validation of what arrived.
+
+The guard is a refusal, not a sanitization, for ADR-0019's reason: a URL containing a
+newline is not a URL with a formatting problem, it is a different value than the one the
+caller believes they hold. Rewriting it would make this class the second thing on the path
+that quietly changes the address.
+
+Spaces (`0x20`) are deliberately **not** refused. A literal space makes a URI invalid, but
+it is a validity question rather than an injection one, and whether it should become `%20`
+or `+` is a semantic choice belonging to the caller.
+
+### 2. Absolute URLs only
+
+A scheme and a host are both required; a relative reference is refused with a message
+saying so. FR-27's purpose is addresses that survive recomposition, and a string with no
+scheme has no scheme to protect. This also gives `parse_url('not a url')` — which otherwise
+"succeeds" — a clear answer.
+
+### 3. The downgrade rule, and the limit it does not cover
+
+`withScheme()` refuses a transition from an encrypted transport to its plaintext
+counterpart: `https`→`http`, `wss`→`ws`, `ftps`→`ftp`, `sftp`→`ftp`. Upgrades and
+same-scheme calls pass. The comparison is done on the lowercased scheme, so `HTTP` does not
+evade it — asserted by a test, and by a planted defect that reads the raw input instead.
+
+**The honest limit:** a scheme this class does not know is allowed through. `https` →
+`myapp` succeeds. The security properties of an unrecognised scheme cannot be asserted, and
+refusing every unknown would make the class unusable for custom schemes; the alternative —
+an allowlist of known-good schemes — was rejected because it fails closed on legitimate
+values a library cannot enumerate in advance. A test pins this so the limit is visible
+rather than discovered.
+
+The refusal is the *second* line of defence, and the weaker one. The first is that the
+object **carries** its scheme through every recomposition, which makes the estate's actual
+defect — losing the scheme and substituting a constant — structurally unreachable rather
+than merely discouraged.
+
+### 4. An untouched query is preserved byte-exact
+
+The raw query string is the stored form. It is returned unchanged by `rawQuery()` and
+recomposed unchanged by `toString()`; only a `withQuery*` call re-encodes. Normalizing a
+query nobody edited would reorder and re-encode parameters, invalidating any signature
+computed over the URL — a silent breakage in exactly the integrations that care most.
+
+`query()` decodes on demand via `parse_str()` and is documented as lossy in the way
+`parse_str()` is: repeated keys collapse. Its keys are typed `array-key`, not `string`,
+because `?0=zero` yields the **integer** key `0` — ADR-0025's superglobal-key lesson,
+reached again from a different direction.
+
+Composition encodes with `PHP_QUERY_RFC3986`, not `http_build_query()`'s default: the
+default is the HTML-form encoding (`+` for space), which is not what a URL query is.
+
+### 5. A `null` query value is refused, at any depth
+
+`http_build_query()` drops null entries without a signal, so a caller who meant "send this
+key empty" gets a URL missing the key entirely. `withQuery()` refuses it and names the
+alternative (`''`, or `withoutQueryParam()`).
+
+The **recursion** was found by PHPStan rather than by design. The acceptable value shape is
+recursive (scalars, or nested arrays of scalars), which PHPDoc cannot express without lying
+at some depth; typing the parameter honestly as `array<array-key, mixed>` removed the
+static check and made it obvious that the runtime guard — which at that point walked only
+the top level — was the *whole* enforcement, and was incomplete. It now descends and names
+the offender's dotted path.
+
+That the enforcement is a runtime walk rather than a type is the right split for this
+library regardless: spec §1 names native and legacy applications as the audience, and those
+consumers run no static analysis at all. A type-only refusal would protect only the
+consumers least likely to need it.
+
+### 6. One new exception, `InvalidUrlException`
+
+All four refusals raise `InvalidUrlException extends UtilsException`, with the cause named
+in the message. A consumer needs to separate "this URL is unusable" from every other
+library failure — item 11.1's `HttpClient` will have to, since it must distinguish a bad
+address from a failed request. A distinct type *per cause* (a `SchemeDowngradeException`
+for security logging, say) was considered and deferred under the precedent items 9.1 and
+9.2 set: a type is earned by a consumer that needs the distinct `catch`, and adding a
+subclass later is additive.
+
+Spec §2's r3 exception enumeration did not list this type, so **the spec is amended to r4**
+in the same PR rather than left to drift (AGENTS.md §7).
+
+## Alternatives
+
+1. **`FILTER_VALIDATE_URL` as the gate** — rejected on the probe: it rejects valid IDN
+   hosts (`https://exämple.com/`), trading a correctness bug for the control-character
+   check that an explicit refusal provides without the collateral damage.
+2. **Sanitize control characters instead of refusing** — rejected: it makes this class the
+   second component on the path that silently changes the caller's address, which is the
+   defect being fixed, not a fix for it.
+3. **Remove `withScheme()` entirely** (a scheme fixed at parse time cannot be downgraded) —
+   rejected: it also forbids the legitimate `http`→`https` upgrade, which is the operation a
+   consumer hardening a stored URL actually wants. Refusing only the downgrade keeps the
+   useful direction open.
+4. **An allowlist of permitted schemes** — rejected: fails closed on legitimate custom
+   schemes a library cannot enumerate, and the failure would surface as an unusable class
+   rather than as a security event.
+5. **Normalize the query on parse** (sort, re-encode canonically) — rejected: it breaks any
+   signature computed over the URL, silently, in the integrations that care most.
+6. **Type `null` out of `withQuery()`'s signature** — rejected: it would give a compile-time
+   error to PHPStan-max consumers and *nothing* to everyone else, while making the runtime
+   guard untestable. An untested guard is worse than a slightly wider type.
+
+## Consequences
+
+**Easier:** a URL can be inspected, edited and recomposed without a component going missing;
+credentials are reportable (`userInfo()`) and strippable (`withoutUserInfo()`) before a URL
+reaches a log; a downgrade is a caught exception rather than a plaintext request. Item 11.1's
+`HttpClient` inherits all of it, including the control-character refusal, before it builds
+its first request line.
+
+**Harder / accepted:** the class is stricter than `parse_url()`, so a caller passing a
+relative reference or a laundered string now gets an exception where PHP would have returned
+something; normalization is visible (`https://example.com` becomes `https://example.com/`),
+which a byte-comparison against the input will notice; and the unknown-scheme limit in §3
+means the downgrade refusal is not a complete scheme policy — it is the *known* downgrades,
+named.
+
+**Verification:** 82 tests across three suites, and the suite is **proved non-vacuous by 11
+planted defects** — neutering the control-character guard, dropping DEL from it, removing the
+downgrade check, making that check read the raw scheme (case evasion), form-encoding the
+query, dropping the null refusal, removing its recursion, dropping the absoluteness check,
+keeping the default port, skipping the scheme lowercase, and re-encoding the raw query at
+parse. Each was caught.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,3 +51,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0033](0033-bridge-source-in-the-monorepo-published-through-a-generated-split-repository.md) | The bridge's source lives in this monorepo; a generated, read-only split repository is only its publication target | Accepted |
 | [0034](0034-whole-collection-readers-on-request.md) | Whole-collection readers on `Request`, because a key-scoped reader cannot enumerate | Accepted |
 | [0035](0035-guard-the-ref-shape-rather-than-trust-a-glob-and-never-skip-release-mode.md) | Guard the ref shape rather than trust a glob, and never skip release mode | Accepted |
+| [0036](0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md) | Refuse the scheme downgrade, and refuse the characters `parse_url()` launders | Accepted |

--- a/docs/journal/2026/08/2026-08-06-url.md
+++ b/docs/journal/2026/08/2026-08-06-url.md
@@ -1,0 +1,81 @@
+# 2026-08-06 — The parser that launders
+
+Roadmap item **9.3**, third in Milestone 9 and the first RFC-0002 item carrying the
+security floor. Route `frontier-reasoning / extra`; run at standard tier — mismatch
+recorded, the pattern items 5.3–6.3 established.
+
+## The probe that rewrote the item
+
+I expected to write a value object whose interesting part was the downgrade refusal FR-27
+names. The first probe moved the centre of gravity:
+
+```
+parse_url("https://example.com\n/evil")  =>  host: "example.com_"
+```
+
+`parse_url()` does not reject control characters. It **rewrites** each one to `_` and
+reports success. So the parse looks clean, the components look plausible, and they are
+**not the string that was supplied**. Anything that validates the parsed host and then
+forwards the original URL is inspecting a value the attacker did not send — and CR/LF is
+precisely the payload that matters when the URL reaches a request line or a `Location`
+header.
+
+The guard is therefore a refusal at the front door, applied in `parse()` and in every
+wither, buying one invariant worth stating plainly: **the input and the parsed value are
+the same string.**
+
+`FILTER_VALIDATE_URL` would have caught that specific case, and I probed it before reaching
+for it — it rejects `https://exämple.com/`. Adopting it as the gate would have traded a
+security check for a correctness bug against every internationalized host.
+
+Two more probes shaped the class: `parse_url('not a url')` **succeeds**, returning
+`['path' => 'not a url']`, so "did it parse?" cannot answer "is this a URL?" — absoluteness
+is checked separately. And `http_build_query()` drops null values with no signal, so they
+are refused.
+
+## PHPStan found the guard incomplete
+
+The null refusal started as a loop over the top level. Typing the parameter honestly is
+what exposed the hole: the acceptable value shape is recursive (scalars, or nested arrays
+of scalars) and PHPDoc cannot express that without lying at some depth, so the parameter
+became `array<array-key, mixed>` — and with the static check gone, it was suddenly obvious
+that the runtime walk *was* the whole enforcement, and that it never descended.
+`['filter' => ['status' => null]]` would have been dropped as quietly as a top-level null.
+It now recurses and names the offender's dotted path.
+
+The wider split is the right one for this library anyway: spec §1 names native and legacy
+applications as the audience, and those consumers run no static analysis at all. A
+type-only refusal protects exactly the consumers least likely to need it.
+
+## The downgrade refusal is the second line, not the first
+
+Worth being honest about in the ADR: `withScheme()`'s refusal is the visible mechanism, but
+the one that actually kills the estate's defect is duller — the object **carries** its
+scheme through every recomposition, so "rebuild with a hardcoded `http://`" is not a thing
+this class can be made to do. The refusal covers the remaining case, an explicit downgrade,
+and covers it only for the pairs it knows: an **unknown** target scheme is allowed through,
+because the security properties of a scheme nobody enumerated cannot be asserted. That
+limit has a test of its own, so it is visible rather than discovered.
+
+## The registry caught me
+
+Adding `InvalidUrlException` turned `ExceptionHierarchyTest` red — the discovery test that
+enumerates Support's exceptions from disk and pins the set. It did exactly what item 6.3
+built that shape for. Updating it is the correct response, and the same pass caught that
+spec r3's exception enumeration had not anticipated the type: amended to **r4** in this PR
+rather than left to drift.
+
+## Gates
+
+82 new tests across three suites; full suite 1468 green. **Suite proved non-vacuous with 11
+planted defects** — control-char guard neutered, DEL dropped from it, downgrade check
+removed, downgrade check reading the raw scheme (case evasion), form-encoded query, null
+refusal removed, its recursion removed, absoluteness check removed, default port kept,
+scheme lowercase skipped, raw query re-encoded at parse. All eleven caught. PHPStan max
+clean, CS-Fixer clean, deptrac 0/0, `consistency_lint` green, leak-gate zero.
+
+## Lesson
+
+Probe the standard-library function before designing around it: `parse_url()` looked like a
+parser that either succeeds or fails, and it is neither — it succeeds while quietly
+changing the value, which is the one behaviour a security check cannot survive.

--- a/docs/specs/01_spec_utils.md
+++ b/docs/specs/01_spec_utils.md
@@ -3,7 +3,7 @@
 > Rendered from the intake interview (Phase 5). Frozen contract: diverging implementation
 > updates this spec in the same PR or adds an ADR superseding the relevant section.
 
-**Revision r3** — 2026-08-06. See [Revision history](#revision-history).
+**Revision r4** — 2026-08-06. See [Revision history](#revision-history).
 
 ## 1. Objective & Business Context
 
@@ -39,11 +39,11 @@ Provide EGL PHP projects (framework-based and native/legacy) with a modern utili
 **r3 addendum (RFC-0002)** — normative detail in
 [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md); one error-model rule
 spans all of it: **no silent sentinel returns** — every new failure path throws a typed
-exception in the FR-26 hierarchy (new: CsvException, SequenceExhaustedException,
+exception in the FR-26 hierarchy (new: InvalidUrlException, CsvException, SequenceExhaustedException,
 HttpClientException, RouteNotFoundException, MethodNotAllowedException, CryptoException,
 MailException).
 
-- FR-27 Url: parse/normalize/build value object; refuses scheme downgrade on rebuild; query composition without hand-concatenation
+- FR-27 Url: parse/normalize/build value object; absolute URLs only; refuses C0/DEL control characters up front (parse_url() rewrites them to "_" rather than rejecting them — ADR-0036); refuses a scheme downgrade (https->http, wss->ws, ftps/sftp->ftp; an unknown target scheme is allowed through — recorded limit); query preserved byte-exact until edited, composed per RFC 3986, null values refused at any depth
 - FR-28 Csv + Delimiter enum: streaming write/read, typed failures (never boolean), atomic write via File; formula-guard opt-in (default off — input-mutilation lesson, spec §1)
 - FR-29 CsvSerializable: csvHeader()/csvRow() contract; reflective default documented via ClassMetadata
 - FR-30 Lookup: immutable code→label map; label() throws on a missing key, labelOr()/tryLabel() tolerant
@@ -161,6 +161,7 @@ non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.y
 |-----|------|--------|
 | r1 | 2026-08-03 | Frozen from the imported `.specs/d4np-php.md` v2.0 via RFC-0001 (naming mapping A-7). |
 | r2 | 2026-08-05 | §6/T-03: the `hash_equals` **timing test** is replaced by a **mechanism assertion**. Rationale below; see [ADR-0027](../adr/0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md). |
+| r4 | 2026-08-06 | §2: FR-27 stated to the precision item 9.3 implemented (control-character refusal, absolute-only, the named downgrade pairs and their recorded limit, query preservation), and `InvalidUrlException` added to the r3 exception enumeration, which had not anticipated it. Additive; see [ADR-0036](../adr/0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md). |
 | r3 | 2026-08-06 | §2–§6: the RFC-0002 surface — FR-27…FR-44, NFR-09…NFR-14, suites T-07…T-15, the Persistence/Mail groups and the two named layering edges. Additive; no existing requirement changed. Source: [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) (approved 2026-08-05, PR #49); roadmap: M9–M12. |
 
 ### r2 rationale — why T-03 asserts a mechanism instead of measuring time

--- a/src/main/php/d4np/utils/Support/InvalidUrlException.php
+++ b/src/main/php/d4np/utils/Support/InvalidUrlException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * A URL string could not be accepted, or an operation on one was refused.
+ *
+ * Raised by {@see Url} for four distinct causes, each named in the message: a control
+ * character in the input (see ADR-0036 — `parse_url()` silently rewrites those to `_`
+ * rather than rejecting them), a string that is not an absolute URL, a string
+ * `parse_url()` cannot decompose at all, and a refused **scheme downgrade**.
+ *
+ * One type rather than four: the message names the cause, and a consumer that later needs
+ * to branch on one of them gets a subclass additively (the item 9.1 / 9.2 precedent — a
+ * distinct type is earned by a consumer that needs the distinct `catch`, not anticipated).
+ * What a consumer does need today is to separate "this URL is unusable" from every other
+ * library failure, which is what this type provides.
+ */
+final class InvalidUrlException extends UtilsException
+{
+}

--- a/src/main/php/d4np/utils/Support/Url.php
+++ b/src/main/php/d4np/utils/Support/Url.php
@@ -1,0 +1,459 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * An immutable absolute URL: parse, inspect, recompose (spec r3 FR-27, RFC-0002; ADR-0036).
+ *
+ * Two defects from the surveyed estate shape this class.
+ *
+ * **The scheme was thrown away.** Its URL helper decomposed a URL and rebuilt it as
+ * `"http://{$host}{$path}"` — a hardcoded scheme, so every `https` address it touched came
+ * back as plaintext, and the query and fragment vanished with it. Here the scheme is carried
+ * by the object, so no recomposition can lose it, and {@see self::withScheme()} additionally
+ * **refuses a downgrade** (a TLS-protected scheme to its plaintext counterpart) rather than
+ * performing it quietly.
+ *
+ * **`parse_url()` launders control characters.** It does not reject `\r`, `\n`, `\0` or `\t`
+ * — it silently rewrites each to `_`, so `https://example.com\n/evil` parses to the host
+ * `example.com_`. Code that validates the parsed components and then uses the *original*
+ * string is checking a value the attacker did not send. {@see self::parse()} therefore
+ * refuses control characters before `parse_url()` ever sees them, and every wither applies
+ * the same guard to what it is given.
+ *
+ * Immutable throughout: every `with*()` returns a new instance.
+ */
+final class Url
+{
+    /**
+     * Schemes whose transport is encrypted, mapped to the plaintext scheme a downgrade would
+     * reach. {@see self::withScheme()} refuses exactly these transitions.
+     */
+    private const DOWNGRADE_TARGETS = [
+        'https' => ['http'],
+        'wss' => ['ws'],
+        'ftps' => ['ftp'],
+        'sftp' => ['ftp'],
+    ];
+
+    /**
+     * The port each scheme uses by default. A URL carrying its scheme's default port
+     * normalizes to no port at all, since the two forms address the same resource.
+     */
+    private const DEFAULT_PORTS = [
+        'http' => 80,
+        'https' => 443,
+        'ws' => 80,
+        'wss' => 443,
+        'ftp' => 21,
+        'sftp' => 22,
+    ];
+
+    private function __construct(
+        private readonly string $scheme,
+        private readonly ?string $userInfo,
+        private readonly string $host,
+        private readonly ?int $port,
+        private readonly string $path,
+        private readonly string $rawQuery,
+        private readonly ?string $fragment,
+    ) {
+    }
+
+    /**
+     * Parses an **absolute** URL — one carrying both a scheme and a host.
+     *
+     * Relative references are refused rather than guessed at: `parse_url('not a url')`
+     * succeeds, returning `['path' => 'not a url']`, so "did this parse?" is not a question
+     * `parse_url()` can answer. FR-27's purpose is addresses that survive recomposition, and
+     * a string with no scheme has nothing to protect from downgrade.
+     *
+     * Normalization applied here, and nowhere else: the scheme and host are lowercased (RFC
+     * 3986 §6.2.2.1 — both are case-insensitive; the **path is not** and is left alone), a
+     * port equal to the scheme's default is dropped, and an empty path becomes `/`. The query
+     * string is preserved **byte-exact**; see {@see self::rawQuery()}.
+     *
+     * @throws InvalidUrlException if the input holds a control character, is not absolute, or
+     *                             cannot be decomposed
+     */
+    public static function parse(string $url): self
+    {
+        self::guardControlCharacters($url, 'URL');
+
+        $parts = parse_url($url);
+        if ($parts === false) {
+            throw new InvalidUrlException(sprintf('Cannot parse "%s" as a URL.', $url));
+        }
+
+        $scheme = isset($parts['scheme']) ? strtolower($parts['scheme']) : '';
+        $host = isset($parts['host']) ? strtolower($parts['host']) : '';
+
+        if ($scheme === '' || $host === '') {
+            throw new InvalidUrlException(sprintf(
+                'An absolute URL (scheme and host) is required, got "%s".',
+                $url,
+            ));
+        }
+
+        $userInfo = null;
+        if (isset($parts['user'])) {
+            $userInfo = isset($parts['pass'])
+                ? $parts['user'] . ':' . $parts['pass']
+                : $parts['user'];
+        }
+
+        return new self(
+            $scheme,
+            $userInfo,
+            $host,
+            self::normalizePort($scheme, $parts['port'] ?? null),
+            self::normalizePath($parts['path'] ?? ''),
+            $parts['query'] ?? '',
+            $parts['fragment'] ?? null,
+        );
+    }
+
+    public function scheme(): string
+    {
+        return $this->scheme;
+    }
+
+    public function host(): string
+    {
+        return $this->host;
+    }
+
+    /**
+     * The port, or `null` when the URL uses its scheme's default (or names none).
+     */
+    public function port(): ?int
+    {
+        return $this->port;
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * The query string exactly as it arrived — no decoding, no re-encoding, no reordering.
+     *
+     * This is the authoritative form. A query is preserved byte-for-byte until a `withQuery*`
+     * call replaces it, because re-encoding one the caller did not touch would invalidate any
+     * signature computed over it.
+     */
+    public function rawQuery(): string
+    {
+        return $this->rawQuery;
+    }
+
+    /**
+     * The query decoded into an array, via `parse_str()`.
+     *
+     * A convenience over {@see self::rawQuery()}, and **lossy in the way `parse_str()` is**:
+     * repeated keys collapse to the last occurrence (`a=1&a=2` decodes to `['a' => '2']`) and
+     * `a[]=x` becomes a nested array. When exactness matters, read the raw query.
+     *
+     * Keys are `array-key`, not `string`: `?0=zero` yields the **integer** key `0`, the same
+     * superglobal-key lesson ADR-0025 recorded for `Request`.
+     *
+     * @return array<array-key, array<mixed>|string>
+     */
+    public function query(): array
+    {
+        parse_str($this->rawQuery, $decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * The fragment without its `#`, or `null` when the URL carries none.
+     */
+    public function fragment(): ?string
+    {
+        return $this->fragment;
+    }
+
+    /**
+     * The `user` or `user:password` component, or `null`.
+     *
+     * Reported truthfully rather than hidden, so a caller can detect credentials and act;
+     * {@see self::withoutUserInfo()} is the way to strip them before a URL reaches a log.
+     * Note that credentials shift what the host is: in `https://example.com\@evil.com/` the
+     * host is **`evil.com`** and `example.com\` is the user — correct per RFC 3986, and the
+     * reason a host check must read {@see self::host()} rather than search the raw string.
+     */
+    public function userInfo(): ?string
+    {
+        return $this->userInfo;
+    }
+
+    /**
+     * The same URL under a different scheme — **unless that is a downgrade**.
+     *
+     * A downgrade is a transition from an encrypted transport to its plaintext counterpart
+     * (`https`→`http`, `wss`→`ws`, `ftps`/`sftp`→`ftp`), and is refused. Upgrades and
+     * same-scheme calls pass. A scheme this class does not know is allowed through, because
+     * the security properties of an unrecognised scheme cannot be asserted and refusing every
+     * unknown would make custom schemes unusable — the honest limit, recorded in ADR-0036.
+     *
+     * @throws InvalidUrlException on a downgrade, a syntactically invalid scheme, or a control
+     *                             character
+     */
+    public function withScheme(string $scheme): self
+    {
+        self::guardControlCharacters($scheme, 'Scheme');
+        $normalized = strtolower($scheme);
+
+        if (preg_match('/\A[a-z][a-z0-9+.\-]*\z/', $normalized) !== 1) {
+            throw new InvalidUrlException(sprintf(
+                'Invalid scheme "%s": a scheme is a letter followed by letters, digits, '
+                . '"+", "-" or "." (RFC 3986 §3.1).',
+                $scheme,
+            ));
+        }
+
+        if (in_array($normalized, self::DOWNGRADE_TARGETS[$this->scheme] ?? [], true)) {
+            throw new InvalidUrlException(sprintf(
+                'Refusing to downgrade "%s" to "%s": the transport would go from encrypted '
+                . 'to plaintext. Build the URL with the intended scheme instead.',
+                $this->scheme,
+                $normalized,
+            ));
+        }
+
+        return new self(
+            $normalized,
+            $this->userInfo,
+            $this->host,
+            // The old port may have been the old scheme's default; re-normalize against the new.
+            self::normalizePort($normalized, $this->port),
+            $this->path,
+            $this->rawQuery,
+            $this->fragment,
+        );
+    }
+
+    /**
+     * @throws InvalidUrlException on a control character
+     */
+    public function withPath(string $path): self
+    {
+        self::guardControlCharacters($path, 'Path');
+
+        return new self(
+            $this->scheme,
+            $this->userInfo,
+            $this->host,
+            $this->port,
+            self::normalizePath($path),
+            $this->rawQuery,
+            $this->fragment,
+        );
+    }
+
+    /**
+     * Replaces the entire query, encoding `$params` per RFC 3986 (spaces become `%20`, not
+     * `+` — `http_build_query()`'s default is the HTML-form encoding, which is not what a URL
+     * query is).
+     *
+     * A `null` value is **refused**, not dropped: `http_build_query()` silently omits null
+     * entries, so a caller who meant "send this key empty" would get a URL missing the key
+     * with nothing to indicate it. Remove a key with {@see self::withoutQueryParam()} and pass
+     * `''` for an empty value. The check descends into nested arrays, naming the dotted path
+     * of the offender — `http_build_query()` drops a nested null just as quietly as a
+     * top-level one.
+     *
+     * Values may be scalars or nested arrays of scalars. The parameter is typed
+     * `array<array-key, mixed>` rather than a scalar union because the acceptable shape is
+     * recursive and PHPDoc cannot express that without lying at some depth; the runtime walk
+     * below is the real enforcement, which is also what serves this library's stated
+     * native/legacy audience (spec §1) — those consumers run no static analysis at all.
+     *
+     * @param array<array-key, mixed> $params
+     *
+     * @throws InvalidUrlException if any value, at any depth, is `null`
+     */
+    public function withQuery(array $params): self
+    {
+        self::guardNoNullValues($params, '');
+
+        return new self(
+            $this->scheme,
+            $this->userInfo,
+            $this->host,
+            $this->port,
+            $this->path,
+            http_build_query($params, '', '&', PHP_QUERY_RFC3986),
+            $this->fragment,
+        );
+    }
+
+    /**
+     * Adds or replaces one query parameter, leaving the rest as {@see self::query()} decodes
+     * them. A `bool` encodes as `1`/`0`, matching `http_build_query()`.
+     *
+     * Because this re-encodes the whole query, a raw query with repeated keys loses its
+     * duplicates here — the `parse_str()` limit named on {@see self::query()}.
+     */
+    public function withQueryParam(string $key, string|int|float|bool $value): self
+    {
+        $params = $this->query();
+        $params[$key] = $value;
+
+        return $this->withQuery($params);
+    }
+
+    /**
+     * Removes one query parameter. Removing a key that is not present is a no-op, not an
+     * error — the caller's intent ("this key must not be in the URL") is satisfied either way.
+     */
+    public function withoutQueryParam(string $key): self
+    {
+        $params = $this->query();
+        unset($params[$key]);
+
+        return $this->withQuery($params);
+    }
+
+    /**
+     * @throws InvalidUrlException on a control character
+     */
+    public function withFragment(?string $fragment): self
+    {
+        if ($fragment !== null) {
+            self::guardControlCharacters($fragment, 'Fragment');
+        }
+
+        return new self(
+            $this->scheme,
+            $this->userInfo,
+            $this->host,
+            $this->port,
+            $this->path,
+            $this->rawQuery,
+            $fragment,
+        );
+    }
+
+    /**
+     * The same URL with any credentials stripped — the form to log, store, or report.
+     */
+    public function withoutUserInfo(): self
+    {
+        return new self(
+            $this->scheme,
+            null,
+            $this->host,
+            $this->port,
+            $this->path,
+            $this->rawQuery,
+            $this->fragment,
+        );
+    }
+
+    /**
+     * The recomposed URL.
+     *
+     * Stable under re-parsing: `Url::parse((string) $url)` yields an equal object, because
+     * every normalization this class performs happens at {@see self::parse()} and is therefore
+     * already applied to what this returns.
+     */
+    public function toString(): string
+    {
+        $authority = $this->host;
+        if ($this->userInfo !== null) {
+            $authority = $this->userInfo . '@' . $authority;
+        }
+        if ($this->port !== null) {
+            $authority .= ':' . $this->port;
+        }
+
+        $url = $this->scheme . '://' . $authority . $this->path;
+
+        if ($this->rawQuery !== '') {
+            $url .= '?' . $this->rawQuery;
+        }
+        if ($this->fragment !== null) {
+            $url .= '#' . $this->fragment;
+        }
+
+        return $url;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    /**
+     * Refuses C0 controls and DEL anywhere in `$value`.
+     *
+     * The guard exists because `parse_url()` **rewrites** these to `_` instead of rejecting
+     * them (ADR-0036): the parse appears to succeed and the components come back subtly
+     * different from what was supplied, which is how a CRLF payload survives a validation
+     * step that inspects the parsed result. Refusing early keeps input and parsed value the
+     * same thing.
+     *
+     * @throws InvalidUrlException if a control character is present
+     */
+    private static function guardControlCharacters(string $value, string $subject): void
+    {
+        if (preg_match('/[\x00-\x1F\x7F]/', $value) === 1) {
+            throw new InvalidUrlException(sprintf(
+                '%s contains a control character. parse_url() would rewrite it to "_" rather '
+                . 'than reject it, so the parsed value would differ from the input.',
+                $subject,
+            ));
+        }
+    }
+
+    /**
+     * Refuses a `null` anywhere in the parameter tree, naming its dotted path.
+     *
+     * @param array<array-key, mixed> $params
+     *
+     * @throws InvalidUrlException
+     */
+    private static function guardNoNullValues(array $params, string $prefix): void
+    {
+        foreach ($params as $key => $value) {
+            $path = $prefix === '' ? (string) $key : $prefix . '.' . $key;
+
+            if ($value === null) {
+                throw new InvalidUrlException(sprintf(
+                    'Query parameter "%s" is null, which http_build_query() would drop '
+                    . 'silently. Pass "" for an empty value, or withoutQueryParam() to remove '
+                    . 'the key.',
+                    $path,
+                ));
+            }
+
+            if (is_array($value)) {
+                self::guardNoNullValues($value, $path);
+            }
+        }
+    }
+
+    private static function normalizePort(string $scheme, ?int $port): ?int
+    {
+        if ($port === null) {
+            return null;
+        }
+
+        return (self::DEFAULT_PORTS[$scheme] ?? null) === $port ? null : $port;
+    }
+
+    /**
+     * An empty path becomes `/`: with an authority present the two forms address the same
+     * resource (RFC 3986 §6.2.3), and choosing one keeps recomposition stable under
+     * re-parsing.
+     */
+    private static function normalizePath(string $path): string
+    {
+        return $path === '' ? '/' : $path;
+    }
+}

--- a/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
+++ b/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
@@ -8,6 +8,7 @@ use D4np\Utils\Support\DatabaseException;
 use D4np\Utils\Support\FileException;
 use D4np\Utils\Support\HttpException;
 use D4np\Utils\Support\HydrationException;
+use D4np\Utils\Support\InvalidUrlException;
 use D4np\Utils\Support\JsonException;
 use D4np\Utils\Support\MissingKeyException;
 use D4np\Utils\Support\TypeMismatchException;
@@ -89,6 +90,7 @@ final class ExceptionHierarchyTest extends TestCase
                 FileException::class,
                 HttpException::class,
                 HydrationException::class,
+                InvalidUrlException::class,
                 JsonException::class,
                 MissingKeyException::class,
                 TypeMismatchException::class,
@@ -160,6 +162,7 @@ final class ExceptionHierarchyTest extends TestCase
             DatabaseException::class,
             FileException::class,
             HttpException::class,
+            InvalidUrlException::class,
             JsonException::class,
             MissingKeyException::class,
             TypeMismatchException::class,

--- a/src/test/php/d4np/utils/Support/UrlQueryTest.php
+++ b/src/test/php/d4np/utils/Support/UrlQueryTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\InvalidUrlException;
+use D4np\Utils\Support\Url;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Query composition — spec r3 FR-27's "query composition without hand-concatenation"
+ * (RFC-0002), ADR-0036.
+ *
+ * Two behaviours are load-bearing and both are non-obvious: an untouched query is preserved
+ * **byte-exact** (re-encoding one nobody edited would invalidate a signature computed over
+ * it), and a composed query is RFC 3986-encoded rather than form-encoded.
+ */
+final class UrlQueryTest extends TestCase
+{
+    public function testAnUntouchedQueryIsPreservedByteExact(): void
+    {
+        // Deliberately non-canonical: unsorted, mixed encodings, a repeated key. None of it
+        // is rewritten, because nothing asked for it to be.
+        $raw = 'z=1&a=%20&a=2&flag&s=a+b';
+
+        self::assertSame($raw, Url::parse("https://example.com/?{$raw}")->rawQuery());
+        self::assertSame("https://example.com/?{$raw}", Url::parse("https://example.com/?{$raw}")->toString());
+    }
+
+    public function testQueryDecodesToAnArray(): void
+    {
+        self::assertSame(
+            ['a' => '1', 'b' => 'two'],
+            Url::parse('https://example.com/?a=1&b=two')->query(),
+        );
+    }
+
+    public function testDecodingIsLossyForRepeatedKeysWhichIsWhyRawQueryExists(): void
+    {
+        $url = Url::parse('https://example.com/?a=1&a=2');
+
+        // parse_str() keeps the last occurrence — documented on query(), pinned here.
+        self::assertSame(['a' => '2'], $url->query());
+        self::assertSame('a=1&a=2', $url->rawQuery());
+    }
+
+    public function testWithQueryEncodesPerRfc3986NotAsAForm(): void
+    {
+        $url = Url::parse('https://example.com/')->withQuery(['s' => 'a b']);
+
+        // http_build_query()'s default would give 's=a+b' — the HTML-form encoding, which is
+        // not what a URL query is.
+        self::assertSame('s=a%20b', $url->rawQuery());
+    }
+
+    public function testWithQueryReplacesTheWholeQuery(): void
+    {
+        self::assertSame(
+            'https://example.com/?c=3',
+            Url::parse('https://example.com/?a=1&b=2')->withQuery(['c' => '3'])->toString(),
+        );
+    }
+
+    public function testWithQueryAcceptsAnEmptyArrayAndDropsTheQuestionMark(): void
+    {
+        self::assertSame(
+            'https://example.com/a',
+            Url::parse('https://example.com/a?x=1')->withQuery([])->toString(),
+        );
+    }
+
+    public function testNullValuesAreRefusedRatherThanSilentlyDropped(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('null');
+
+        Url::parse('https://example.com/')->withQuery(['a' => '1', 'b' => null]);
+    }
+
+    public function testHttpBuildQueryDropsNullsWhichIsWhyTheyAreRefused(): void
+    {
+        // Pinning the PHP behaviour the refusal exists for: 'b' vanishes without a trace.
+        self::assertSame('a=1', http_build_query(['a' => '1', 'b' => null], '', '&', PHP_QUERY_RFC3986));
+    }
+
+    public function testANestedNullIsRefusedAndItsPathIsNamed(): void
+    {
+        // A nested null is dropped exactly as quietly as a top-level one, so the guard
+        // descends. PHPStan is what surfaced this: the acceptable shape is recursive, the
+        // type cannot say so, and the first version of the guard only walked the top level.
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('"filter.status" is null');
+
+        Url::parse('https://example.com/')->withQuery(['filter' => ['status' => null]]);
+    }
+
+    public function testNestedArraysOfScalarsAreAccepted(): void
+    {
+        $url = Url::parse('https://example.com/')->withQuery(['f' => ['a' => '1', 'b' => '2']]);
+
+        self::assertSame('f%5Ba%5D=1&f%5Bb%5D=2', $url->rawQuery());
+        self::assertSame(['f' => ['a' => '1', 'b' => '2']], $url->query());
+    }
+
+    public function testAnIntegerQueryKeyDecodesAsAnIntegerNotAString(): void
+    {
+        // The superglobal-key lesson from ADR-0025, in a query string: '?0=zero' yields the
+        // INTEGER key 0, which is why query() is typed array-key rather than string.
+        self::assertSame([0 => 'zero'], Url::parse('https://example.com/?0=zero')->query());
+    }
+
+    public function testWithQueryParamAddsAKey(): void
+    {
+        self::assertSame(
+            'a=1&b=2',
+            Url::parse('https://example.com/?a=1')->withQueryParam('b', '2')->rawQuery(),
+        );
+    }
+
+    public function testWithQueryParamReplacesAnExistingKey(): void
+    {
+        self::assertSame(
+            'a=9',
+            Url::parse('https://example.com/?a=1')->withQueryParam('a', '9')->rawQuery(),
+        );
+    }
+
+    public function testWithQueryParamAcceptsScalarsAndEncodesBoolsAsDigits(): void
+    {
+        $url = Url::parse('https://example.com/')
+            ->withQueryParam('i', 42)
+            ->withQueryParam('f', 1.5)
+            ->withQueryParam('t', true)
+            ->withQueryParam('e', '');
+
+        self::assertSame('i=42&f=1.5&t=1&e=', $url->rawQuery());
+    }
+
+    public function testWithQueryParamEncodesSpecialCharacters(): void
+    {
+        $url = Url::parse('https://example.com/')->withQueryParam('q', 'a&b=c d');
+
+        self::assertSame('q=a%26b%3Dc%20d', $url->rawQuery());
+        self::assertSame(['q' => 'a&b=c d'], $url->query());
+    }
+
+    public function testWithoutQueryParamRemovesOneKey(): void
+    {
+        self::assertSame(
+            'a=1',
+            Url::parse('https://example.com/?a=1&b=2')->withoutQueryParam('b')->rawQuery(),
+        );
+    }
+
+    public function testRemovingTheLastParamLeavesNoQuestionMark(): void
+    {
+        self::assertSame(
+            'https://example.com/',
+            Url::parse('https://example.com/?a=1')->withoutQueryParam('a')->toString(),
+        );
+    }
+
+    public function testRemovingAnAbsentKeyIsANoOp(): void
+    {
+        self::assertSame(
+            'a=1',
+            Url::parse('https://example.com/?a=1')->withoutQueryParam('zzz')->rawQuery(),
+        );
+    }
+
+    public function testEditingAQueryReEncodesItAndLosesDuplicateKeys(): void
+    {
+        // The documented consequence of decode-edit-encode: stated here so it is a known
+        // trade-off rather than a surprise. rawQuery() is the exact form; editing leaves it.
+        $url = Url::parse('https://example.com/?a=1&a=2')->withQueryParam('b', '3');
+
+        self::assertSame('a=2&b=3', $url->rawQuery());
+    }
+
+    public function testQueryParamSurvivesFragmentAndPathEdits(): void
+    {
+        $url = Url::parse('https://example.com/x?a=1#f')->withPath('/y');
+
+        self::assertSame('https://example.com/y?a=1#f', $url->toString());
+    }
+}

--- a/src/test/php/d4np/utils/Support/UrlSchemeDowngradeTest.php
+++ b/src/test/php/d4np/utils/Support/UrlSchemeDowngradeTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\InvalidUrlException;
+use D4np\Utils\Support\Url;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The scheme policy — spec r3 FR-27's security clause (RFC-0002), ADR-0036.
+ *
+ * The estate defect this closes: a URL helper that decomposed an address and rebuilt it as
+ * `"http://{$host}{$path}"`, so every `https` URL it touched came back plaintext. Two
+ * mechanisms are asserted here — that recomposition **carries** the scheme (the defect is
+ * structurally unreachable), and that an explicit downgrade is **refused**.
+ */
+final class UrlSchemeDowngradeTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function refusedDowngrades(): iterable
+    {
+        yield 'https to http' => ['https://example.com/a', 'http'];
+        yield 'wss to ws' => ['wss://example.com/socket', 'ws'];
+        yield 'ftps to ftp' => ['ftps://example.com/file', 'ftp'];
+        yield 'sftp to ftp' => ['sftp://example.com/file', 'ftp'];
+        yield 'case does not evade the check' => ['https://example.com/a', 'HTTP'];
+    }
+
+    #[DataProvider('refusedDowngrades')]
+    public function testDowngradeIsRefused(string $url, string $target): void
+    {
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('Refusing to downgrade');
+
+        Url::parse($url)->withScheme($target);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function allowedTransitions(): iterable
+    {
+        yield 'http to https is an upgrade' => ['http://example.com/a', 'https', 'https://example.com/a'];
+        yield 'ws to wss is an upgrade' => ['ws://example.com/s', 'wss', 'wss://example.com/s'];
+        yield 'same scheme' => ['https://example.com/a', 'https', 'https://example.com/a'];
+        yield 'plaintext to plaintext' => ['http://example.com/a', 'ftp', 'ftp://example.com/a'];
+    }
+
+    #[DataProvider('allowedTransitions')]
+    public function testAllowedTransitions(string $url, string $target, string $expected): void
+    {
+        self::assertSame($expected, Url::parse($url)->withScheme($target)->toString());
+    }
+
+    public function testAnUnknownSchemeIsAllowedThroughWhichIsTheRecordedLimit(): void
+    {
+        // ADR-0036's honest limit: the security properties of an unrecognised scheme cannot
+        // be asserted, so only *known* plaintext counterparts are refused. This test exists
+        // so the limit is visible rather than discovered.
+        self::assertSame(
+            'myapp://example.com/a',
+            Url::parse('https://example.com/a')->withScheme('myapp')->toString(),
+        );
+    }
+
+    public function testTheSchemeSurvivesEveryRecomposition(): void
+    {
+        // The estate defect directly: no sequence of edits can silently yield plaintext.
+        $url = Url::parse('https://example.com/old?a=1#f')
+            ->withPath('/new')
+            ->withQueryParam('b', '2')
+            ->withFragment('g')
+            ->withoutUserInfo();
+
+        self::assertSame('https', $url->scheme());
+        self::assertStringStartsWith('https://', $url->toString());
+    }
+
+    public function testUpgradeReNormalizesThePortAgainstTheNewScheme(): void
+    {
+        // :443 is not http's default, so it survives; after the upgrade it IS https's
+        // default and must drop, or the URL would carry a redundant port.
+        $url = Url::parse('http://example.com:443/a');
+
+        self::assertSame(443, $url->port());
+        self::assertSame('https://example.com/a', $url->withScheme('https')->toString());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidSchemes(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'leading digit' => ['1http'];
+        yield 'contains a colon' => ['http:'];
+        yield 'contains a slash' => ['ht/tp'];
+        yield 'contains a space' => ['ht tp'];
+    }
+
+    #[DataProvider('invalidSchemes')]
+    public function testSyntacticallyInvalidSchemesAreRefused(string $scheme): void
+    {
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('Invalid scheme');
+
+        Url::parse('https://example.com/')->withScheme($scheme);
+    }
+
+    public function testASchemeCarryingCrlfIsRefusedBeforeItReachesTheString(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('control character');
+
+        Url::parse('https://example.com/')->withScheme("https\r\nX-Injected: 1");
+    }
+}

--- a/src/test/php/d4np/utils/Support/UrlTest.php
+++ b/src/test/php/d4np/utils/Support/UrlTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\InvalidUrlException;
+use D4np\Utils\Support\Url;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Url` parsing, normalization and recomposition — spec r3 FR-27 (RFC-0002), ADR-0036.
+ *
+ * The downgrade policy has its own suite ({@see UrlSchemeDowngradeTest}); this one covers
+ * what the object must get right before that policy means anything: that it refuses input
+ * `parse_url()` would launder, that it refuses relative references `parse_url()` accepts,
+ * and that it recomposes without losing a component.
+ */
+final class UrlTest extends TestCase
+{
+    public function testParsesEveryComponent(): void
+    {
+        $url = Url::parse('https://user:pass@example.com:8443/a/b?q=1&r=2#frag');
+
+        self::assertSame('https', $url->scheme());
+        self::assertSame('user:pass', $url->userInfo());
+        self::assertSame('example.com', $url->host());
+        self::assertSame(8443, $url->port());
+        self::assertSame('/a/b', $url->path());
+        self::assertSame('q=1&r=2', $url->rawQuery());
+        self::assertSame('frag', $url->fragment());
+    }
+
+    public function testRoundTripsAFullUrlUnchanged(): void
+    {
+        $input = 'https://user:pass@example.com:8443/a/b?q=1&r=2#frag';
+
+        self::assertSame($input, Url::parse($input)->toString());
+    }
+
+    public function testStringCastIsTheRecomposedUrl(): void
+    {
+        $url = Url::parse('https://example.com/a');
+
+        self::assertSame($url->toString(), (string) $url);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function normalizationCases(): iterable
+    {
+        yield 'scheme lowercased' => ['HTTPS://example.com/', 'https://example.com/'];
+        yield 'host lowercased' => ['https://EXAMPLE.COM/', 'https://example.com/'];
+        yield 'path case preserved' => ['https://example.com/Path', 'https://example.com/Path'];
+        yield 'default https port dropped' => ['https://example.com:443/x', 'https://example.com/x'];
+        yield 'default http port dropped' => ['http://example.com:80/x', 'http://example.com/x'];
+        yield 'non-default port kept' => ['https://example.com:8443/x', 'https://example.com:8443/x'];
+        yield 'empty path becomes slash' => ['https://example.com', 'https://example.com/'];
+        yield 'query preserved byte-exact' => ['https://example.com/?b=2&a=1', 'https://example.com/?b=2&a=1'];
+        yield 'encoded query untouched' => ['https://example.com/?s=a%20b', 'https://example.com/?s=a%20b'];
+    }
+
+    #[DataProvider('normalizationCases')]
+    public function testNormalization(string $input, string $expected): void
+    {
+        self::assertSame($expected, Url::parse($input)->toString());
+    }
+
+    #[DataProvider('normalizationCases')]
+    public function testRecompositionIsStableUnderReparsing(string $input): void
+    {
+        $once = Url::parse($input)->toString();
+
+        self::assertSame($once, Url::parse($once)->toString());
+    }
+
+    /**
+     * The finding behind ADR-0036: `parse_url()` does not reject control characters, it
+     * rewrites each to `_`. Both halves are asserted — PHP's laundering, and our refusal —
+     * because the refusal only matters if the underlying behavior is what we claim.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function controlCharacterCases(): iterable
+    {
+        yield 'newline' => ["https://example.com\n/evil"];
+        yield 'carriage return' => ["https://example.com/a\rb"];
+        yield 'CRLF' => ["https://example.com/a\r\nb"];
+        yield 'NUL' => ["https://example.com/a\0b"];
+        yield 'tab in host' => ["https://exam\tple.com/"];
+        yield 'DEL' => ["https://example.com/a\x7Fb"];
+    }
+
+    #[DataProvider('controlCharacterCases')]
+    public function testControlCharactersAreRefused(string $input): void
+    {
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('control character');
+
+        Url::parse($input);
+    }
+
+    public function testParseUrlLaundersControlCharactersWhichIsWhyWeRefuseThem(): void
+    {
+        // Not testing our code: pinning the PHP behavior the guard exists for, so that if a
+        // future PHP starts rejecting these outright, this test says so.
+        $parts = parse_url("https://example.com\n/evil");
+
+        self::assertIsArray($parts);
+        self::assertSame('example.com_', $parts['host'] ?? null);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function notAbsoluteCases(): iterable
+    {
+        yield 'bare word' => ['not a url'];
+        yield 'relative path' => ['/just/a/path'];
+        yield 'protocol-relative' => ['//example.com/path'];
+        yield 'scheme with no host' => ['mailto:someone@example.com'];
+        yield 'empty string' => [''];
+    }
+
+    #[DataProvider('notAbsoluteCases')]
+    public function testRelativeReferencesAreRefused(string $input): void
+    {
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('absolute URL');
+
+        Url::parse($input);
+    }
+
+    public function testParseUrlAcceptsABareWordWhichIsWhyAbsolutenessIsCheckedSeparately(): void
+    {
+        // parse_url('not a url') succeeds with ['path' => 'not a url'], so "did it parse?"
+        // cannot answer "is this a URL?".
+        self::assertSame(['path' => 'not a url'], parse_url('not a url'));
+    }
+
+    public function testUnparseableStringIsRefused(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+
+        // parse_url() returns false for this one.
+        Url::parse('http:///path');
+    }
+
+    public function testCredentialsAreReportedTruthfullyAndCanBeStripped(): void
+    {
+        $url = Url::parse('https://user:secret@example.com/a');
+
+        self::assertSame('user:secret', $url->userInfo());
+        self::assertSame('https://example.com/a', $url->withoutUserInfo()->toString());
+    }
+
+    public function testUserOnlyCredentialHasNoColon(): void
+    {
+        self::assertSame('user', Url::parse('https://user@example.com/')->userInfo());
+    }
+
+    public function testHostIsTheAuthorityAfterAnyCredentials(): void
+    {
+        // A backslash before '@' makes the readable-looking host the *userinfo* and the real
+        // host what follows — correct per RFC 3986, and the reason a host check must read
+        // host() rather than search the raw string.
+        $url = Url::parse('https://example.com\\@evil.com/');
+
+        self::assertSame('evil.com', $url->host());
+    }
+
+    public function testWithersAreImmutable(): void
+    {
+        $url = Url::parse('https://example.com/a?x=1#f');
+
+        $url->withPath('/b');
+        $url->withFragment('other');
+        $url->withoutUserInfo();
+
+        self::assertSame('https://example.com/a?x=1#f', $url->toString());
+    }
+
+    public function testWithPathReplacesThePath(): void
+    {
+        self::assertSame(
+            'https://example.com/b?x=1',
+            Url::parse('https://example.com/a?x=1')->withPath('/b')->toString(),
+        );
+    }
+
+    public function testWithPathNormalizesEmptyToSlash(): void
+    {
+        self::assertSame('/', Url::parse('https://example.com/a')->withPath('')->path());
+    }
+
+    public function testWithFragmentSetsAndClears(): void
+    {
+        $url = Url::parse('https://example.com/a');
+
+        self::assertSame('https://example.com/a#top', $url->withFragment('top')->toString());
+        self::assertNull($url->withFragment('top')->withFragment(null)->fragment());
+    }
+
+    public function testControlCharactersAreRefusedInWithersToo(): void
+    {
+        $url = Url::parse('https://example.com/');
+
+        $this->expectException(InvalidUrlException::class);
+
+        $url->withPath("/a\r\nX-Injected: 1");
+    }
+
+    public function testFragmentWitherRefusesControlCharacters(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+
+        Url::parse('https://example.com/')->withFragment("a\nb");
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item **9.3** — `D4np\Utils\Support\Url` and `InvalidUrlException`, spec r4
**FR-27** (RFC-0002), **ADR-0036**. An immutable absolute-URL value: parse, inspect,
recompose, compose queries. 82 new tests; **suite proved non-vacuous with 11 planted
defects**, all caught.

## Motivation

FR-27's security clause exists because of a specific estate helper: it decomposed a URL and
rebuilt it as `"http://{$host}{$path}"` — hardcoded scheme, so every `https` address it
touched came back plaintext, with the query and fragment dropped on the way.

**The probe moved the item's centre of gravity.** Four behaviours were measured against PHP
8.3.1 before the class was designed; two changed it:

| probe | result |
|---|---|
| `parse_url("https://example.com\n/evil")` | **succeeds**, host `example.com_` — the newline is rewritten to `_`, not rejected |
| `parse_url('not a url')` | **succeeds**, `['path' => 'not a url']` |
| `filter_var('https://exämple.com/', FILTER_VALIDATE_URL)` | **false** — rejects valid IDN hosts |
| `http_build_query(['a' => '1', 'b' => null])` | `a=1` — the null vanishes with no signal |

`parse_url()` **launders** control characters rather than rejecting them. The parse looks
clean and the components are **not the string that was supplied** — so anything that
validates the parsed host and then forwards the original URL is inspecting a value the
caller never sent, and CR/LF is exactly the payload that matters once a URL reaches a
request line or a `Location` header.

## Changes

- **`Url`** — `parse()` (absolute only; **C0/DEL refused up front**, in `parse()` and in
  every wither, so input and parsed value are the same string), accessors, `withScheme()`
  / `withPath()` / `withFragment()` / `withoutUserInfo()`, `withQuery()` /
  `withQueryParam()` / `withoutQueryParam()`, `toString()`.
- **Scheme-downgrade refusal** — `https`→`http`, `wss`→`ws`, `ftps`/`sftp`→`ftp`. Compared
  on the lowercased scheme, so `HTTP` does not evade it. **Recorded limit:** an *unknown*
  target scheme is allowed through (the properties of a scheme nobody enumerated cannot be
  asserted; an allowlist would fail closed on legitimate custom schemes) — pinned by its own
  test so the limit is visible rather than discovered.
- **Query preserved byte-exact** until edited — re-encoding one nobody touched would
  invalidate any signature computed over the URL. Composition uses `PHP_QUERY_RFC3986`, not
  `http_build_query()`'s HTML-form default. `query()` decodes on demand and is documented as
  lossy exactly as `parse_str()` is; its keys are `array-key`, since `?0=zero` yields the
  **integer** key `0` (ADR-0025's superglobal lesson, reached again).
- **`null` query values refused at any depth**, naming the offender's dotted path.
- **`InvalidUrlException extends UtilsException`** — one type, cause named in the message.
- Normalization, all at parse: scheme and host lowercased (path untouched — it is
  case-sensitive), default port dropped, empty path → `/`. Recomposition is stable under
  re-parsing.
- **Spec → r4**, ADR-0036, ADR index, CHANGELOG, ROADMAP 9.3 flipped, session journal.

### Two findings worth the reviewer's attention

**PHPStan found the null guard incomplete.** The acceptable value shape is recursive
(scalars, or nested arrays of scalars) and PHPDoc cannot express that without lying at some
depth, so the parameter is honestly `array<array-key, mixed>` — and with the static check
gone it was obvious the runtime walk *was* the whole enforcement and never descended.
`['filter' => ['status' => null]]` would have been dropped as quietly as a top-level null.
The wider type is also the right split for this library: spec §1 names native/legacy
applications as the audience, and they run no static analysis at all.

**The exception registry caught the new type.** `ExceptionHierarchyTest` — the discovery
test that enumerates Support's exceptions from disk — went red when `InvalidUrlException`
joined, which is precisely the completeness guard doing its job. Updated in this PR, and the
same pass caught that **spec r3's exception enumeration had not anticipated the type**:
amended to r4 rather than left to drift (AGENTS.md §7).

## Design Patterns

- None adopted — an immutable value object; no catalogue entry. The decision content is in
  **ADR-0036**.

## Verification

- [x] Full suite green: **1468 tests, 3187 assertions** (82 new; 7 pre-existing environment
      skips, unchanged)
- [x] **Non-vacuity: 11 planted defects, 11 caught** — control-char guard neutered, DEL
      dropped from it, downgrade check removed, downgrade check reading the raw scheme
      (case evasion), form-encoded query, null refusal removed, its recursion removed,
      absoluteness check removed, default port kept, scheme lowercase skipped, raw query
      re-encoded at parse
- [x] `PHPStan (max level)` — No errors
- [x] `PHP-CS-Fixer (PSR-12)` — clean
- [x] `deptrac` — 0 violations, 0 uncovered
- [x] `python tools/consistency_lint.py` — OK (ADR index ↔ files, spec map, milestones)
- [x] Leak-gate grep over the staged diff — zero estate tokens
- [ ] CI matrix (8.1/8.2/8.3) + coverage floor — this PR's checks

## Documentation Impact

- [ ] README.md — unchanged (it names groups, not methods)
- [x] ROADMAP.md — 9.3 flipped with its completion note; latest-journal pointer updated
- [x] **ADR added** — ADR-0036, indexed
- [ ] docs/patterns/README.md — unchanged
- [x] **Spec updated → r4** — FR-27 stated to the precision implemented, and
      `InvalidUrlException` added to the exception enumeration
- [x] CHANGELOG.md — `[Unreleased] / Added` entry
- [x] PR metadata — assignee (owner), label `enhancement`, milestone **v0.8.0**

**Route note:** item routed `frontier-reasoning / extra`; run at standard tier — mismatch
recorded, the pattern items 5.3–6.3 established.

## Lesson

Lesson: probe the standard-library function before designing around it — `parse_url()` looks
like a parser that either succeeds or fails, and it is neither: it succeeds while quietly
changing the value, which is the one behaviour a security check cannot survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
