### PR TITLE
feat(support): a sequence that refuses to wrap, and the lock it needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`D4np\Utils\Support\FileSequence`, `SequenceExhaustedException`** and **`File::update()`**
+  (spec r6 **FR-32**, RFC-0002; roadmap item **9.5**; **ADR-0038**) — a rolling counter
+  persisted to a file and safe across processes. The whole read-modify-write runs under
+  **one** exclusive lock: `read()` + `write()` as two separately locked calls lets two
+  processes both read `5` and both write `6`, and for a sequence a lost increment is a
+  **duplicate identifier**. The cap **refuses** (`SequenceExhaustedException`) rather than
+  wrapping, since wrapping re-issues identifiers already in use, and the refusal leaves the
+  state untouched. A corrupt state file is refused and **left on disk as evidence** rather
+  than reset — resetting re-issues the whole window; an absent or blank file is a legitimate
+  fresh start. The window is a caller-supplied opaque string, so no timezone decision happens
+  inside the library. `File::update()` is the general read-modify-write primitive this
+  needed, sharing ADR-0005's lock, temporary file and atomic rename with the other two
+  writers. Verified by **T-14**: four real processes, each number issued exactly once.
+
 - **`D4np\Utils\Support\Csv`, `Delimiter`, `CsvSerializable`, `CsvException`** and
   **`File::writeStream()`** (spec r5 **FR-28/FR-29**, RFC-0002; roadmap item **9.4**;
   **ADR-0037**) — streaming CSV whose memory cost is one row, written through the atomic

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — The escape character that eats a row](docs/journal/2026/08/2026-08-06-csv.md).
+  [2026-08-06 — Two locks are one too many](docs/journal/2026/08/2026-08-06-file-sequence.md).
 
 ## Model & effort routing (advisory)
 
@@ -662,10 +662,33 @@ surface (RFC-0002 FR-27…FR-32).
       through the writer callback, which was fixed the honest way — `writeStream()` now
       documents `@throws Throwable`, the propagation contract `Transaction::run()` already
       had.*
-- [ ] 9.5 `FileSequence`: rolling lock-guarded counter with an explicit cap policy
+- [x] 9.5 `FileSequence`: rolling lock-guarded counter with an explicit cap policy
       (`SequenceExhaustedException`, never a silent wrap) + T-14 multi-process concurrency
       suite (RFC-0002 FR-32; T-14) (severity:medium — concurrency/atomicity) — size: S ·
-      route: standard / medium
+      route: standard / medium *(session model matched the route — no mismatch)* ·
+      **ADR-0038**, **spec r6**. ***The item's real problem was not the counter.*** *A
+      sequence is a **read-modify-write**, and this library's primitives could not express one
+      safely: `read()` takes a shared lock and `write()` an exclusive one, so composing them
+      lets two processes both read `5` and both write `6` — and a lost increment in a sequence
+      is a **duplicate identifier**. `File` therefore gains `update()`, which holds one
+      exclusive lock across both halves and calls the mutator **before** writing, so a
+      refusal leaves the file untouched. Following ADR-0037's precedent rather than
+      re-deciding it: `FileSequence` opening its own `flock()` would have put ADR-0005's
+      discipline in a second place. **T-14 is the load-bearing suite and it is real** — four
+      separate PHP processes drawing 30 numbers each, asserting the union is exactly 1..120
+      with no duplicate and no gap; everything inside one process shares a lock owner, so an
+      in-process "concurrency" test would pass against an implementation with no locking at
+      all. Proved by planting the split-lock race: **T-14 catches it**. Three refusals decided
+      against their tempting alternatives: the cap **refuses instead of wrapping** (wrapping
+      re-issues live identifiers, silently, at peak load); a **corrupt state file is refused
+      and left on disk** as evidence (resetting is the reflex and it re-issues the entire
+      window), while an absent or blank file — what `touch` and deploy scripts leave — is a
+      legitimate fresh start; and the **window stays a caller-supplied opaque string**, so no
+      timezone decision happens inside the library (the estate's helper called
+      `date_default_timezone_set()` as a side effect of minting an id). Recorded limit: opaque
+      windows cannot be ordered, so any change resets — a lexicographic guard was considered
+      and rejected because it silently breaks unpadded numeric windows. 41 tests; **suite
+      proved non-vacuous with 8 planted defects**, all caught.*
 - [ ] 9.6 phpbench: NFR-12 (Csv streaming) + NFR-10 (FileSequence) wired into the ADR-0030
       same-runner harness (RFC-0002) (step:optimize) — size: S · route: fast / medium
 

