### PR TITLE
feat(bench): wire NFR-10 and NFR-12 into the ADR-0030 same-runner harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
         if: steps.cfg.outputs.present == 'true'
         shell: bash
         run: |
-          python3 tools/bench_budget_gate.py build/logs/head.xml             --budget benchHydrateWarm=5             --budget benchBuildFiveConditionSelect=10             --budget benchWarmSingletonResolve=2             --budget benchFirstAutowiredResolve=30
+          python3 tools/bench_budget_gate.py build/logs/head.xml             --budget benchHydrateWarm=5             --budget benchBuildFiveConditionSelect=10             --budget benchWarmSingletonResolve=2             --budget benchFirstAutowiredResolve=30             --budget benchSequenceNext=200             --budget benchWriteTenThousandByTen=150000
       - name: NFR-01 ratio — hydration vs manual construction
         if: steps.cfg.outputs.present == 'true'
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,9 @@ jobs:
             --budget benchHydrateWarm=5 \
             --budget benchBuildFiveConditionSelect=10 \
             --budget benchWarmSingletonResolve=2 \
-            --budget benchFirstAutowiredResolve=30
+            --budget benchFirstAutowiredResolve=30 \
+            --budget benchSequenceNext=200 \
+            --budget benchWriteTenThousandByTen=150000
 
       - name: NFR-01 ratio — hydration vs manual construction
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **phpbench benchmarks for NFR-10 (`FileSequence`) and NFR-12 (`Csv`)** (spec r6 §3,
+  RFC-0002; roadmap item **9.6**, closing **Milestone 9**): `FileSequenceBench` and
+  `CsvBench` under `src/bench/php/d4np/utils/`, wired into the same
+  `bench_budget_gate.py` call ADR-0030 already established for the other four subjects
+  (`benchSequenceNext<=200µs`, `benchWriteTenThousandByTen<=150000µs`). No new ADR and no
+  production code change: ADR-0030's standing decision (CI-gated on Linux, same-runner,
+  environment-asserted) already covers two more subjects added to it. NFR-12's other
+  clause — streaming memory, never a full-table buffer — is `Csv::write()`'s
+  construction, proven by `CsvRoundTripTest`, not benchmarked: a stopwatch cannot see an
+  absence. This developer's machine measured `benchSequenceNext` at roughly 250× its
+  budget via direct timing; read as the same environment artifact ADR-0030 already named
+  on this exact box (Windows/NTFS I/O latency, not NFR-06's methodology), not as a defect
+  — the Linux CI run is the authoritative measurement.
+
 - **`D4np\Utils\Support\FileSequence`, `SequenceExhaustedException`** and **`File::update()`**
   (spec r6 **FR-32**, RFC-0002; roadmap item **9.5**; **ADR-0038**) — a rolling counter
   persisted to a file and safe across processes. The whole read-modify-write runs under

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ setup.
 | 6 | HTTP, container, errors | ✅ done |
 | 7 | Release engineering & bridge | ✅ done |
 | 8 | PSR-7 bridge (`packages/utils-psr7-bridge`) | ✅ done |
-| 9 | Support & values | ⏳ planned |
+| 9 | Support & values | ✅ done |
 | 10 | Persistence | ⏳ planned |
 | 11 | Http application layer | ⏳ planned |
 | 12 | Security & channels | ⏳ planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — Two locks are one too many](docs/journal/2026/08/2026-08-06-file-sequence.md).
+  [2026-08-06 — A budget this machine cannot honestly measure](docs/journal/2026/08/2026-08-06-utils-benchmarks.md).
 
 ## Model & effort routing (advisory)
 
@@ -689,8 +689,28 @@ surface (RFC-0002 FR-27…FR-32).
       windows cannot be ordered, so any change resets — a lexicographic guard was considered
       and rejected because it silently breaks unpadded numeric windows. 41 tests; **suite
       proved non-vacuous with 8 planted defects**, all caught.*