--- a/docs/adr/0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md
+++ b/docs/adr/0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md
@@ -1,0 +1,153 @@
+# ADR-0038: One lock across the read and the write, and a sequence that refuses to wrap
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 9.5 · spec r6 FR-32, FR-22/23, §6 T-14 ·
+  [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) §Decision (`Support`
+  additions) · [ADR-0005](0005-atomic-file-writes-with-a-sidecar-lock.md) (the sidecar lock
+  this composes) · [ADR-0037](0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md)
+  (the immediately preceding case for extending `File` rather than duplicating it) ·
+  [ADR-0027](0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md) (a
+  property no in-process test can observe) · [ADR-0036](0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md)
+  (naming a limit rather than pretending it away)
+
+## Context
+
+FR-32 asks for a rolling counter with an explicit cap. The estate's version generates a
+daily identifier from a `.state` file holding `window|counter` — the format is sound. Three
+things around it are not:
+
+- the counter file sits **beside each deployed endpoint**, so one counter exists per deploy
+  folder while every folder mints identifiers into the same table;
+- the ceiling is computed and compared by hand at the call site, and the failure is a bare
+  `RuntimeException` built from string interpolation;
+- generating an identifier calls `date_default_timezone_set()` as a side effect, changing
+  the timezone for everything else in the request.
+
+None of those is the interesting problem. The interesting problem is that a counter is a
+**read-modify-write**, and this library's existing file primitives cannot express one safely.
+
+## Decision
+
+### 1. `File::update()` — the lock spans the read *and* the write
+
+`File::read()` takes a shared lock. `File::write()` takes an exclusive one. Composing them
+gives:
+
+```
+process A: [lock] read 5 [unlock]                [lock] write 6 [unlock]
+process B:            [lock] read 5 [unlock]  [lock] write 6 [unlock]
+```
+
+Both read `5`, both write `6`, and one increment is gone. For a sequence, a lost increment
+is not a lost update — it is a **duplicate identifier**, surfacing later as a duplicate key
+or, worse, as a row quietly attached to the wrong record.
+
+So `File` gains a third writer: `update(string $path, callable $mutator)`, which acquires the
+exclusive sidecar lock, reads, calls the mutator, writes atomically, and only then releases.
+The mutator is called **before** anything is written, so a mutator that throws — refusing an
+increment past a cap — leaves the file exactly as it was.
+
+This follows ADR-0037's precedent rather than re-deciding it: `FileSequence` could have
+opened its own `flock()`, and that would have put ADR-0005's discipline in a second place,
+where it would drift. The three writers now cover the three shapes — replace, replace by
+streaming, read-modify-write — and share one implementation of the lock, the
+same-directory temporary file, the mode-before-rename ordering, and the cleanup.
+
+**Why not lock the target itself**, which would be simpler? ADR-0005 already measured that:
+a handle held on the target makes `rename()` fail on Windows. The sidecar is what makes the
+replacement atomic *and* lockable at the same time.
+
+### 2. The cap refuses; it never wraps
+
+`next()` returns `1..cap` within a window. Reaching the cap raises
+`SequenceExhaustedException` — the type spec r3 already named — with the path, the window,
+and both numbers in the message.
+
+Wrapping is the tempting alternative and it is the dangerous one: returning to `1` re-issues
+identifiers that are already in use, and does so silently, at exactly the moment the system
+is busiest. A refusal is loud, local, and recoverable — the caller widens the cap, narrows
+the window, or stops.
+
+The refusal leaves the state file untouched, so a caller that catches it and retries in the
+next window is not penalised. Asserted by a test.
+
+### 3. A corrupt state file is refused, not reset
+
+Resetting is the reflex. It is also the failure mode with the worst blast radius: a
+sequence that treats unparseable state as "start again" re-issues **every** number in the
+window.
+
+The distinction drawn is between *absent* and *unparseable*. An absent or blank file is the
+legitimate first-run state — and is also what `touch` and most deploy scripts leave behind —
+so it starts at `1`. Anything else that does not match `window|digits` raises `FileException`
+and, deliberately, **does not overwrite the file**: the evidence a human needs to diagnose it
+has to survive the failure.
+
+### 4. The window is an opaque caller-supplied string — with a named limit
+
+`next(string $window)` takes the window rather than deriving it. Keeping the calendar out of
+the class avoids the estate's timezone side effect, and lets a caller roll by date, by
+day-of-year, by shift, or by anything else.
+
+The cost is stated rather than hidden: **the class cannot order opaque strings**, so *any*
+change of window resets the counter — including a change to an earlier one. A caller
+supplying a window that goes backwards (a clock stepped back, a hand-passed constant)
+re-issues numbers. Callers must supply a monotonically advancing window; `peek()` exists so
+this is observable, and a test pins the behaviour so the limit is visible rather than
+discovered.
+
+A lexicographic "must not go backwards" check was considered and rejected: it works for
+`2026-08-06` and for zero-padded `008`, and silently breaks unpadded numeric windows, where
+`10` sorts below `9`. A guard that is correct for some formats and wrong for others is worse
+than a documented limit.
+
+### 5. `peek()` and `remaining()` are advisory, and say so
+
+Both read without the lock. Any value they return may be stale before the caller acts on it,
+so branching on them to decide whether `next()` will succeed is a race. Documented on both
+methods: call `next()` and catch the refusal.
+
+## Alternatives
+
+1. **`read()` + `write()` at the call site** — rejected: the interleaving above loses
+   increments, which for a sequence means duplicate identifiers.
+2. **`flock()` inside `FileSequence`** — rejected on ADR-0037's precedent: a second copy of
+   ADR-0005's discipline is one that will drift.
+3. **Lock the target file instead of a sidecar** — rejected: ADR-0005 measured that a held
+   handle breaks `rename()` on Windows, and losing atomicity to gain simplicity is the wrong
+   trade for a file whose corruption re-issues identifiers.
+4. **Wrap at the cap** — rejected: silent duplicate identifiers, at peak load.
+5. **Reset on a corrupt state file** — rejected: re-issues the whole window, and destroys
+   the evidence.
+6. **Derive the window from the clock inside the class** — rejected: it forces a timezone
+   decision the library cannot make, which is how the estate's helper ended up mutating
+   global state from inside an identifier generator.
+7. **Refuse a lexicographically-earlier window** — rejected: correct for ISO dates and padded
+   numbers, wrong for unpadded ones, and a guard that is wrong for some callers is worse than
+   a named limit.
+8. **Test concurrency with threads or sequential calls** — rejected as vacuous: everything
+   inside one PHP process shares a lock owner, so `flock()` never contends and the suite
+   would pass against an implementation with no locking at all.
+
+## Consequences
+
+**Easier:** a counter shared by several processes — or several deploy folders — issues each
+number exactly once; exhaustion is a typed, catchable event rather than a wrap nobody
+notices; and `File::update()` is available to any future read-modify-write.
+
+**Harder / accepted:** `File`'s public surface has grown to three writers in two items, which
+is deliberate but worth watching; a corrupt state file now stops the caller rather than
+limping on; and the window's monotonicity is the caller's responsibility, stated as a limit
+rather than enforced.
+
+**Verification:** 41 tests, of which the load-bearing one is **T-14**
+(`#[Group('T-14')]`) — four real processes drawing 30 numbers each, asserting the union is
+exactly `1..120` with no duplicate and no gap, plus a capped variant asserting that no number
+above the cap is ever issued and that at least one worker is refused. The suite is **proved
+non-vacuous by 8 planted defects**, the first of which is the one that matters: splitting
+`update()` into a separate read and write reproduces the classic race, and **T-14 catches
+it**. The others — cap check removed, cap wrapping, corrupt state reset, window change not
+resetting, blank file treated as corrupt, window guard removed, `cap: 0` accepted — were each
+caught by the unit suite.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,3 +53,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0035](0035-guard-the-ref-shape-rather-than-trust-a-glob-and-never-skip-release-mode.md) | Guard the ref shape rather than trust a glob, and never skip release mode | Accepted |
 | [0036](0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md) | Refuse the scheme downgrade, and refuse the characters `parse_url()` launders | Accepted |
 | [0037](0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md) | Disable PHP's CSV escape character, and keep the formula guard opt-in | Accepted |
+| [0038](0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md) | One lock across the read and the write, and a sequence that refuses to wrap | Accepted |

--- a/docs/journal/2026/08/2026-08-06-file-sequence.md
+++ b/docs/journal/2026/08/2026-08-06-file-sequence.md
@@ -1,0 +1,75 @@
+# 2026-08-06 — Two locks are one too many
+
+Roadmap item **9.5**, fifth in Milestone 9. Route `standard / medium`, session model matched
+— **the first item in this milestone with no route mismatch to record**.
+
+## The item was filed for a counter; the problem was a primitive
+
+FR-32 reads like a small class: keep a number in a file, roll it by window, cap it. The
+first real question killed that framing — a counter is a **read-modify-write**, and nothing
+in `File` could express one safely.
+
+```
+process A: [lock] read 5 [unlock]                [lock] write 6 [unlock]
+process B:            [lock] read 5 [unlock]  [lock] write 6 [unlock]
+```
+
+`read()` takes a shared lock, `write()` an exclusive one, and composing them is a race. For
+most data a lost update is annoying. For a sequence it is a **duplicate identifier**, which
+surfaces far from the cause — a duplicate key, or a row quietly attached to the wrong
+record.
+
+So the deliverable grew a second half: `File::update()`, holding one exclusive lock across
+the read and the write, calling the mutator before anything is written so a refusal leaves
+the file untouched. That followed ADR-0037's precedent rather than re-litigating it — a
+`flock()` inside `FileSequence` would have put ADR-0005's discipline in a second place, where
+it drifts. `File` now has three writers for three shapes: replace, replace-by-streaming,
+read-modify-write.
+
+## The concurrency test had to be real, and then had to be proved real
+
+Everything inside one PHP process shares a lock owner, so `flock()` never contends: an
+in-process "concurrency" suite passes against an implementation with **no locking at all**.
+T-14 therefore spawns four actual processes — the same reasoning that put T-03 against a live
+`php -S` — each drawing 30 numbers, asserting the union is exactly `1..120` with no duplicate
+and no gap.
+
+A green concurrency test proves nothing by itself, so the first planted defect was the split
+lock: `update()` reduced to a read followed by `File::write()`. **T-14 caught it.** That one
+result is what makes the other 40 tests worth having.
+
+## Three refusals, each against a tempting alternative
+
+- **The cap refuses; it does not wrap.** Wrapping to `1` re-issues identifiers already in
+  use, silently, at exactly the load that makes duplicates expensive. The refusal also leaves
+  the state untouched, so catching it and retrying in the next window costs nothing.
+- **A corrupt state file is refused and left on disk.** Resetting is the reflex and has the
+  worst blast radius: it re-issues the entire window. The distinction that matters is
+  *absent* versus *unparseable* — an absent or blank file is what `touch` and deploy scripts
+  leave behind, and is a legitimate fresh start.
+- **The window stays an opaque caller-supplied string.** The estate's helper called
+  `date_default_timezone_set()` as a side effect of minting an identifier, changing the
+  timezone for the rest of the request. Keeping the calendar out means the library never
+  makes that decision.
+
+The cost of the third is a limit I could not engineer away: opaque strings cannot be ordered,
+so *any* window change resets, including a change to an earlier one. A lexicographic
+"must not go backwards" guard would work for `2026-08-06` and padded `008` and silently break
+unpadded numbers, where `10` sorts below `9`. A guard that is right for some formats and
+wrong for others is worse than a limit written down — so it is written down, in the class, in
+the ADR, and in a test.
+
+## Gates
+
+41 new tests (T-14 tagged); full suite 1601 green. **8 planted defects, 8 caught** — the split
+lock, cap check removed, cap wrapping, corrupt state reset, window change not resetting, blank
+file treated as corrupt, window guard removed, `cap: 0` accepted. PHPStan max clean on the
+first run this time, CS-Fixer clean, deptrac 0/0, `composer normalize` clean,
+`consistency_lint` green.
+
+## Lesson
+
+Before writing the class a requirement names, check whether the primitives it will stand on
+can express its core operation. FR-32 looked like a counter; the missing piece was a lock
+that spans two operations, and building the counter first would have produced something that
+passed every test and lost increments in production.

--- a/docs/specs/01_spec_utils.md
+++ b/docs/specs/01_spec_utils.md
@@ -3,7 +3,7 @@
 > Rendered from the intake interview (Phase 5). Frozen contract: diverging implementation
 > updates this spec in the same PR or adds an ADR superseding the relevant section.
 
-**Revision r5** — 2026-08-06. See [Revision history](#revision-history).
+**Revision r6** — 2026-08-06. See [Revision history](#revision-history).
 
 ## 1. Objective & Business Context
 
@@ -31,7 +31,7 @@ Provide EGL PHP projects (framework-based and native/legacy) with a modern utili
 - FR-17 Logger: PSR-3 file/console logger
 - FR-18 ExceptionHandler: fatal-error capture, JSON problem responses for API calls; never leaks traces in production mode (env-gated)
 - FR-19..21 Str: slug() (transliteration via ext-intl when present), uuid() (v4 from random_bytes), random() (CSPRNG alphanumeric tokens)
-- FR-22..23 File: write()/read() flock-guarded, atomic write via temp+rename; writeStream() streams to the temp file under the same discipline, for producers whose output must not be buffered (r5, spec NFR-12); mime() via Fileinfo (never trusts extensions)
+- FR-22..23 File: write()/read() flock-guarded, atomic write via temp+rename; writeStream() streams to the temp file under the same discipline, for producers whose output must not be buffered (r5, spec NFR-12); update() performs a read-modify-write under ONE exclusive lock, which read()+write() cannot express (r6, ADR-0038); mime() via Fileinfo (never trusts extensions)
 - FR-24 Env::get(): env reads with correct boolean coercion ('false' -> false)
 - FR-25 Json: encode()/decode() with JSON_THROW_ON_ERROR; library JsonException wraps and rethrows PHP's native \JsonException (RFC-0001 R-7)
 - FR-26 Exception hierarchy: UtilsException <- DatabaseException, HydrationException (<- UnknownKeyException, TypeMismatchException, MissingKeyException), HttpException, FileException, JsonException
@@ -49,7 +49,7 @@ MailException).
 - FR-29 CsvSerializable: csvHeader()/csvRow() contract, with the pairing ENFORCED — Csv::write() takes the header from the first item and refuses any row whose width disagrees (ADR-0037)
 - FR-30 Lookup: immutable code→label map; label() throws on a missing key, labelOr()/tryLabel() tolerant
 - FR-31 Str additions: collapseWhitespace(), nullIfBlank(), transcode() (strict default, lossy opt-in), multibyte-safe padLeft()/padRight(), shortClassName(), pascalCase()
-- FR-32 FileSequence: rolling flock-guarded counter with an explicit cap (SequenceExhaustedException); never wraps silently
+- FR-32 FileSequence: rolling counter with an explicit cap (SequenceExhaustedException); never wraps silently. The whole read-modify-write runs under ONE exclusive lock via File::update() — read()+write() as two separately locked calls loses an increment, which for a sequence is a duplicate identifier (ADR-0038). A corrupt state file is refused, not reset (resetting re-issues the whole window) and is left on disk as evidence; an absent or blank file is a legitimate fresh start. The window is a caller-supplied opaque string (no timezone decision inside the library); recorded limit: windows cannot be ordered, so ANY window change resets — callers must supply a monotonically advancing window. peek()/remaining() are advisory and unlocked.
 - FR-33 SqlStatement (Database): immutable SQL+params value — the only shape connection-side execution accepts; hand-written dialect SQL always travels with its binds
 - FR-34 Repository (Persistence): fetchAll/fetchOne/execute/withTransaction; rows normalized (FR-36) then hydrated via the shared Hydrator; every failure throws DatabaseException
 - FR-35 TableGateway (Persistence): Table Data Gateway over QueryBuilder — identifiers allowlisted, values bound, by construction
@@ -135,7 +135,7 @@ r3 (RFC-0002) additions:
 
 - D4np\Utils\Persistence\ — Repository (fetchAll/fetchOne/execute/withTransaction), TableGateway (select/insert/update/delete), RowNormalizer
 - D4np\Utils\Mail\ — EmailAddress, MailMessage, Mailer, NativeMailer
-- D4np\Utils\Database\ — + SqlStatement · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, File::writeStream(), Str additions (FR-31)
+- D4np\Utils\Database\ — + SqlStatement · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, SequenceExhaustedException, File::writeStream(), File::update(), Str additions (FR-31)
 
 
 ## 6. Verification & Test Strategy
@@ -162,6 +162,7 @@ non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.y
 |-----|------|--------|
 | r1 | 2026-08-03 | Frozen from the imported `.specs/d4np-php.md` v2.0 via RFC-0001 (naming mapping A-7). |
 | r2 | 2026-08-05 | §6/T-03: the `hash_equals` **timing test** is replaced by a **mechanism assertion**. Rationale below; see [ADR-0027](../adr/0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md). |
+| r6 | 2026-08-06 | §2/§6: FR-32 stated to the precision item 9.5 implemented (one lock across the read-modify-write, corrupt state refused rather than reset, the caller-supplied window and its recorded ordering limit); FR-22/23 gains `File::update()`, without which a safe counter cannot be built from this library's primitives; §6 gains suite **T-14** (multi-process concurrency: each number issued exactly once, cap holds). Additive; see [ADR-0038](../adr/0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md). |
 | r5 | 2026-08-06 | §2: FR-28/FR-29 stated to the precision item 9.4 implemented (PHP's backslash escape disabled, the single-empty-field and zero-column shapes, blank-line handling, the enforced header/row pairing, the guard's leader set); FR-22/23 gains `File::writeStream()`, without which a streaming CSV could not honour NFR-12; `CsvException` added to the exception enumeration. Additive; see [ADR-0037](../adr/0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md). |
 | r4 | 2026-08-06 | §2: FR-27 stated to the precision item 9.3 implemented (control-character refusal, absolute-only, the named downgrade pairs and their recorded limit, query preservation), and `InvalidUrlException` added to the r3 exception enumeration, which had not anticipated it. Additive; see [ADR-0036](../adr/0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md). |
 | r3 | 2026-08-06 | §2–§6: the RFC-0002 surface — FR-27…FR-44, NFR-09…NFR-14, suites T-07…T-15, the Persistence/Mail groups and the two named layering edges. Additive; no existing requirement changed. Source: [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) (approved 2026-08-05, PR #49); roadmap: M9–M12. |

--- a/src/main/php/d4np/utils/Support/File.php
+++ b/src/main/php/d4np/utils/Support/File.php
@@ -51,40 +51,58 @@ final class File
      */
     public static function write(string $path, string $contents): void
     {
-        $dir = \dirname($path);
-        if (!is_dir($dir)) {
-            throw new FileException(sprintf('Cannot write "%s": directory "%s" does not exist.', $path, $dir));
-        }
-        if (!is_writable($dir)) {
-            throw new FileException(sprintf('Cannot write "%s": directory "%s" is not writable.', $path, $dir));
-        }
-
+        $dir = self::writableDirectoryOf($path);
         $mode = self::currentModeOf($path);
         $lock = self::acquireExclusiveLock($path);
 
         try {
-            $tmp = self::createTempFileIn($dir);
+            self::replaceAtomically($path, $dir, $contents, $mode);
+        } finally {
+            self::releaseLock($lock);
+        }
+    }
 
-            try {
-                self::putAll($tmp, $contents, $path);
+    /**
+     * Read `$path`, hand its contents to `$mutator`, and write back what it returns —
+     * **all under one exclusive lock**.
+     *
+     * The lock spanning both halves is the entire point, and the reason this cannot be
+     * assembled from {@see self::read()} plus {@see self::write()}: between two separately
+     * locked calls, two processes both read `5`, both compute `6`, and one increment is
+     * lost. A counter built that way issues duplicate identifiers under exactly the load
+     * that makes duplicates expensive.
+     *
+     * `$mutator` receives the current contents, or `''` when the file does not exist yet, and
+     * returns the new contents. It is called **before** anything is written, so a mutator
+     * that throws — refusing an increment past a cap, say — leaves the file untouched and its
+     * exception propagates unchanged.
+     *
+     * @param callable(string): string $mutator
+     *
+     * @throws FileException if the directory is missing or unwritable, if the current
+     *                        contents cannot be read, or if the replacement fails.
+     * @throws \Throwable    whatever `$mutator` threw, unchanged, with the file unmodified
+     */
+    public static function update(string $path, callable $mutator): void
+    {
+        $dir = self::writableDirectoryOf($path);
+        $mode = self::currentModeOf($path);
+        $lock = self::acquireExclusiveLock($path);
 
-                // chmod BEFORE the rename: tempnam() creates 0600, and a reader must never see
-                // the target briefly carrying the temp file's restrictive mode.
-                if (!@chmod($tmp, $mode)) {
-                    throw new FileException(sprintf('Cannot write "%s": failed to set mode on the temporary file.', $path));
+        try {
+            $current = '';
+            if (is_file($path)) {
+                $read = @file_get_contents($path);
+                if ($read === false) {
+                    throw new FileException(sprintf('Cannot update "%s": reading the current contents failed.', $path));
                 }
-
-                if (!@rename($tmp, $path)) {
-                    throw new FileException(sprintf('Cannot write "%s": atomic rename from the temporary file failed.', $path));
-                }
-            } catch (FileException $e) {
-                // The temp file is this method's litter, not the caller's problem.
-                if (is_file($tmp)) {
-                    @unlink($tmp);
-                }
-
-                throw $e;
+                $current = $read;
             }
+
+            // Computed before the write, so a throwing mutator cannot leave a partial state.
+            $updated = $mutator($current);
+
+            self::replaceAtomically($path, $dir, $updated, $mode);
         } finally {
             self::releaseLock($lock);
         }
@@ -113,14 +131,7 @@ final class File
      */
     public static function writeStream(string $path, callable $writer): void
     {
-        $dir = \dirname($path);
-        if (!is_dir($dir)) {
-            throw new FileException(sprintf('Cannot write "%s": directory "%s" does not exist.', $path, $dir));
-        }
-        if (!is_writable($dir)) {
-            throw new FileException(sprintf('Cannot write "%s": directory "%s" is not writable.', $path, $dir));
-        }
-
+        $dir = self::writableDirectoryOf($path);
         $mode = self::currentModeOf($path);
         $lock = self::acquireExclusiveLock($path);
 
@@ -232,6 +243,57 @@ final class File
             return $mime;
         } finally {
             finfo_close($finfo);
+        }
+    }
+
+    /**
+     * The directory `$path` lives in, having confirmed it exists and is writable.
+     *
+     * @throws FileException
+     */
+    private static function writableDirectoryOf(string $path): string
+    {
+        $dir = \dirname($path);
+        if (!is_dir($dir)) {
+            throw new FileException(sprintf('Cannot write "%s": directory "%s" does not exist.', $path, $dir));
+        }
+        if (!is_writable($dir)) {
+            throw new FileException(sprintf('Cannot write "%s": directory "%s" is not writable.', $path, $dir));
+        }
+
+        return $dir;
+    }
+
+    /**
+     * Put `$contents` in place of `$path` atomically. **The caller must already hold the
+     * exclusive lock** — this is the shared body of {@see self::write()} and
+     * {@see self::update()}, not an entry point.
+     *
+     * @throws FileException
+     */
+    private static function replaceAtomically(string $path, string $dir, string $contents, int $mode): void
+    {
+        $tmp = self::createTempFileIn($dir);
+
+        try {
+            self::putAll($tmp, $contents, $path);
+
+            // chmod BEFORE the rename: tempnam() creates 0600, and a reader must never see
+            // the target briefly carrying the temp file's restrictive mode.
+            if (!@chmod($tmp, $mode)) {
+                throw new FileException(sprintf('Cannot write "%s": failed to set mode on the temporary file.', $path));
+            }
+
+            if (!@rename($tmp, $path)) {
+                throw new FileException(sprintf('Cannot write "%s": atomic rename from the temporary file failed.', $path));
+            }
+        } catch (FileException $e) {
+            // The temp file is this method's litter, not the caller's problem.
+            if (is_file($tmp)) {
+                @unlink($tmp);
+            }
+
+            throw $e;
         }
     }
 

--- a/src/main/php/d4np/utils/Support/FileSequence.php
+++ b/src/main/php/d4np/utils/Support/FileSequence.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+use InvalidArgumentException;
+
+/**
+ * A rolling counter persisted to a file, safe across processes (spec r3 FR-32, RFC-0002;
+ * ADR-0038).
+ *
+ * The estate's version generated a daily identifier from a `.state` file holding
+ * `window|counter`, checked its ceiling by hand, and — because the file sat beside each
+ * deployed endpoint — kept **one counter per deploy folder** while every folder minted
+ * identifiers into the same table. This class keeps the shape and fixes what made it unsafe:
+ *
+ * - **The whole read-modify-write happens under one exclusive lock** ({@see File::update()}).
+ *   Read-then-write through two separately locked calls loses an increment whenever two
+ *   processes interleave, and a lost increment in a sequence is a duplicate identifier.
+ * - **The cap is enforced, and exceeding it throws** {@see SequenceExhaustedException}.
+ *   Wrapping to `1` would re-issue live identifiers.
+ * - **A corrupt state file is refused, not reset.** Resetting is the reflex, and it is the
+ *   dangerous one: it re-issues every number in the window.
+ *
+ * The **window** is supplied by the caller as an opaque string — a date, a day-of-year, a
+ * shift name. Keeping the calendar out of the class is deliberate: the estate's helper called
+ * `date_default_timezone_set()` as a side effect of generating an identifier, which changed
+ * the timezone for everything else in the request.
+ *
+ * **Recorded limit:** the class cannot order opaque windows, so *any* change of window resets
+ * the counter — including a change to an earlier one. A caller that supplies a window going
+ * backwards (a clock stepped back, a hand-passed constant) re-issues numbers already used.
+ * Callers must supply a monotonically advancing window; {@see self::peek()} exists so this is
+ * observable.
+ */
+final class FileSequence
+{
+    private const SEPARATOR = '|';
+
+    /**
+     * @param string $path where the state is kept. It holds one line, `window|counter`, and
+     *                     nothing else; a sidecar `.lock` file lives beside it (ADR-0005).
+     * @param int    $cap  the highest number this sequence may issue within one window
+     *
+     * @throws InvalidArgumentException if `$cap` is below 1
+     */
+    public function __construct(
+        private readonly string $path,
+        private readonly int $cap,
+    ) {
+        if ($cap < 1) {
+            throw new InvalidArgumentException(sprintf('$cap must be >= 1, got %d.', $cap));
+        }
+    }
+
+    /**
+     * The next number in `$window`: one more than the last issued in that window, or `1` when
+     * the window is new.
+     *
+     * @throws SequenceExhaustedException if the next number would exceed the cap
+     * @throws FileException              if the state file cannot be read, parsed or replaced
+     * @throws InvalidArgumentException   if `$window` is empty or holds a reserved character
+     */
+    public function next(string $window): int
+    {
+        self::guardWindow($window);
+
+        $issued = 0;
+
+        File::update($this->path, function (string $current) use ($window, &$issued): string {
+            [$storedWindow, $counter] = $this->parse($current);
+
+            $next = $storedWindow === $window ? $counter + 1 : 1;
+
+            if ($next > $this->cap) {
+                throw new SequenceExhaustedException(sprintf(
+                    'Sequence "%s" is exhausted for window "%s": %d of %d issued. It will not '
+                    . 'wrap, because wrapping re-issues identifiers that are already in use.',
+                    $this->path,
+                    $window,
+                    $counter,
+                    $this->cap,
+                ));
+            }
+
+            $issued = $next;
+
+            return $window . self::SEPARATOR . $next . "\n";
+        });
+
+        return $issued;
+    }
+
+    /**
+     * The last number issued in `$window`, or `0` when none has been — without issuing one.
+     *
+     * Deliberately **not** locked: a peek is advisory by nature, and any value it returns may
+     * be stale by the time the caller reads it. Do not branch on it to decide whether
+     * {@see self::next()} will succeed; call `next()` and catch its refusal.
+     *
+     * @throws FileException if the state file exists but cannot be read or parsed
+     */
+    public function peek(string $window): int
+    {
+        if (!is_file($this->path)) {
+            return 0;
+        }
+
+        [$storedWindow, $counter] = $this->parse(File::read($this->path));
+
+        return $storedWindow === $window ? $counter : 0;
+    }
+
+    /**
+     * How many numbers `$window` has left. Advisory, for the same reason as {@see self::peek()}.
+     *
+     * @throws FileException
+     */
+    public function remaining(string $window): int
+    {
+        return $this->cap - $this->peek($window);
+    }
+
+    /**
+     * Decompose the stored record.
+     *
+     * An absent or blank file means "nothing issued yet", which is the legitimate first-run
+     * state and also what a deploy script that touches the file produces. Anything else that
+     * does not parse is **corrupt and refused**: silently treating it as a fresh start would
+     * re-issue the whole window.
+     *
+     * @return array{string, int} the stored window (`''` when none) and its counter
+     *
+     * @throws FileException
+     */
+    private function parse(string $raw): array
+    {
+        $trimmed = trim($raw);
+
+        if ($trimmed === '') {
+            return ['', 0];
+        }
+
+        $parts = explode(self::SEPARATOR, $trimmed);
+
+        if (\count($parts) !== 2 || $parts[0] === '' || preg_match('/\A\d+\z/', $parts[1]) !== 1) {
+            throw new FileException(sprintf(
+                'Sequence state file "%s" is corrupt: expected "window%scounter", found "%s". '
+                . 'Refusing to treat it as a fresh start, which would re-issue every number '
+                . 'in the window.',
+                $this->path,
+                self::SEPARATOR,
+                $trimmed,
+            ));
+        }
+
+        return [$parts[0], (int) $parts[1]];
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private static function guardWindow(string $window): void
+    {
+        if ($window === '') {
+            throw new InvalidArgumentException('$window must not be empty.');
+        }
+
+        if (str_contains($window, self::SEPARATOR) || preg_match('/[\r\n]/', $window) === 1) {
+            throw new InvalidArgumentException(sprintf(
+                '$window must not contain "%s" or a line break: the state file stores '
+                . '"window%scounter" on one line, and either would make it unparseable.',
+                self::SEPARATOR,
+                self::SEPARATOR,
+            ));
+        }
+    }
+}

--- a/src/main/php/d4np/utils/Support/SequenceExhaustedException.php
+++ b/src/main/php/d4np/utils/Support/SequenceExhaustedException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * A {@see FileSequence} has issued every number its cap allows for the current window.
+ *
+ * The alternative a sequence must never take is wrapping. A counter that silently returns to
+ * `1` re-issues identifiers that are already in use, and the damage surfaces far from the
+ * cause — as a duplicate key, or worse, as a row quietly attached to the wrong record. This
+ * exception is the sequence refusing to do that; the caller widens the cap, narrows the
+ * window, or stops.
+ */
+final class SequenceExhaustedException extends UtilsException
+{
+}

--- a/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
+++ b/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
@@ -12,6 +12,7 @@ use D4np\Utils\Support\HydrationException;
 use D4np\Utils\Support\InvalidUrlException;
 use D4np\Utils\Support\JsonException;
 use D4np\Utils\Support\MissingKeyException;
+use D4np\Utils\Support\SequenceExhaustedException;
 use D4np\Utils\Support\TypeMismatchException;
 use D4np\Utils\Support\UnknownKeyException;
 use D4np\Utils\Support\UtilsException;
@@ -95,6 +96,7 @@ final class ExceptionHierarchyTest extends TestCase
                 InvalidUrlException::class,
                 JsonException::class,
                 MissingKeyException::class,
+                SequenceExhaustedException::class,
                 TypeMismatchException::class,
                 UnknownKeyException::class,
                 UtilsException::class,
@@ -168,6 +170,7 @@ final class ExceptionHierarchyTest extends TestCase
             InvalidUrlException::class,
             JsonException::class,
             MissingKeyException::class,
+            SequenceExhaustedException::class,
             TypeMismatchException::class,
             UnknownKeyException::class,
         ];

--- a/src/test/php/d4np/utils/Support/FileSequenceConcurrencyTest.php
+++ b/src/test/php/d4np/utils/Support/FileSequenceConcurrencyTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * T-14 — `FileSequence` under genuine concurrency (spec r3 §6, RFC-0002; ADR-0038).
+ *
+ * **Real processes, not simulated ones.** Everything inside one PHP process shares a lock
+ * owner, so `flock()` never contends and a suite built that way passes against an
+ * implementation with no locking at all. Only separate processes make the race real — the
+ * same reasoning that put T-03 against a live `php -S` rather than a mock.
+ *
+ * The property is the one a sequence exists for: across every process, **each number is
+ * issued exactly once**. A lost increment shows up here as a duplicate.
+ */
+#[Group('T-14')]
+final class FileSequenceConcurrencyTest extends TestCase
+{
+    private const WORKERS = 4;
+    private const DRAWS_EACH = 30;
+
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/egl-utils-t14-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->dir) && !is_dir($this->dir)) {
+            self::fail('could not create the test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $entry) {
+            @unlink($entry);
+        }
+        @rmdir($this->dir);
+    }
+
+    private static function autoloadPath(): string
+    {
+        return \dirname(__DIR__, 6) . '/vendor/autoload.php';
+    }
+
+    private static function workerPath(): string
+    {
+        return __DIR__ . '/Fixture/sequence_worker.php';
+    }
+
+    /**
+     * Run `self::WORKERS` processes concurrently and return every number they drew.
+     *
+     * @return list<int>
+     */
+    private function drawConcurrently(int $cap, string $window): array
+    {
+        $state = $this->dir . '/shared.state';
+        $processes = [];
+        $outputs = [];
+
+        for ($i = 0; $i < self::WORKERS; $i++) {
+            $out = $this->dir . "/worker-{$i}.out";
+            $outputs[] = $out;
+
+            $process = @proc_open(
+                [
+                    PHP_BINARY,
+                    self::workerPath(),
+                    self::autoloadPath(),
+                    $state,
+                    (string) $cap,
+                    $window,
+                    (string) self::DRAWS_EACH,
+                    $out,
+                ],
+                [
+                    0 => ['file', DIRECTORY_SEPARATOR === '\\' ? 'nul' : '/dev/null', 'r'],
+                    1 => ['file', $this->dir . "/worker-{$i}.log", 'w'],
+                    2 => ['file', $this->dir . "/worker-{$i}.log", 'a'],
+                ],
+                $pipes,
+            );
+
+            self::assertIsResource($process, 'could not spawn ' . PHP_BINARY);
+            $processes[] = $process;
+        }
+
+        foreach ($processes as $process) {
+            proc_close($process);
+        }
+
+        $drawn = [];
+        foreach ($outputs as $index => $out) {
+            self::assertFileExists($out, "worker {$index} produced no output");
+            $contents = trim((string) file_get_contents($out));
+            self::assertStringStartsNotWith('ERROR:', $contents, "worker {$index} failed: {$contents}");
+
+            foreach (explode("\n", $contents) as $line) {
+                if ($line !== '') {
+                    $drawn[] = (int) $line;
+                }
+            }
+        }
+
+        return $drawn;
+    }
+
+    public function testEveryNumberIsIssuedExactlyOnceAcrossProcesses(): void
+    {
+        $total = self::WORKERS * self::DRAWS_EACH;
+
+        $drawn = $this->drawConcurrently(cap: $total, window: 'shift-a');
+
+        self::assertCount($total, $drawn, 'every worker should have completed all its draws');
+
+        sort($drawn);
+
+        self::assertSame(range(1, $total), $drawn, 'the drawn numbers must be 1..N with no duplicate and no gap');
+    }
+
+    public function testTheSuiteWouldSeeADuplicateIfOneOccurred(): void
+    {
+        // Guards the assertion above against being vacuous: the comparison it makes is one
+        // that a duplicated draw genuinely fails.
+        $withDuplicate = [1, 2, 2, 4];
+        sort($withDuplicate);
+
+        self::assertNotSame(range(1, 4), $withDuplicate);
+    }
+
+    public function testTheCapHoldsUnderConcurrencySoNoWorkerExceedsIt(): void
+    {
+        // Half the capacity the workers collectively ask for: some draws must be refused,
+        // and no number above the cap may ever be issued.
+        $cap = intdiv(self::WORKERS * self::DRAWS_EACH, 2);
+        $state = $this->dir . '/capped.state';
+        $processes = [];
+        $outputs = [];
+
+        for ($i = 0; $i < self::WORKERS; $i++) {
+            $out = $this->dir . "/capped-{$i}.out";
+            $outputs[] = $out;
+
+            $process = @proc_open(
+                [
+                    PHP_BINARY,
+                    self::workerPath(),
+                    self::autoloadPath(),
+                    $state,
+                    (string) $cap,
+                    'shift-b',
+                    (string) self::DRAWS_EACH,
+                    $out,
+                ],
+                [
+                    0 => ['file', DIRECTORY_SEPARATOR === '\\' ? 'nul' : '/dev/null', 'r'],
+                    1 => ['file', $this->dir . "/capped-{$i}.log", 'w'],
+                    2 => ['file', $this->dir . "/capped-{$i}.log", 'a'],
+                ],
+                $pipes,
+            );
+
+            self::assertIsResource($process);
+            $processes[] = $process;
+        }
+
+        foreach ($processes as $process) {
+            proc_close($process);
+        }
+
+        $drawn = [];
+        $refusals = 0;
+
+        foreach ($outputs as $out) {
+            $contents = trim((string) file_get_contents($out));
+
+            if (str_starts_with($contents, 'ERROR:')) {
+                $refusals++;
+                self::assertStringContainsString('exhausted', $contents);
+
+                continue;
+            }
+
+            foreach (explode("\n", $contents) as $line) {
+                if ($line !== '') {
+                    $drawn[] = (int) $line;
+                }
+            }
+        }
+
+        self::assertGreaterThan(0, $refusals, 'the cap should have refused at least one worker');
+        self::assertLessThanOrEqual($cap, \count($drawn), 'no more numbers than the cap may be issued');
+
+        if ($drawn !== []) {
+            self::assertLessThanOrEqual($cap, max($drawn), 'no number above the cap may be issued');
+            self::assertSame(\count($drawn), \count(array_unique($drawn)), 'no number may be issued twice');
+        }
+    }
+}

--- a/src/test/php/d4np/utils/Support/FileSequenceTest.php
+++ b/src/test/php/d4np/utils/Support/FileSequenceTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\FileException;
+use D4np\Utils\Support\FileSequence;
+use D4np\Utils\Support\SequenceExhaustedException;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `FileSequence` — spec r3 FR-32 (RFC-0002), ADR-0038.
+ *
+ * Single-process behaviour: rollover, the cap that refuses rather than wraps, and the
+ * corrupt-state refusal. The cross-process guarantee is {@see FileSequenceConcurrencyTest}
+ * (T-14), which is the one that can actually fail if the locking is wrong.
+ */
+final class FileSequenceTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/egl-utils-seq-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->dir) && !is_dir($this->dir)) {
+            self::fail('could not create the test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $entry) {
+            @unlink($entry);
+        }
+        @rmdir($this->dir);
+    }
+
+    private function path(): string
+    {
+        return $this->dir . '/counter.state';
+    }
+
+    private function sequence(int $cap = 100): FileSequence
+    {
+        return new FileSequence($this->path(), $cap);
+    }
+
+    public function testFirstDrawIsOne(): void
+    {
+        self::assertSame(1, $this->sequence()->next('2026-08-06'));
+    }
+
+    public function testSubsequentDrawsIncrement(): void
+    {
+        $sequence = $this->sequence();
+
+        self::assertSame(1, $sequence->next('w'));
+        self::assertSame(2, $sequence->next('w'));
+        self::assertSame(3, $sequence->next('w'));
+    }
+
+    public function testANewWindowResetsToOne(): void
+    {
+        $sequence = $this->sequence();
+        $sequence->next('day-1');
+        $sequence->next('day-1');
+
+        self::assertSame(1, $sequence->next('day-2'));
+    }
+
+    public function testTheStateSurvivesANewInstanceOnTheSamePath(): void
+    {
+        $this->sequence()->next('w');
+        $this->sequence()->next('w');
+
+        self::assertSame(3, $this->sequence()->next('w'));
+    }
+
+    public function testTheStateFileHoldsExactlyOneWindowCounterLine(): void
+    {
+        $this->sequence()->next('day-1');
+        $this->sequence()->next('day-1');
+
+        self::assertSame("day-1|2\n", file_get_contents($this->path()));
+    }
+
+    public function testTheCapIsIssuableAndTheNextDrawIsRefused(): void
+    {
+        $sequence = $this->sequence(cap: 3);
+
+        self::assertSame(1, $sequence->next('w'));
+        self::assertSame(2, $sequence->next('w'));
+        self::assertSame(3, $sequence->next('w'));
+
+        $this->expectException(SequenceExhaustedException::class);
+        $this->expectExceptionMessage('exhausted for window "w": 3 of 3 issued');
+
+        $sequence->next('w');
+    }
+
+    public function testExhaustionNeverWrapsToOne(): void
+    {
+        $sequence = $this->sequence(cap: 1);
+        $sequence->next('w');
+
+        try {
+            $sequence->next('w');
+            self::fail('the sequence should have refused');
+        } catch (SequenceExhaustedException) {
+            // expected
+        }
+
+        // The state must be untouched by the refusal — not reset, not advanced.
+        self::assertSame("w|1\n", file_get_contents($this->path()));
+    }
+
+    public function testARefusedDrawDoesNotConsumeTheNextWindowsCapacity(): void
+    {
+        $sequence = $this->sequence(cap: 1);
+        $sequence->next('day-1');
+
+        try {
+            $sequence->next('day-1');
+        } catch (SequenceExhaustedException) {
+            // expected
+        }
+
+        self::assertSame(1, $sequence->next('day-2'));
+    }
+
+    public function testACapOfOneIsUsable(): void
+    {
+        self::assertSame(1, $this->sequence(cap: 1)->next('w'));
+    }
+
+    public function testACapBelowOneIsRefusedAtConstruction(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$cap must be >= 1');
+
+        new FileSequence($this->path(), 0);
+    }
+
+    public function testAnAbsentStateFileIsAFreshStartNotAnError(): void
+    {
+        self::assertFalse(is_file($this->path()));
+        self::assertSame(1, $this->sequence()->next('w'));
+    }
+
+    public function testABlankStateFileIsAlsoAFreshStart(): void
+    {
+        // What `touch` and most deploy scripts leave behind.
+        file_put_contents($this->path(), "  \n");
+
+        self::assertSame(1, $this->sequence()->next('w'));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function corruptStates(): iterable
+    {
+        yield 'no separator' => ["garbage\n"];
+        yield 'counter is not numeric' => ["w|abc\n"];
+        yield 'counter is negative' => ["w|-3\n"];
+        yield 'too many separators' => ["a|b|3\n"];
+        yield 'empty window' => ["|3\n"];
+        yield 'counter missing' => ["w|\n"];
+    }
+
+    #[DataProvider('corruptStates')]
+    public function testACorruptStateFileIsRefusedNotSilentlyReset(string $contents): void
+    {
+        file_put_contents($this->path(), $contents);
+
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('corrupt');
+
+        $this->sequence()->next('w');
+    }
+
+    public function testACorruptStateFileIsNotOverwrittenByTheRefusal(): void
+    {
+        file_put_contents($this->path(), "garbage\n");
+
+        try {
+            $this->sequence()->next('w');
+        } catch (FileException) {
+            // expected
+        }
+
+        // The evidence a human needs to diagnose it must survive.
+        self::assertSame("garbage\n", file_get_contents($this->path()));
+    }
+
+    public function testPeekReportsTheLastIssuedNumber(): void
+    {
+        $sequence = $this->sequence();
+        $sequence->next('w');
+        $sequence->next('w');
+
+        self::assertSame(2, $sequence->peek('w'));
+    }
+
+    public function testPeekIsZeroForAnUnknownWindowOrAnAbsentFile(): void
+    {
+        $sequence = $this->sequence();
+
+        self::assertSame(0, $sequence->peek('never-used'));
+
+        $sequence->next('w');
+
+        self::assertSame(0, $sequence->peek('other'));
+    }
+
+    public function testPeekDoesNotIssueANumber(): void
+    {
+        $sequence = $this->sequence();
+        $sequence->next('w');
+        $sequence->peek('w');
+
+        self::assertSame(2, $sequence->next('w'));
+    }
+
+    public function testRemainingCountsDownFromTheCap(): void
+    {
+        $sequence = $this->sequence(cap: 5);
+
+        self::assertSame(5, $sequence->remaining('w'));
+
+        $sequence->next('w');
+        $sequence->next('w');
+
+        self::assertSame(3, $sequence->remaining('w'));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidWindows(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'contains the separator' => ['a|b'];
+        yield 'contains a newline' => ["a\nb"];
+        yield 'contains a carriage return' => ["a\rb"];
+    }
+
+    #[DataProvider('invalidWindows')]
+    public function testAnUnstorableWindowIsRefused(string $window): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->sequence()->next($window);
+    }
+
+    public function testAWindowGoingBackwardsReissuesNumbersWhichIsTheRecordedLimit(): void
+    {
+        // ADR-0038's named limit: windows are opaque, so the class cannot order them and any
+        // change resets. Pinned as a test so the limit is visible rather than discovered.
+        $sequence = $this->sequence();
+        $sequence->next('day-2');
+        $sequence->next('day-2');
+
+        self::assertSame(1, $sequence->next('day-1'));
+    }
+
+    public function testTwoSequencesOnDifferentPathsAreIndependent(): void
+    {
+        $a = new FileSequence($this->dir . '/a.state', 10);
+        $b = new FileSequence($this->dir . '/b.state', 10);
+
+        $a->next('w');
+        $a->next('w');
+
+        self::assertSame(1, $b->next('w'));
+    }
+}