-- [ ] 9.6 phpbench: NFR-12 (Csv streaming) + NFR-10 (FileSequence) wired into the ADR-0030
-      same-runner harness (RFC-0002) (step:optimize) — size: S · route: fast / medium
+- [x] 9.6 phpbench: NFR-12 (Csv streaming) + NFR-10 (FileSequence) wired into the ADR-0030
+      same-runner harness (RFC-0002) (step:optimize) — route: fast / medium. **Closes
+      Milestone 9.** *`FileSequenceBench::benchSequenceNext()` and
+      `CsvBench::benchWriteTenThousandByTen()` follow the established shape exactly:
+      `Revs(1)` for Csv (10 000 rows already is NFR-12's unit, `MemoryBench`'s precedent),
+      1000 same-file revolutions for FileSequence since `next()`'s cost is dominated by the
+      lock-and-rewrite, not by the counter's value — unlike `ContainerBench`'s cold subject,
+      no per-revolution freshness is needed. Both wired into `ci.yml`/`nightly.yml`'s
+      existing `bench_budget_gate.py` call (`benchSequenceNext<=200`,
+      `benchWriteTenThousandByTen<=150000`, phpbench's native µs). NFR-12's other clause —
+      "memory O(row)" — is `Csv::write()`/`File::writeStream()`'s streaming-by-construction,
+      proven by `CsvRoundTripTest`, not by a benchmark that cannot see an absence (item 4.5's
+      "0 queries" precedent). **Honest limit:** this developer machine could not produce a
+      trustworthy number for either subject — direct timing (bypassing phpbench's own broken
+      environment-detection capture on this box, a pre-existing quirk) measured
+      `benchSequenceNext` at **~49.8 ms**, roughly 250× the budget, on Windows/NTFS with the
+      antivirus-scanned temp directory `File::update()`'s lock-create/rename cycle runs
+      through. ADR-0030 already named this exact machine unreliable for benchmark numbers
+      (`--php-disable-ini` there, extension-load warnings corrupting phpbench's own capture
+      here); repeating the workaround was rejected for the same reason ADR-0030 rejected it.
+      The budgets are therefore verified by CI's Linux runner, not locally — the same
+      division of labor as every other absolute NFR in this project.*
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -710,7 +710,14 @@ surface (RFC-0002 FR-27…FR-32).
       (`--php-disable-ini` there, extension-load warnings corrupting phpbench's own capture
       here); repeating the workaround was rejected for the same reason ADR-0030 rejected it.
       The budgets are therefore verified by CI's Linux runner, not locally — the same
-      division of labor as every other absolute NFR in this project.*
+      division of labor as every other absolute NFR in this project. **CI's own numbers**
+      (this PR's `benchmark` job, `ubuntu-24.04`): `benchSequenceNext` **182.981 µs**
+      against ≤ 200 µs — **passes, but with the thinnest headroom of any gated NFR in this
+      project** (~9%, against NFR-01's 2.6×, NFR-03's 3.4×, NFR-05's 2.4×); named rather
+      than left implicit, since ADR-0030's 40%-peak-to-peak cross-runner noise finding is
+      larger than this margin, and a future PR narrowing it further is worth watching for,
+      not assuming away. `benchWriteTenThousandByTen` **20.213 ms** against ≤ 150 ms —
+      **7.4× headroom**, comfortable.*
 
 ---
 

--- a/docs/journal/2026/08/2026-08-06-utils-benchmarks.md
+++ b/docs/journal/2026/08/2026-08-06-utils-benchmarks.md
@@ -49,12 +49,22 @@ machine being a Ryzen 7 5800X nobody here runs on, and *why* a same-runner compa
 (not this developer's box) is the trustworthy read. Item 9.6 applies that standing
 decision to two more subjects; it does not make a new one.
 
-## What actually verifies this item
+## What actually verified it, and what that verification is worth qualifying
 
 The CI benchmark job, on `ubuntu-24.04`, gated by `tools/assert_bench_env.php` (PHP 8.3,
-OPcache and JIT off) — the same authority every other NFR in this project answers to. This
-journal entry exists so that whoever reads the PR sees the 250× number and does not read it
-as an unexamined regression; it is this machine's number, not the library's.
+OPcache and JIT off) — the same authority every other NFR in this project answers to. It
+reported `benchSequenceNext` at **182.981 µs** and `benchWriteTenThousandByTen` at
+**20.213 ms**, both under budget. The 250× local number was indeed this machine, not the
+library.
+
+One number is worth not just checking off. NFR-10's budget clears by **~9%** — the
+thinnest margin of any gated NFR here, against NFR-01's 2.6×, NFR-03's 3.4×, NFR-05's 2.4×,
+and this item's own NFR-12 at 7.4×. ADR-0030 measured 40% peak-to-peak noise on identical
+code across `master` runs, which dwarfs a 9% margin. This PR's single run passing is not
+evidence the margin is real; the regression gate (base-vs-HEAD, same runner) is what would
+catch drift going forward, and it correctly reported both subjects as *new* — nothing to
+compare against yet. Recorded here so a future flaky-looking failure on this subject is
+read as "the margin was always this thin" rather than investigated as a fresh regression.
 
 ## Lesson
 

--- a/docs/journal/2026/08/2026-08-06-utils-benchmarks.md
+++ b/docs/journal/2026/08/2026-08-06-utils-benchmarks.md
@@ -1,0 +1,62 @@
+# 2026-08-06 — A budget this machine cannot honestly measure
+
+Roadmap item **9.6**, closing Milestone 9. Route `fast / medium` — matched, no mismatch.
+Two benchmark subjects, `FileSequenceBench::benchSequenceNext()` (NFR-10, ≤ 200 µs) and
+`CsvBench::benchWriteTenThousandByTen()` (NFR-12, ≤ 150 ms), wired into the same
+`bench_budget_gate.py` call ADR-0030 already established for the other four.
+
+## The design was the easy part
+
+Both subjects follow shapes this codebase already has names for. `CsvBench` takes
+`MemoryBench`'s reasoning verbatim — 10 000 rows is the unit NFR-12 names, so `Revs(1)`
+measures it directly rather than averaging several apart. `FileSequenceBench` takes
+`ContainerBench`'s *opposite* lesson: that class needs a fresh subject every revolution
+because its cold path is what is being timed; `FileSequence::next()`'s cost is dominated
+by `File::update()`'s lock-acquire-and-rewrite, not by the counter's numeric value, so one
+state file created per **iteration** (phpbench's hooks run once per iteration, not per
+revolution — the fact `ContainerBench`'s docblock had to go read the runner template to
+learn) is correct, reused across a thousand revolutions inside it.
+
+NFR-12's other half — "memory O(row), never a full-table buffer" — is not a benchmark's
+business at all, for the reason `QueryBuilderBench` already states: a stopwatch cannot see
+an absence. `Csv::write()` streams through `File::writeStream()`'s handle; that is proven
+by `CsvRoundTripTest`, not measured here.
+
+## What this machine reported, and why it does not count
+
+Direct timing (bypassing phpbench's own CLI, which fails its environment-detection capture
+on this box before a single subject runs — a pre-existing warning-noise issue, not this
+item's) put `benchSequenceNext` at **~49.8 ms per call** against a 200 µs budget: roughly
+**250×** over. `CsvBench` came in at 213 ms against 150 ms — over, but by a plausible
+margin rather than an alarming one.
+
+The instinct is to treat a 250× miss as a defect. It is the same shape ADR-0030 already
+named and closed, on this exact machine: Windows/NTFS plus (very likely) real-time
+antivirus scanning turns each `File::update()` call's lock-file create, temp-file rename,
+and lock-file delete into several disk round-trips that on Linux ext4 cost microseconds
+and here cost milliseconds. ADR-0030's own three earlier benchmark corrections
+(ADR-0018, ADR-0020, ADR-0028) all had the same tell — *"the total looked plausible and
+the thing being measured was wrong"* — and each time the fix was to the workload, never to
+trust a bad environment less loudly. This is a fourth instance of the same tell pointing
+the other way: the workload here is exactly what NFR-10/12 name, and the environment is
+what is wrong.
+
+Re-deriving that conclusion by re-running `--php-disable-ini` (ADR-0030's own rejected
+workaround, which discards the whole `php.ini`) was not repeated — the ADR already spent a
+section rejecting it. Nothing about that finding needed a new ADR: ADR-0030 already
+decided *that* absolute budgets are CI-gated on Linux hardware despite the reference
+machine being a Ryzen 7 5800X nobody here runs on, and *why* a same-runner comparison
+(not this developer's box) is the trustworthy read. Item 9.6 applies that standing
+decision to two more subjects; it does not make a new one.
+
+## What actually verifies this item
+
+The CI benchmark job, on `ubuntu-24.04`, gated by `tools/assert_bench_env.php` (PHP 8.3,
+OPcache and JIT off) — the same authority every other NFR in this project answers to. This
+journal entry exists so that whoever reads the PR sees the 250× number and does not read it
+as an unexamined regression; it is this machine's number, not the library's.
+
+## Lesson
+
+A wild local benchmark number is information about the machine at least as often as about
+the code — check which one changed before trusting either.

--- a/src/bench/php/d4np/utils/CsvBench.php
+++ b/src/bench/php/d4np/utils/CsvBench.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench;
+
+use D4np\Utils\Support\Csv;
+use Generator;
+use PhpBench\Attributes as Bench;
+
+/**
+ * NFR-12: writing 10 000 rows × 10 columns ≤ 150 ms (spec r3 FR-28, RFC-0002).
+ *
+ * **Only the timing half is a benchmark's business.** NFR-12's other clause — "memory
+ * O(row), never a full-table buffer" — is a property of {@see Csv::write()}'s `iterable`
+ * parameter and {@see \D4np\Utils\Support\File::writeStream()}'s handle-based writer: the
+ * table is never materialized, so there is no peak to read a delta from, and a memory
+ * benchmark here would report the *generator's* footprint, not the table's absence. Same
+ * shape as {@see QueryBuilderBench}'s "0 queries executed": a claim a stopwatch cannot see
+ * is proven by construction and by
+ * {@see \D4np\Utils\Tests\Support\CsvRoundTripTest}, not measured.
+ *
+ * `Revs(1)` is deliberate, {@see MemoryBench}'s reasoning: 10 000 rows already is the unit
+ * of work NFR-12 names, so one revolution measures it directly rather than averaging
+ * several apart.
+ *
+ * The absolute ≤ 150 ms ceiling carries the same caveat every benchmark here documents
+ * (roadmap 3.5, ADR-0018, ADR-0030): tied to spec NFR-06's reference machine, gated on CI
+ * hardware only because ADR-0030 measured the headroom to survive cross-runner noise.
+ */
+#[Bench\Revs(1)]
+#[Bench\Iterations(5)]
+#[Bench\RetryThreshold(5)]
+final class CsvBench
+{
+    private const ROWS = 10_000;
+    private const COLUMNS = 10;
+
+    private string $path;
+
+    public function setUpPath(): void
+    {
+        $this->path = sys_get_temp_dir() . '/egl-utils-csv-bench-' . bin2hex(random_bytes(8)) . '.csv';
+    }
+
+    public function tearDownPath(): void
+    {
+        @unlink($this->path);
+        @unlink($this->path . '.lock');
+    }
+
+    #[Bench\BeforeMethods('setUpPath')]
+    #[Bench\AfterMethods('tearDownPath')]
+    public function benchWriteTenThousandByTen(): void
+    {
+        Csv::write($this->path, self::rows());
+    }
+
+    /**
+     * @return Generator<int, list<int>>
+     */
+    private static function rows(): Generator
+    {
+        for ($i = 0; $i < self::ROWS; $i++) {
+            yield array_fill(0, self::COLUMNS, $i);
+        }
+    }
+}

--- a/src/bench/php/d4np/utils/FileSequenceBench.php
+++ b/src/bench/php/d4np/utils/FileSequenceBench.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench;
+
+use D4np\Utils\Support\FileSequence;
+use PhpBench\Attributes as Bench;
+
+/**
+ * NFR-10: `FileSequence::next()` ≤ 200 µs on local disk, lock included (spec r3 FR-32,
+ * RFC-0002).
+ *
+ * **No per-revolution freshness is needed here**, unlike {@see ContainerBench}'s cold
+ * subject. `next()`'s cost is dominated by {@see \D4np\Utils\Support\File::update()}'s
+ * lock-acquire, read, and atomic rewrite of a fixed-shape one-line file — not by the
+ * counter's numeric value, which only ever grows by a digit or two across a whole
+ * benchmark run. A single state file created once per **iteration** (phpbench's hooks run
+ * once per iteration, not per revolution — {@see ContainerBench}'s docblock) is therefore
+ * the correct setup, reused across every revolution inside it.
+ *
+ * The cap is sized far above the revolution count below so the sequence never refuses
+ * mid-iteration — `SequenceExhaustedException` is {@see \D4np\Utils\Support\FileSequenceTest}'s
+ * concern, not this benchmark's.
+ *
+ * The absolute ≤ 200 µs ceiling carries the same caveat every benchmark here documents
+ * (roadmap 3.5, ADR-0018, ADR-0030): tied to spec NFR-06's reference machine, gated on CI
+ * hardware only because ADR-0030 measured the headroom to survive cross-runner noise.
+ */
+#[Bench\Iterations(10)]
+#[Bench\Revs(1000)]
+#[Bench\RetryThreshold(5)]
+final class FileSequenceBench
+{
+    /** Comfortably above the 1000 revolutions one iteration replays against one file. */
+    private const CAP = 100_000;
+
+    private string $path;
+
+    private FileSequence $sequence;
+
+    public function setUpSequence(): void
+    {
+        $this->path = sys_get_temp_dir() . '/egl-utils-seq-bench-' . bin2hex(random_bytes(8)) . '.state';
+        $this->sequence = new FileSequence($this->path, self::CAP);
+    }
+
+    public function tearDownSequence(): void
+    {
+        @unlink($this->path);
+        @unlink($this->path . '.lock');
+    }
+
+    #[Bench\BeforeMethods('setUpSequence')]
+    #[Bench\AfterMethods('tearDownSequence')]
+    public function benchSequenceNext(): void
+    {
+        $this->sequence->next('bench');
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item **9.6**, closing **Milestone 9**: wires NFR-10 (`FileSequence::next()` ≤
200 µs) and NFR-12 (`Csv` streaming write, 10 000×10 ≤ 150 ms) into the ADR-0030
same-runner benchmark harness, alongside the four subjects already gated there.

## Motivation

RFC-0002 / spec r6 §3 states both budgets; nothing measured them yet. Same division of
labor items 3.5/4.5/5.5/7.1 established: a benchmark subject per NFR, gated by
`bench_budget_gate.py` in `ci.yml`/`nightly.yml`, on the Linux runner `assert_bench_env.php`
pins to spec NFR-06's methodology (PHP 8.3, OPcache+JIT off) — never asserted as a hard
local expectation, per ADR-0030.

## Changes

- **`src/bench/php/d4np/utils/FileSequenceBench.php`** — `benchSequenceNext()`. One state
  file created per **iteration** (not per revolution — phpbench's hooks run once per
  iteration; `ContainerBench`'s docblock is the citation), reused across 1000 revolutions:
  `next()`'s cost is dominated by `File::update()`'s lock-acquire-and-rewrite, not by the
  counter's value, so no per-revolution freshness is needed (the *opposite* of why
  `ContainerBench`'s cold subject needs it).
- **`src/bench/php/d4np/utils/CsvBench.php`** — `benchWriteTenThousandByTen()`. `Revs(1)`,
  `MemoryBench`'s reasoning: 10 000 rows already is NFR-12's unit of work. NFR-12's other
  clause — "memory O(row), never a full-table buffer" — is `Csv::write()`/
  `File::writeStream()`'s streaming-by-construction, proven by `CsvRoundTripTest`, not
  measured: a stopwatch cannot see an absence (`QueryBuilderBench`'s "0 queries" precedent).
- **`.github/workflows/ci.yml`, `.github/workflows/nightly.yml`** — two more `--budget`
  flags on the existing `bench_budget_gate.py` call:
  `benchSequenceNext=200`, `benchWriteTenThousandByTen=150000` (phpbench's native µs).
- **ROADMAP.md** — item 9.6 checked, closing Milestone 9, with the measurement caveat below
  recorded in place rather than glossed over.
- **README.md** — Milestone 9 row flipped to done.
- **CHANGELOG.md** — `[Unreleased]` entry, following items 3.5/7.1's precedent of logging
  benchmark-wiring even though it changes no production code.
- **docs/journal/2026/08/2026-08-06-utils-benchmarks.md** — session checkpoint.

**No spec change** and **no new ADR**: NFR-10/NFR-12 are already in spec r6 (item 9.5's
PR); this item wires existing numbers into an existing, already-decided harness, the same
non-event items 3.5/4.5's *wiring* halves were before their *findings* earned ADRs.
ADR-0030's standing decision — CI-gated on Linux, same-runner, environment-asserted —
already covers two more subjects added to it.

## Honest limit (recorded, not chased)

Direct timing on this developer machine (bypassing phpbench's own CLI, which fails its
environment-detection capture here before any subject runs — a pre-existing, unrelated
warning-noise issue) measured `benchSequenceNext` at **~49.8 ms** against its 200 µs
budget: roughly **250× over**. `benchWriteTenThousandByTen` measured ~213 ms against 150 ms.

Both are read as an **environment** artifact, not a defect: ADR-0030 already named this
exact machine (Windows/NTFS, likely antivirus-scanned temp I/O) unreliable for benchmark
numbers, for the same class of reason its own rejected `--php-disable-ini` workaround
existed to paper over. Repeating that workaround was rejected for ADR-0030's own stated
reason.

**This PR's own `benchmark` job (`ubuntu-24.04`) is the authoritative run**, and it
reported: `benchSequenceNext` **182.981 µs** against ≤ 200 µs, `benchWriteTenThousandByTen`
**20.213 ms** against ≤ 150 ms. Both pass — but NFR-10's margin is **~9%**, the thinnest of
any gated NFR here (the others run 2.4×–3.4× headroom; NFR-12 itself is 7.4×), against
ADR-0030's own measured 40% peak-to-peak cross-runner noise. One green run does not prove
that margin is real; the regression gate is what will, going forward, and it correctly
reported both subjects as *new* this run. Flagged rather than left implicit, so a future
flaky-looking failure on `benchSequenceNext` reads as "the margin was always this thin,"
not as a fresh regression to chase.

## Design Patterns

- None adopted or rejected — pure benchmark wiring, no new component or decision.

## Verification

- [x] `vendor/bin/phpunit` — 1601 tests, 3441 assertions, 9 pre-existing skips (fileinfo/
      coverage-driver related, unrelated to this change), all green
- [x] `vendor/bin/phpstan analyse` (max level) — no errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 of 189 files need changes
- [x] `python tools/consistency_lint.py` passes
- [x] `python tools/action_pin_lint.py` passes (workflow files touched; no pin shape changed)
- [x] Leak-gate grep over the staged diff: zero matches
- [x] Build matrix / benchmark job — **green on this PR's own CI run**; see the measured
      numbers and the headroom caveat in the Honest limit section above

## Documentation Impact

- [x] README.md updated (Milestone 9 → done)
- [x] ROADMAP.md updated (9.6 checked, Milestone 9 closed)
- [ ] ADR added/updated — none needed (see Changes)
- [ ] docs/patterns/README.md — unchanged, no pattern introduced
- [ ] Spec updated — unchanged, r6 already states NFR-10/12
- [x] CHANGELOG.md — Added, following items 3.5's and 7.1's own precedent of logging
      benchmark-wiring under `[Unreleased]`
- [x] PR metadata set — assignee (owner), label `enhancement`, milestone `v0.8.0`

## Lesson

Lesson: a wild local benchmark number is information about the machine at least as often
as about the code — check which one changed before trusting either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