--- a/src/test/php/d4np/utils/Support/FileUpdateTest.php
+++ b/src/test/php/d4np/utils/Support/FileUpdateTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Support;
+
+use D4np\Utils\Support\File;
+use D4np\Utils\Support\FileException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * `File::update()` — locked read-modify-write, added for item 9.5.
+ *
+ * The property that distinguishes it from `read()` + `write()` is invisible in a
+ * single-process test: that the lock spans both halves. {@see FileSequenceConcurrencyTest}
+ * (T-14) is what proves it, by failing when the two are split. These tests cover the rest of
+ * the contract — the mutator's view of a missing file, and that a throwing mutator leaves
+ * nothing behind.
+ */
+final class FileUpdateTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/egl-utils-update-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->dir) && !is_dir($this->dir)) {
+            self::fail('could not create the test directory');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $entry) {
+            @unlink($entry);
+        }
+        @rmdir($this->dir);
+    }
+
+    private function path(): string
+    {
+        return $this->dir . '/state.txt';
+    }
+
+    public function testTheMutatorReceivesTheCurrentContents(): void
+    {
+        file_put_contents($this->path(), 'before');
+        $seen = null;
+
+        File::update($this->path(), static function (string $current) use (&$seen): string {
+            $seen = $current;
+
+            return 'after';
+        });
+
+        self::assertSame('before', $seen);
+        self::assertSame('after', file_get_contents($this->path()));
+    }
+
+    public function testAMissingFileIsPresentedAsAnEmptyString(): void
+    {
+        $seen = null;
+
+        File::update($this->path(), static function (string $current) use (&$seen): string {
+            $seen = $current;
+
+            return 'created';
+        });
+
+        self::assertSame('', $seen);
+        self::assertSame('created', file_get_contents($this->path()));
+    }
+
+    public function testAnEmptyFileIsDistinguishableFromNothingByTheCallerOnly(): void
+    {
+        // Both arrive as '' — documented, and the reason FileSequence treats a blank state
+        // file as a fresh start rather than trying to tell them apart.
+        file_put_contents($this->path(), '');
+        $seen = 'unset';
+
+        File::update($this->path(), static function (string $current) use (&$seen): string {
+            $seen = $current;
+
+            return 'x';
+        });
+
+        self::assertSame('', $seen);
+    }
+
+    public function testAThrowingMutatorLeavesTheFileUntouched(): void
+    {
+        file_put_contents($this->path(), 'original');
+
+        try {
+            File::update($this->path(), static function (): string {
+                throw new RuntimeException('refused');
+            });
+            self::fail('the mutator should have thrown');
+        } catch (RuntimeException $e) {
+            self::assertSame('refused', $e->getMessage());
+        }
+
+        self::assertSame('original', file_get_contents($this->path()));
+    }
+
+    public function testAThrowingMutatorDoesNotCreateAMissingFile(): void
+    {
+        try {
+            File::update($this->path(), static function (): string {
+                throw new RuntimeException('refused');
+            });
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        self::assertFileDoesNotExist($this->path());
+    }
+
+    public function testAThrowingMutatorLeavesNoTemporaryFileBehind(): void
+    {
+        try {
+            File::update($this->path(), static function (): string {
+                throw new RuntimeException('boom');
+            });
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        $strays = array_values(array_filter(
+            glob($this->dir . '/*') ?: [],
+            fn (string $p): bool => $p !== $this->path() && $p !== $this->path() . '.lock',
+        ));
+
+        self::assertSame([], $strays);
+    }
+
+    public function testSequentialUpdatesCompose(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            File::update($this->path(), static fn (string $c): string => $c . 'x');
+        }
+
+        self::assertSame('xxxxx', file_get_contents($this->path()));
+    }
+
+    public function testAMissingDirectoryThrowsFileException(): void
+    {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        File::update($this->dir . '/absent/state.txt', static fn (string $c): string => $c);
+    }
+
+    public function testAnExistingFilesModeIsPreserved(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX mode bits are not meaningful on Windows.');
+        }
+
+        file_put_contents($this->path(), 'x');
+        chmod($this->path(), 0640);
+
+        File::update($this->path(), static fn (string $c): string => $c . 'y');
+
+        self::assertSame(0640, fileperms($this->path()) & 0777);
+    }
+}

--- a/src/test/php/d4np/utils/Support/Fixture/sequence_worker.php
+++ b/src/test/php/d4np/utils/Support/Fixture/sequence_worker.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * T-14's worker: a separate PHP process that draws numbers from a shared {@see FileSequence}.
+ *
+ * Separate *processes* are the point. Threads or sequential calls inside one PHPUnit run share
+ * a lock owner, so `flock()` never actually contends and the test would pass against an
+ * implementation that has no locking at all. Only real processes make the race real.
+ *
+ * Usage: php sequence_worker.php <autoload> <statePath> <cap> <window> <draws> <outFile>
+ * Writes one number per line to <outFile>, or `ERROR: ...` if a draw failed.
+ */
+
+declare(strict_types=1);
+
+use D4np\Utils\Support\FileSequence;
+
+/** @var list<string> $argv */
+$argv = $_SERVER['argv'];
+
+if (\count($argv) !== 7) {
+    fwrite(STDERR, "usage: sequence_worker.php <autoload> <statePath> <cap> <window> <draws> <outFile>\n");
+
+    exit(2);
+}
+
+[, $autoload, $statePath, $cap, $window, $draws, $outFile] = $argv;
+
+require_once $autoload;
+
+$sequence = new FileSequence($statePath, (int) $cap);
+$drawn = [];
+
+try {
+    for ($i = 0; $i < (int) $draws; $i++) {
+        $drawn[] = $sequence->next($window);
+    }
+} catch (Throwable $e) {
+    file_put_contents($outFile, 'ERROR: ' . $e->getMessage());
+
+    exit(1);
+}
+
+file_put_contents($outFile, implode("\n", $drawn));
+
+exit(0);


### PR DESCRIPTION
## Summary

Roadmap item **9.5** — `FileSequence`, `SequenceExhaustedException` and `File::update()`;
spec r6 **FR-32**, **ADR-0038**. A rolling counter that is safe across processes. 41 new
tests including **T-14**; suite **proved non-vacuous with 8 planted defects**, all caught.

## Motivation

FR-32 reads like a small class. The first real question changed the shape of the item: **a
sequence is a read-modify-write, and this library's primitives could not express one
safely.**

```
process A: [lock] read 5 [unlock]                [lock] write 6 [unlock]
process B:            [lock] read 5 [unlock]  [lock] write 6 [unlock]
```

`File::read()` takes a shared lock, `File::write()` an exclusive one; composing them is a
race. For most data a lost update is annoying. For a sequence it is a **duplicate
identifier**, surfacing far from the cause — as a duplicate key, or as a row quietly attached
to the wrong record.

## Changes

- **`File::update(string $path, callable $mutator)`** — holds one exclusive lock across the
  read *and* the write, calling the mutator **before** anything is written so a mutator that
  throws leaves the file untouched. Following ADR-0037's precedent rather than re-deciding
  it: a `flock()` inside `FileSequence` would have put ADR-0005's discipline in a second
  place, where it drifts. `File` now has three writers for three shapes — replace,
  replace-by-streaming, read-modify-write — over one shared implementation of the lock, the
  same-directory temp file, mode-before-rename and cleanup (`write()`/`writeStream()`
  refactored onto the shared helpers, behaviour unchanged).
- **`FileSequence`** — `next(string $window)`, plus advisory `peek()`/`remaining()`.
- **`SequenceExhaustedException`** — the type spec r3 already named.
- ADR-0038 + index, **spec → r6**, CHANGELOG, ROADMAP 9.5 flipped, session journal.

### Three refusals, each against its tempting alternative

- **The cap refuses; it does not wrap.** Wrapping re-issues identifiers already in use,
  silently, at exactly the load that makes duplicates expensive. The refusal leaves the state
  untouched, so catching it and retrying in the next window costs nothing (asserted).
- **A corrupt state file is refused and left on disk.** Resetting is the reflex and has the
  worst blast radius — it re-issues the whole window — and it destroys the evidence. The
  distinction drawn is *absent* vs *unparseable*: an absent or blank file (what `touch` and
  deploy scripts leave) is a legitimate fresh start.
- **The window stays a caller-supplied opaque string.** The estate's helper called
  `date_default_timezone_set()` as a side effect of minting an identifier, changing the
  timezone for the rest of the request.

**Recorded limit:** opaque windows cannot be ordered, so *any* window change resets —
including to an earlier one. A lexicographic "must not go backwards" guard was considered and
rejected: correct for `2026-08-06` and padded `008`, silently wrong for unpadded numbers
where `10` sorts below `9`. A guard right for some formats and wrong for others is worse than
a limit written down — so it is, in the class, in the ADR, and in a test.

## Design Patterns

- None adopted — no catalogue entry. The decision content is in **ADR-0038**.

## Verification

- [x] Full suite green: **1601 tests, 3441 assertions** (41 new; 9 environment skips — the 8
      carried in plus one new POSIX-mode test that skips on Windows)
- [x] **T-14 is real, and proved real.** Four separate PHP processes × 30 draws, asserting
      the union is exactly `1..120` with no duplicate and no gap, plus a capped variant
      asserting no number above the cap is issued and at least one worker is refused.
      Everything inside one PHP process shares a lock owner, so an in-process "concurrency"
      test would pass against an implementation with **no locking at all** — the first
      planted defect splits `update()` back into a separate read and write, and **T-14
      catches it**.
- [x] **Non-vacuity: 8 planted defects, 8 caught** — the split-lock race, cap check removed,
      cap wrapping instead of refusing, corrupt state silently reset, window change not
      resetting, blank file treated as corrupt, window guard removed, `cap: 0` accepted
- [x] `PHPStan (max level)` — No errors (clean on the first run this time)
- [x] `PHP-CS-Fixer (PSR-12)` — clean
- [x] `deptrac` — 0 violations, 0 uncovered
- [x] `composer normalize --dry-run` — clean (no dependency change)
- [x] `python tools/consistency_lint.py` — OK
- [x] Leak-gate over the staged diff — zero
- [ ] CI matrix (8.1/8.2/8.3) + coverage floor — this PR's checks

**One thing worth a reviewer's eye:** T-14 spawns `PHP_BINARY` subprocesses via `proc_open`
(the T-03 precedent). It resolves the autoloader from the test's own path and asserts each
worker produced output, so a spawn failure fails loudly rather than passing vacuously.

## Documentation Impact

- [ ] README.md — unchanged (it names groups, not methods)
- [x] ROADMAP.md — 9.5 flipped with its completion note; latest-journal pointer updated
- [x] **ADR added** — ADR-0038, indexed
- [ ] docs/patterns/README.md — unchanged
- [x] **Spec updated → r6** — FR-32 to the precision implemented, FR-22/23 gains
      `File::update()`, T-14 recorded in §6
- [x] CHANGELOG.md — `[Unreleased] / Added` entry
- [x] PR metadata — assignee (owner), label `enhancement`, milestone **v0.8.0**

**Route note:** routed `standard / medium`; session model matched — **no mismatch**, the
first in this milestone.

## Lesson

Lesson: before writing the class a requirement names, check whether the primitives it will
stand on can express its core operation. FR-32 looked like a counter; the missing piece was a
lock spanning two operations, and building the counter first would have produced something
that passed every test and lost increments in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
