### PR TITLE
feat(database): SQL text and its parameters become one value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`D4np\Utils\Database\SqlStatement`** (spec r7 **FR-33**, RFC-0002; roadmap item **10.1**,
+  opening **Milestone 10**; **ADR-0039**) — an immutable pairing of SQL text and its bound
+  parameters. Motivated by the surveyed estate's 199 sites where a value was interpolated
+  into SQL text against 0 sites where one was bound: a `(string, array)` method signature
+  never stopped that from happening, because nothing in it says the two were assembled
+  together. `SqlStatement` makes text-and-parameters one value, and `Persistence\Repository`
+  (upcoming, item 10.3) will accept nothing else from a caller with hand-written SQL.
+
+### Changed
+
+- **`DatabaseConnection::select()`, `selectOne()` and `execute()` now take a single
+  `SqlStatement` argument** instead of `(string $sql, array $parameters = [])` (ADR-0039).
+  A breaking change to the `Database` group's public signature, made in a pre-1.0 MINOR
+  (SemVer §4 permits it; `tools/bc_gate.py` treats it as bump-legal). No behavior changes:
+  every value was already bound as a real parameter (ADR-0014's real prepares) under the
+  old shape — this moves where a reviewer has to look, not what the driver receives.
+  `QueryBuilder::get()`/`first()` and every test call site are migrated in the same PR.
+
 - **phpbench benchmarks for NFR-10 (`FileSequence`) and NFR-12 (`Csv`)** (spec r6 §3,
   RFC-0002; roadmap item **9.6**, closing **Milestone 9**): `FileSequenceBench` and
   `CsvBench` under `src/bench/php/d4np/utils/`, wired into the same

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — A budget this machine cannot honestly measure](docs/journal/2026/08/2026-08-06-utils-benchmarks.md).
+  [2026-08-06 — What one value type actually closes](docs/journal/2026/08/2026-08-06-sql-statement.md).
 
 ## Model & effort routing (advisory)
 
@@ -727,10 +727,22 @@ RFC-0002's centerpiece: the layer that makes value-interpolated SQL a library-im
 shape (the surveyed estate measured 199 interpolation sites against 0 bound parameters).
 First two named cross-group deptrac edges (RFC-0002 P-1).
 
-- [ ] 10.1 `Database\SqlStatement`: immutable SQL+binds value; connection-side execution
+- [x] 10.1 `Database\SqlStatement`: immutable SQL+binds value; connection-side execution
       accepts **only** statements — text never travels without its parameters
-      (RFC-0002 FR-33) (security — the protected floor) — size: S ·
-      route: frontier-reasoning / extra · ADR (statement-only execution)
+      (RFC-0002 FR-33) (security — the protected floor) —
+      route: frontier-reasoning / extra · **ADR-0039**, **spec r7**. *Opens Milestone 10.
+      **What this does and does not close, stated plainly**: every existing call site was
+      already binding real parameters (ADR-0014's real prepares) — a `(string, array)`
+      signature never let a value reach the driver unbound. What it changes is where a
+      reviewer has to look: after this item, `DatabaseConnection::select()`/`selectOne()`/
+      `execute()` accept **only** a `SqlStatement`, so text and parameters cannot be two
+      separately-assembled variables at the one true boundary to the driver — the estate's
+      199-interpolation/0-binding failure mode, generalized as a type rather than left as a
+      discipline every future call site has to re-earn. `QueryBuilder::get()`/`first()` and
+      every test in `Database`/`Security` migrated in this item; a pre-1.0 breaking change
+      to a public signature, permitted under SemVer §4 and `tools/bc_gate.py`. No new
+      deptrac edge — `SqlStatement` stays in `Database`, where `Persistence` (10.2–10.4)
+      will consume it as one of its own two named edges.*
 - [ ] 10.2 `Persistence\RowNormalizer` policy object (strict/lossy transcode, trim,
       empty→`null`) + T-15 policy table + the `Persistence` deptrac layer (edge to Support
       only at this point) (RFC-0002 FR-36; T-15) (severity:medium) — size: S ·

--- a/docs/adr/0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md
+++ b/docs/adr/0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md
@@ -1,0 +1,105 @@
+# ADR-0039: SQL text and its parameters become one value, not two arguments
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 10.1 (opens Milestone 10) · spec r3 FR-33 (RFC-0002) ·
+  [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) §"Decision" (P-1) ·
+  [ADR-0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) (real prepares, the
+  mechanism this decision sits on top of) ·
+  [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) (the sibling
+  decision for identifiers, which cannot be bound at all) ·
+  [ADR-0017](0017-prove-binding-at-the-pdo-boundary-and-defer-t02s-like-leg.md) (the
+  query-log proof this decision does not change) · roadmap items 10.2–10.4 (`Persistence`,
+  which this decision exists for)
+
+## Context
+
+RFC-0002's survey found 199 sites in a legacy application's query-factory classes where a
+value was string-interpolated into SQL text before the statement was ever prepared, against
+zero sites where a value was bound as a parameter. `DatabaseConnection::execute(string $sql,
+array $parameters = [])` — this library's own shape until this item — does not structurally
+prevent the same mistake. Its type signature accepts `execute("... {$value} ...")` with an
+empty `$parameters` exactly as happily as it accepts a correctly bound call; nothing in a
+`(string, array)` pair says the two must have been assembled together, only that they
+happen to have been passed to the same call. Values already travel to the driver as real
+bound parameters here (ADR-0014's `ATTR_EMULATE_PREPARES=false`), so the wire-level safety
+this decision changes is exactly zero — every existing caller was already safe. What is not
+zero is the surface a future caller, or a reviewer checking one, has to get right: today
+that surface is every call site in the codebase; roadmap items 10.2–10.4 are about to add
+`Persistence\Repository` and `Persistence\TableGateway`, whose whole purpose is to accept
+**hand-written SQL from callers less careful than this library's own tests** — the estate's
+own pattern, generalized. A `(string, array)` signature offers those callers no more
+protection than it offered the estate's authors.
+
+## Decision
+
+Introduce `D4np\Utils\Database\SqlStatement` — an immutable value pairing SQL text with the
+parameters bound to it (`public readonly string $sql`, `public readonly array $parameters`)
+— and make it the **only** shape `DatabaseConnection::select()`, `selectOne()` and
+`execute()` accept. Each method drops its `(string $sql, array $parameters = [])` pair in
+favor of a single `SqlStatement $statement` parameter. `QueryBuilder::get()`/`first()` build
+one internally from `toSql()`/`bindings()`; every other caller, present (tests) and future
+(`Persistence\Repository`, item 10.3), must construct or receive a `SqlStatement` to reach
+the database at all.
+
+This is a breaking change to `DatabaseConnection`'s public signature, made in a **pre-1.0
+MINOR** (`v0.8.0 → v0.9.0`), which SemVer 2.0.0 §4 permits and this project's own BC policy
+(ADR-0031, `tools/bc_gate.py`) treats as a bump-legal break rather than a violation.
+
+## Alternatives Considered
+
+- **Add a `SqlStatement`-accepting method alongside the existing `(string, array)` ones** —
+  rejected: it does not close anything. A caller can still reach the old shape, which is
+  exactly the shape that let the estate's mistake happen 199 times; "only" in the roadmap
+  item's own wording means the old shape stops existing, not that a safer one is offered
+  next to it.
+- **Enforce statement-only execution starting at `Persistence\Repository` (item 10.3),
+  leaving `DatabaseConnection` unchanged** — rejected: `DatabaseConnection` is public, and a
+  consumer who reaches past `Repository` straight to the connection (which RFC-0001 always
+  allowed — it is a thin PDO wrapper, not a sealed internal) would still have the
+  two-argument door open. The choke point has to be the actual boundary to the driver, not
+  a layer above it that can be routed around.
+- **A runtime assertion that `$parameters` is non-empty whenever `$sql` contains a `?` or a
+  named placeholder** — rejected: it cannot distinguish a legitimately parameter-free
+  statement (`CREATE TABLE`, a `SELECT` with no `WHERE`) from a forgotten bind, so it would
+  either reject valid calls or miss the case that matters (a placeholder-free string built
+  by concatenating an already-interpolated value contains no `?` for the assertion to see).
+  A type-level guarantee catches what a string never announces; a runtime heuristic cannot.
+- **Name the value type `Query` or `Statement`** — rejected for `SqlStatement`: `QueryBuilder`
+  already uses "query" for the fluent builder itself, and a bare `Statement` collides in
+  spirit with `PDOStatement`, which this class is deliberately not — it holds no connection,
+  no result cursor, and cannot be executed by itself.
+
+## Consequences
+
+- **API / compatibility:** `DatabaseConnection::select()`, `selectOne()` and `execute()`
+  change signature; every in-repo call site is migrated in this same PR
+  (`QueryBuilder`, `DatabaseConnectionTest`, `InjectionTest`, `QueryBuilderTest`,
+  `TransactionTest`, `SanitizerTest`, and `Transaction`'s docblock example). No behavior
+  changes for any of them — same PDO calls, same bound values, same exceptions.
+- **Nothing at the wire level changes.** ADR-0014's real prepares already bound every value
+  through both shapes; this decision moves where a reviewer has to look, not what the driver
+  receives. Recorded explicitly so this ADR is not mistaken for closing a live
+  vulnerability — none existed in this library's own code before it.
+- **Testing:** `SqlStatementTest` is new and minimal — the class has no behavior beyond
+  pairing two readonly values, so there is nothing more to assert. The existing T-02
+  suites (`InjectionTest`, `QueryBuilderTest`'s identifier cases, `SanitizerTest`) are
+  unchanged in what they prove, only in how they call it.
+- **Deptrac:** no new layer edge. `SqlStatement` lives in `Database`, alongside
+  `QueryBuilder` and `DatabaseConnection`; `Persistence` (item 10.2) will depend on it as
+  part of the two edges that item's own ADR names.
+- **Forward-looking:** `Persistence\Repository` and `TableGateway` (items 10.3–10.4) now
+  have exactly one type to accept from a caller with hand-written SQL, and exactly one
+  place — this class's constructor call — where text and parameters are still two separate
+  variables that could be paired incorrectly.
+
+## References
+
+- RFC-0002, Context ("199 interpolation sites... against 0 bound parameters") and Decision
+  §"Persistence" (FR-33's rationale, verbatim: *"the defect was that its values traveled
+  interpolated"*)
+- ADR-0014 (real prepares — the mechanism this decision's choke point sits on top of, and
+  which already made every migrated call site safe at the wire before this ADR)
+- ADR-0017 (the query-log proof at the PDO boundary — unaffected; it observes what reaches
+  `PDOStatement::execute()`, which this change does not alter)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,3 +54,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0036](0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md) | Refuse the scheme downgrade, and refuse the characters `parse_url()` launders | Accepted |
 | [0037](0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md) | Disable PHP's CSV escape character, and keep the formula guard opt-in | Accepted |
 | [0038](0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md) | One lock across the read and the write, and a sequence that refuses to wrap | Accepted |
+| [0039](0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md) | SQL text and its parameters become one value, not two arguments | Accepted |

--- a/docs/journal/2026/08/2026-08-06-sql-statement.md
+++ b/docs/journal/2026/08/2026-08-06-sql-statement.md
@@ -1,0 +1,53 @@
+# 2026-08-06 — What one value type actually closes
+
+Roadmap item **10.1**, opening Milestone 10. Route `frontier-reasoning / extra` — matched,
+no mismatch. The item's own wording carries a security tag and a mandated ADR, so the first
+question worth answering honestly is what, exactly, changing a method signature secures.
+
+## The number that motivated it does not describe this codebase
+
+RFC-0002's Context cites the survey finding this milestone exists to answer: 199
+SQL-interpolation sites in a legacy query-factory, against 0 sites where a value was bound.
+`DatabaseConnection::execute(string $sql, array $parameters = [])` — this library's own
+shape until today — was never that vulnerable. Every value already travels to the driver as
+a real bound parameter (ADR-0014's `ATTR_EMULATE_PREPARES=false`), so nothing about the
+`(string, array)` signature let a value slip through unbound. Checking that before writing
+anything mattered: an ADR that opened by claiming to fix an injection hole that does not
+exist would be the wrong kind of overstatement — the "count first, then propose" lesson
+from RFC-0002's own drafting, applied to code this time instead of a proposal.
+
+What the old signature *does* fail to do is stop the mistake **structurally**. Nothing in
+`execute(string $sql, array $parameters = [])` distinguishes "I forgot to bind" from "there
+is nothing to bind" — both produce the exact same call shape, an empty or short
+`$parameters` array. Every one of the estate's 199 sites would have type-checked against
+this signature too. That is the real target: not this library's existing call sites (all
+already safe), but `Persistence\Repository` and `TableGateway`, two items away (10.3–10.4),
+whose entire purpose is to accept hand-written SQL from callers who will not all be as
+careful as this suite's tests.
+
+## The decision, and its honest cost
+
+`SqlStatement` — one readonly value, `sql` plus `parameters` — becomes the **only** thing
+`DatabaseConnection`'s three query methods accept. Not an additional convenience alongside
+the old shape: the roadmap item's own wording, "accepts only statements," was read
+literally, because a second door next to a bad one does not close it. That reading forced a
+larger diff than the value type alone would suggest — every call site in
+`QueryBuilder`, `DatabaseConnectionTest`, `InjectionTest`, `QueryBuilderTest`,
+`TransactionTest`, `SanitizerTest`, and one docblock example in `Transaction`, all migrated
+in this PR. Pre-1.0 permits the break (SemVer §4, `tools/bc_gate.py`); permits is not the
+same as free, and the migration is the size this item actually is under "size: S."
+
+## What the ADR says plainly, because it would be easy to imply otherwise
+
+ADR-0039 states, in its own Consequences section, that nothing changes at the wire level:
+every migrated call was already binding correctly. The value this decision buys is where a
+future reviewer has to look — one type's constructor, instead of every call site that could
+have assembled two separate arguments wrong. That is a real, if narrower, security property
+(a choke point is easier to audit than a convention), and naming it precisely is worth more
+than letting the item's own "security — protected floor" tag imply a vulnerability that
+was never there.
+
+## Lesson
+
+A security ADR is allowed to say "this closes a mistake nothing here has made yet" — that
+is what "protected floor" means for the next three items, not a confession about this one.

--- a/docs/specs/01_spec_utils.md
+++ b/docs/specs/01_spec_utils.md
@@ -3,7 +3,7 @@
 > Rendered from the intake interview (Phase 5). Frozen contract: diverging implementation
 > updates this spec in the same PR or adds an ADR superseding the relevant section.
 
-**Revision r6** — 2026-08-06. See [Revision history](#revision-history).
+**Revision r7** — 2026-08-06. See [Revision history](#revision-history).
 
 ## 1. Objective & Business Context
 
@@ -125,7 +125,7 @@ Consumers import via `use D4np\Utils\Dto\DataTransferObject;`. The public surfac
 
 - D4np\Utils\Dto\ — DataTransferObject::fromArray()/lenient(), WithersTrait::with(), Collection<T>
 - D4np\Utils\Container\ — PSR-11 Container (get/has, autowire, singleton/factory), ServiceProvider
-- D4np\Utils\Database\ — DatabaseConnection (pinned PDO defaults), QueryBuilder (fluent, Sort enum), Transaction::run(closure)
+- D4np\Utils\Database\ — DatabaseConnection (pinned PDO defaults; `select`/`selectOne`/`execute` take a `SqlStatement`, r7 ADR-0039), QueryBuilder (fluent, Sort enum), Transaction::run(closure)
 - D4np\Utils\Security\ — Escaper::html/attr/js/url, Sanitizer::richText/sqlLikePattern, Hash::make/verify/needsRehash
 - D4np\Utils\Http\ — Request (typed superglobal reader), Response, Session::regenerate(), CsrfToken; PSR-7 via optional egl/utils-psr7-bridge
 - D4np\Utils\Errors\ — Result::map/flatMap/orElseThrow, PSR-3 Logger, ExceptionHandler
@@ -135,7 +135,7 @@ r3 (RFC-0002) additions:
 
 - D4np\Utils\Persistence\ — Repository (fetchAll/fetchOne/execute/withTransaction), TableGateway (select/insert/update/delete), RowNormalizer
 - D4np\Utils\Mail\ — EmailAddress, MailMessage, Mailer, NativeMailer
-- D4np\Utils\Database\ — + SqlStatement · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, SequenceExhaustedException, File::writeStream(), File::update(), Str additions (FR-31)
+- D4np\Utils\Database\ — + SqlStatement (r7: the only shape `DatabaseConnection`'s query methods accept, ADR-0039) · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, SequenceExhaustedException, File::writeStream(), File::update(), Str additions (FR-31)
 
 
 ## 6. Verification & Test Strategy
@@ -162,6 +162,7 @@ non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.y
 |-----|------|--------|
 | r1 | 2026-08-03 | Frozen from the imported `.specs/d4np-php.md` v2.0 via RFC-0001 (naming mapping A-7). |
 | r2 | 2026-08-05 | §6/T-03: the `hash_equals` **timing test** is replaced by a **mechanism assertion**. Rationale below; see [ADR-0027](../adr/0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md). |
+| r7 | 2026-08-06 | §2/§5: FR-33 realized as the only shape `DatabaseConnection::select()`/`selectOne()`/`execute()` accept — the `(string, array)` pair is retired in favor of one `SqlStatement` argument (item 10.1, opens Milestone 10). A pre-1.0 breaking change to the `Database` group's public signature, permitted and migrated in the same PR. See [ADR-0039](../adr/0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md). |
 | r6 | 2026-08-06 | §2/§6: FR-32 stated to the precision item 9.5 implemented (one lock across the read-modify-write, corrupt state refused rather than reset, the caller-supplied window and its recorded ordering limit); FR-22/23 gains `File::update()`, without which a safe counter cannot be built from this library's primitives; §6 gains suite **T-14** (multi-process concurrency: each number issued exactly once, cap holds). Additive; see [ADR-0038](../adr/0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md). |
 | r5 | 2026-08-06 | §2: FR-28/FR-29 stated to the precision item 9.4 implemented (PHP's backslash escape disabled, the single-empty-field and zero-column shapes, blank-line handling, the enforced header/row pairing, the guard's leader set); FR-22/23 gains `File::writeStream()`, without which a streaming CSV could not honour NFR-12; `CsvException` added to the exception enumeration. Additive; see [ADR-0037](../adr/0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md). |
 | r4 | 2026-08-06 | §2: FR-27 stated to the precision item 9.3 implemented (control-character refusal, absolute-only, the named downgrade pairs and their recorded limit, query preservation), and `InvalidUrlException` added to the r3 exception enumeration, which had not anticipated it. Additive; see [ADR-0036](../adr/0036-refuse-the-downgrade-and-the-characters-parse-url-launders.md). |

--- a/src/main/php/d4np/utils/Database/DatabaseConnection.php
+++ b/src/main/php/d4np/utils/Database/DatabaseConnection.php
@@ -48,6 +48,12 @@ use PDOStatement;
  * accepts an interpolated value, because the one that did would be the one that got used.
  * Identifiers are a different problem — they cannot be bound — and belong to `QueryBuilder`
  * (roadmap 4.2), which allowlists them.
+ *
+ * **Every query method takes a {@see SqlStatement}, not a bare `(string, array)` pair**
+ * (roadmap 10.1, ADR-0039). SQL text and its parameters are one value here, not two
+ * variables a caller could assemble incorrectly — the estate's 199 interpolation sites were
+ * exactly that assembly going wrong, 199 times, because nothing forced the two to travel
+ * together.
  */
 final class DatabaseConnection
 {
@@ -85,16 +91,14 @@ final class DatabaseConnection
     /**
      * Every row of a query, as associative arrays.
      *
-     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
-     *
      * @return list<array<string, mixed>>
      *
      * @throws DatabaseException
      */
-    public function select(string $sql, array $parameters = []): array
+    public function select(SqlStatement $statement): array
     {
         /** @var list<array<string, mixed>> */
-        return $this->run($sql, $parameters)->fetchAll(PDO::FETCH_ASSOC);
+        return $this->run($statement)->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**
@@ -103,15 +107,13 @@ final class DatabaseConnection
      * `null` rather than PDO's `false`, so the empty case is expressible in the type system and a
      * caller cannot confuse "no row" with "a row whose first column was falsy".
      *
-     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
-     *
      * @return array<string, mixed>|null
      *
      * @throws DatabaseException
      */
-    public function selectOne(string $sql, array $parameters = []): ?array
+    public function selectOne(SqlStatement $statement): ?array
     {
-        $row = $this->run($sql, $parameters)->fetch(PDO::FETCH_ASSOC);
+        $row = $this->run($statement)->fetch(PDO::FETCH_ASSOC);
 
         /** @var array<string, mixed>|false $row */
         return $row === false ? null : $row;
@@ -120,29 +122,25 @@ final class DatabaseConnection
     /**
      * Run a statement that changes rows, and return how many it affected.
      *
-     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
-     *
      * @throws DatabaseException
      */
-    public function execute(string $sql, array $parameters = []): int
+    public function execute(SqlStatement $statement): int
     {
-        return $this->run($sql, $parameters)->rowCount();
+        return $this->run($statement)->rowCount();
     }
 
     /**
      * Prepare and execute, converting PDO's failure into this library's own (ADR-0004).
      *
-     * @param array<string|int, mixed> $parameters
-     *
      * @throws DatabaseException
      */
-    private function run(string $sql, array $parameters): PDOStatement
+    private function run(SqlStatement $statement): PDOStatement
     {
         try {
-            $statement = $this->pdo->prepare($sql);
-            $statement->execute($parameters === [] ? null : $parameters);
+            $prepared = $this->pdo->prepare($statement->sql);
+            $prepared->execute($statement->parameters === [] ? null : $statement->parameters);
 
-            return $statement;
+            return $prepared;
         } catch (PDOException $e) {
             // The SQL is deliberately not in the message. It is frequently logged, and a failing
             // statement's text is the most likely place for data a consumer would rather not see

--- a/src/main/php/d4np/utils/Database/QueryBuilder.php
+++ b/src/main/php/d4np/utils/Database/QueryBuilder.php
@@ -340,7 +340,7 @@ final class QueryBuilder
      */
     public function get(): array
     {
-        return $this->connection->select($this->toSql(), $this->bindings);
+        return $this->connection->select(new SqlStatement($this->toSql(), $this->bindings));
     }
 
     /**
@@ -352,7 +352,7 @@ final class QueryBuilder
      */
     public function first(): ?array
     {
-        return $this->connection->selectOne($this->toSql(), $this->bindings);
+        return $this->connection->selectOne(new SqlStatement($this->toSql(), $this->bindings));
     }
 
     /**

--- a/src/main/php/d4np/utils/Database/SqlStatement.php
+++ b/src/main/php/d4np/utils/Database/SqlStatement.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Database;
+
+/**
+ * An immutable pairing of SQL text and the parameters bound to it (spec r3 FR-33, RFC-0002;
+ * ADR-0039).
+ *
+ * **The narrow waist, not a new safety mechanism.** The surveyed estate's query-factory
+ * classes never had a type that forced text and parameters to travel together: a method
+ * signature of `execute(string $sql, array $params = [])` does not stop a caller from
+ * writing `execute("... {$value} ...")` and leaving `$params` empty — nothing in that shape
+ * distinguishes "I forgot to bind" from "there is nothing to bind". That is exactly the
+ * estate's failure mode (199 interpolation sites, 0 bound parameters), and no amount of
+ * discipline at each of 199 call sites prevented it.
+ *
+ * `SqlStatement` does not make binding safer at the byte level — `DatabaseConnection`
+ * already only ever executes through real prepares (ADR-0014), so a value bound through
+ * either shape was equally safe on the wire. What it changes is where a reviewer has to
+ * look: after this class exists, {@see DatabaseConnection}'s query methods accept **only**
+ * a `SqlStatement`, so there is exactly one place in this codebase where SQL text and
+ * parameters are still two separate variables that could be assembled wrongly —
+ * {@see QueryBuilder::toSql()}/{@see QueryBuilder::bindings()} and this class's own
+ * constructor call. Every other caller, present and future ({@see \D4np\Utils\Persistence}'s
+ * upcoming `Repository`, roadmap 10.3), receives or builds a `SqlStatement` and cannot
+ * un-pair it.
+ */
+final class SqlStatement
+{
+    /**
+     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
+     */
+    public function __construct(
+        public readonly string $sql,
+        public readonly array $parameters = [],
+    ) {
+    }
+}

--- a/src/main/php/d4np/utils/Database/Transaction.php
+++ b/src/main/php/d4np/utils/Database/Transaction.php
@@ -20,8 +20,8 @@ use Throwable;
  *
  * ```php
  * $total = (new Transaction($connection))->run(function (DatabaseConnection $db): int {
- *     $db->execute('UPDATE accounts SET balance = balance - ? WHERE id = ?', [100, 1]);
- *     $db->execute('UPDATE accounts SET balance = balance + ? WHERE id = ?', [100, 2]);
+ *     $db->execute(new SqlStatement('UPDATE accounts SET balance = balance - ? WHERE id = ?', [100, 1]));
+ *     $db->execute(new SqlStatement('UPDATE accounts SET balance = balance + ? WHERE id = ?', [100, 2]));
  *
  *     return 2;
  * });

--- a/src/test/php/d4np/utils/Database/DatabaseConnectionTest.php
+++ b/src/test/php/d4np/utils/Database/DatabaseConnectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace D4np\Utils\Tests\Database;
 
 use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\SqlStatement;
 use D4np\Utils\Support\DatabaseException;
 use D4np\Utils\Tests\Database\Fixture\PretendDriverPdo;
 use D4np\Utils\Tests\Database\Fixture\StubbornlyEmulatingPdo;
@@ -31,7 +32,7 @@ final class DatabaseConnectionTest extends TestCase
     private function connect(): DatabaseConnection
     {
         $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
-        $connection->execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)');
+        $connection->execute(new SqlStatement('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)'));
 
         return $connection;
     }
@@ -66,9 +67,9 @@ final class DatabaseConnectionTest extends TestCase
     public function testSelectReturnsAssociativeArraysOnly(): void
     {
         $connection = $this->connect();
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]);
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
 
-        $rows = $connection->select('SELECT name, age FROM users');
+        $rows = $connection->select(new SqlStatement('SELECT name, age FROM users'));
 
         // FETCH_BOTH would additionally carry 0 and 1; asserting the exact key set is the point.
         self::assertSame([['name' => 'Grace', 'age' => 45]], $rows);
@@ -81,7 +82,7 @@ final class DatabaseConnectionTest extends TestCase
     public function testThePinnedFetchModeAppliesToStatementsRunOnTheRawPdo(): void
     {
         $connection = $this->connect();
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]);
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
 
         // No fetch mode passed anywhere here: whatever comes back is the pinned default's doing.
         $statement = $connection->pdo()->query('SELECT name, age FROM users');
@@ -146,33 +147,33 @@ final class DatabaseConnectionTest extends TestCase
 
     public function testSelectOneReturnsNullRatherThanFalseWhenThereIsNoRow(): void
     {
-        self::assertNull($this->connect()->selectOne('SELECT * FROM users WHERE id = ?', [404]));
+        self::assertNull($this->connect()->selectOne(new SqlStatement('SELECT * FROM users WHERE id = ?', [404])));
     }
 
     public function testSelectOneReturnsTheFirstRow(): void
     {
         $connection = $this->connect();
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]);
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]);
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
 
-        self::assertSame(['id' => 1, 'name' => 'Ada', 'age' => 36], $connection->selectOne('SELECT * FROM users ORDER BY id'));
+        self::assertSame(['id' => 1, 'name' => 'Ada', 'age' => 36], $connection->selectOne(new SqlStatement('SELECT * FROM users ORDER BY id')));
     }
 
     public function testExecuteReportsAffectedRows(): void
     {
         $connection = $this->connect();
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]);
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]);
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
 
-        self::assertSame(2, $connection->execute('UPDATE users SET age = age + 1'));
+        self::assertSame(2, $connection->execute(new SqlStatement('UPDATE users SET age = age + 1')));
     }
 
     public function testNamedParametersBind(): void
     {
         $connection = $this->connect();
-        $connection->execute('INSERT INTO users (name, age) VALUES (:name, :age)', ['name' => 'Ada', 'age' => 36]);
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (:name, :age)', ['name' => 'Ada', 'age' => 36]));
 
-        self::assertSame([['name' => 'Ada']], $connection->select('SELECT name FROM users WHERE age = :age', ['age' => 36]));
+        self::assertSame([['name' => 'Ada']], $connection->select(new SqlStatement('SELECT name FROM users WHERE age = :age', ['age' => 36])));
     }
 
     /**
@@ -187,23 +188,23 @@ final class DatabaseConnectionTest extends TestCase
         $connection = $this->connect();
         $payload = "Robert'); DROP TABLE users;--";
 
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]);
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]));
 
-        self::assertSame($payload, $connection->selectOne('SELECT name FROM users')['name'] ?? null);
-        self::assertSame([['n' => 1]], $connection->select('SELECT COUNT(*) AS n FROM users'));
+        self::assertSame($payload, $connection->selectOne(new SqlStatement('SELECT name FROM users'))['name'] ?? null);
+        self::assertSame([['n' => 1]], $connection->select(new SqlStatement('SELECT COUNT(*) AS n FROM users')));
     }
 
     public function testAFailingStatementRaisesTheLibraryException(): void
     {
         $this->expectException(DatabaseException::class);
 
-        $this->connect()->select('SELECT * FROM a_table_that_does_not_exist');
+        $this->connect()->select(new SqlStatement('SELECT * FROM a_table_that_does_not_exist'));
     }
 
     public function testTheFailureCarriesThePdoExceptionAsItsCause(): void
     {
         try {
-            $this->connect()->select('THIS IS NOT SQL');
+            $this->connect()->select(new SqlStatement('THIS IS NOT SQL'));
             self::fail('expected a DatabaseException');
         } catch (DatabaseException $e) {
             self::assertInstanceOf(\PDOException::class, $e->getPrevious());
@@ -216,7 +217,7 @@ final class DatabaseConnectionTest extends TestCase
     public function testTheFailureMessageDoesNotEchoTheStatement(): void
     {
         try {
-            $this->connect()->select('SELECT * FROM missing_table WHERE secret = 1');
+            $this->connect()->select(new SqlStatement('SELECT * FROM missing_table WHERE secret = 1'));
             self::fail('expected a DatabaseException');
         } catch (DatabaseException $e) {
             self::assertStringNotContainsString('secret', $e->getMessage());

--- a/src/test/php/d4np/utils/Database/InjectionTest.php
+++ b/src/test/php/d4np/utils/Database/InjectionTest.php
@@ -8,6 +8,7 @@ use D4np\Utils\Database\DatabaseConnection;
 use D4np\Utils\Database\Operator;
 use D4np\Utils\Database\QueryBuilder;
 use D4np\Utils\Database\Sort;
+use D4np\Utils\Database\SqlStatement;
 use D4np\Utils\Database\Transaction;
 use D4np\Utils\Security\Sanitizer;
 use D4np\Utils\Tests\Database\Fixture\LoggedStatement;
@@ -55,9 +56,9 @@ final class InjectionTest extends TestCase
         $pdo->setAttribute(PDO::ATTR_STATEMENT_CLASS, [LoggedStatement::class, [$this->log]]);
 
         $this->connection = new DatabaseConnection($pdo);
-        $this->connection->execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
-        $this->connection->execute('CREATE TABLE secrets (token TEXT)');
-        $this->connection->execute("INSERT INTO secrets (token) VALUES ('do-not-leak')");
+        $this->connection->execute(new SqlStatement('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)'));
+        $this->connection->execute(new SqlStatement('CREATE TABLE secrets (token TEXT)'));
+        $this->connection->execute(new SqlStatement("INSERT INTO secrets (token) VALUES ('do-not-leak')"));
 
         // Only the payload traffic matters; drop the fixture's own setup from the log.
         $this->log->entries = [];
@@ -137,7 +138,7 @@ final class InjectionTest extends TestCase
     #[DataProvider('payloads')]
     public function testConnectionExecuteBindsRatherThanInterpolates(string $payload): void
     {
-        $this->connection->execute('INSERT INTO users (name) VALUES (?)', [$payload]);
+        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', [$payload]));
 
         $this->assertNeverInStatementText($payload);
     }
@@ -145,7 +146,7 @@ final class InjectionTest extends TestCase
     #[DataProvider('payloads')]
     public function testConnectionSelectBindsRatherThanInterpolates(string $payload): void
     {
-        $this->connection->select('SELECT * FROM users WHERE name = ?', [$payload]);
+        $this->connection->select(new SqlStatement('SELECT * FROM users WHERE name = ?', [$payload]));
 
         $this->assertNeverInStatementText($payload);
     }
@@ -153,7 +154,7 @@ final class InjectionTest extends TestCase
     #[DataProvider('payloads')]
     public function testConnectionSelectOneBindsRatherThanInterpolates(string $payload): void
     {
-        $this->connection->selectOne('SELECT * FROM users WHERE name = :name', ['name' => $payload]);
+        $this->connection->selectOne(new SqlStatement('SELECT * FROM users WHERE name = :name', ['name' => $payload]));
 
         $this->assertNeverInStatementText($payload);
     }
@@ -184,7 +185,7 @@ final class InjectionTest extends TestCase
     public function testBindingHoldsInsideATransaction(string $payload): void
     {
         (new Transaction($this->connection))->run(function () use ($payload): void {
-            $this->connection->execute('INSERT INTO users (name) VALUES (?)', [$payload]);
+            $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', [$payload]));
         });
 
         $this->assertNeverInStatementText($payload);
@@ -198,14 +199,14 @@ final class InjectionTest extends TestCase
     #[DataProvider('payloads')]
     public function testThePayloadRoundTripsAndTheSchemaSurvives(string $payload): void
     {
-        $this->connection->execute('INSERT INTO users (name) VALUES (?)', [$payload]);
+        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', [$payload]));
 
-        $row = $this->connection->selectOne('SELECT name FROM users WHERE name = ?', [$payload]);
+        $row = $this->connection->selectOne(new SqlStatement('SELECT name FROM users WHERE name = ?', [$payload]));
 
         self::assertSame($payload, $row['name'] ?? null);
-        self::assertSame([['n' => 1]], $this->connection->select('SELECT COUNT(*) AS n FROM users'));
+        self::assertSame([['n' => 1]], $this->connection->select(new SqlStatement('SELECT COUNT(*) AS n FROM users')));
         // Exfiltration and destruction both leave traces here.
-        self::assertSame([['n' => 1]], $this->connection->select('SELECT COUNT(*) AS n FROM secrets'));
+        self::assertSame([['n' => 1]], $this->connection->select(new SqlStatement('SELECT COUNT(*) AS n FROM secrets')));
     }
 
     /**
@@ -216,8 +217,8 @@ final class InjectionTest extends TestCase
      */
     public function testATautologyMatchesNothingBecauseItIsAValue(): void
     {
-        $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['Ada']);
-        $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['Grace']);
+        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', ['Ada']));
+        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', ['Grace']));
 
         $rows = (new QueryBuilder($this->connection, 'users'))
             ->where('name', Operator::Equals, "' OR '1'='1")
@@ -240,8 +241,8 @@ final class InjectionTest extends TestCase
      */
     public function testLikeWildcardsAreNeutralisedWhileTheValueStillBinds(): void
     {
-        $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['secret-document']);
-        $this->connection->execute('INSERT INTO users (name) VALUES (?)', ['public-note']);
+        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', ['secret-document']));
+        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', ['public-note']));
 
         // Unescaped, a lone '%' still matches everything — it is legitimate pattern syntax, and
         // neutralising it unconditionally would break every prefix search in the library.

--- a/src/test/php/d4np/utils/Database/QueryBuilderTest.php
+++ b/src/test/php/d4np/utils/Database/QueryBuilderTest.php
@@ -8,6 +8,7 @@ use D4np\Utils\Database\DatabaseConnection;
 use D4np\Utils\Database\Operator;
 use D4np\Utils\Database\QueryBuilder;
 use D4np\Utils\Database\Sort;
+use D4np\Utils\Database\SqlStatement;
 use D4np\Utils\Support\DatabaseException;
 use D4np\Utils\Tests\Database\Fixture\DriverLookupCountingPdo;
 use D4np\Utils\Tests\Database\Fixture\LoggedStatement;
@@ -34,7 +35,7 @@ final class QueryBuilderTest extends TestCase
     private function connection(): DatabaseConnection
     {
         $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
-        $connection->execute('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)');
+        $connection->execute(new SqlStatement('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)'));
 
         return $connection;
     }
@@ -297,9 +298,9 @@ final class QueryBuilderTest extends TestCase
     public function testEndToEndAgainstARealDriver(): void
     {
         $connection = $this->connection();
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]);
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]);
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]);
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
 
         $rows = (new QueryBuilder($connection, 'users'))
             ->select('name')
@@ -323,11 +324,11 @@ final class QueryBuilderTest extends TestCase
     {
         $connection = $this->connection();
         $payload = "'; DROP TABLE users; --";
-        $connection->execute('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]);
+        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]));
 
         $row = (new QueryBuilder($connection, 'users'))->where('name', Operator::Equals, $payload)->first();
 
         self::assertSame($payload, $row['name'] ?? null);
-        self::assertSame([['n' => 1]], $connection->select('SELECT COUNT(*) AS n FROM users'));
+        self::assertSame([['n' => 1]], $connection->select(new SqlStatement('SELECT COUNT(*) AS n FROM users')));
     }
 }

--- a/src/test/php/d4np/utils/Database/SqlStatementTest.php
+++ b/src/test/php/d4np/utils/Database/SqlStatementTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database;
+
+use D4np\Utils\Database\SqlStatement;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `SqlStatement` — spec r3 FR-33 (RFC-0002), ADR-0039.
+ *
+ * The class has no behaviour beyond pairing two readonly values, so what is worth asserting is
+ * exactly that pairing: both fields are readable back unchanged, and a statement with nothing to
+ * bind does not require a caller to say so.
+ */
+final class SqlStatementTest extends TestCase
+{
+    public function testSqlAndParametersAreReadableBack(): void
+    {
+        $statement = new SqlStatement('SELECT * FROM users WHERE id = ?', [42]);
+
+        self::assertSame('SELECT * FROM users WHERE id = ?', $statement->sql);
+        self::assertSame([42], $statement->parameters);
+    }
+
+    public function testParametersDefaultToEmpty(): void
+    {
+        $statement = new SqlStatement('SELECT 1');
+
+        self::assertSame([], $statement->parameters);
+    }
+
+    public function testNamedParametersAreKeptByName(): void
+    {
+        $statement = new SqlStatement('SELECT * FROM users WHERE age = :age', ['age' => 36]);
+
+        self::assertSame(['age' => 36], $statement->parameters);
+    }
+}

--- a/src/test/php/d4np/utils/Database/TransactionTest.php
+++ b/src/test/php/d4np/utils/Database/TransactionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace D4np\Utils\Tests\Database;
 
 use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\SqlStatement;
 use D4np\Utils\Database\Transaction;
 use D4np\Utils\Support\DatabaseException;
 use LogicException;
@@ -32,7 +33,7 @@ final class TransactionTest extends TestCase
     protected function setUp(): void
     {
         $this->connection = new DatabaseConnection(new PDO('sqlite::memory:'));
-        $this->connection->execute('CREATE TABLE t (v TEXT)');
+        $this->connection->execute(new SqlStatement('CREATE TABLE t (v TEXT)'));
     }
 
     private function transaction(): Transaction
@@ -51,13 +52,13 @@ final class TransactionTest extends TestCase
 
                 return $row['v'];
             },
-            $this->connection->select('SELECT v FROM t ORDER BY rowid'),
+            $this->connection->select(new SqlStatement('SELECT v FROM t ORDER BY rowid')),
         );
     }
 
     private function insert(string $value): void
     {
-        $this->connection->execute('INSERT INTO t (v) VALUES (?)', [$value]);
+        $this->connection->execute(new SqlStatement('INSERT INTO t (v) VALUES (?)', [$value]));
     }
 
     public function testWorkIsCommittedWhenTheClosureReturns(): void
@@ -297,7 +298,7 @@ final class TransactionTest extends TestCase
             }
         };
         $connection = new DatabaseConnection($pdo);
-        $connection->execute('CREATE TABLE t (v TEXT)');
+        $connection->execute(new SqlStatement('CREATE TABLE t (v TEXT)'));
 
         $original = new LogicException('the reason the caller needs');
         $caught = null;

--- a/src/test/php/d4np/utils/Security/SanitizerTest.php
+++ b/src/test/php/d4np/utils/Security/SanitizerTest.php
@@ -7,6 +7,7 @@ namespace D4np\Utils\Tests\Security;
 use D4np\Utils\Database\DatabaseConnection;
 use D4np\Utils\Database\Operator;
 use D4np\Utils\Database\QueryBuilder;
+use D4np\Utils\Database\SqlStatement;
 use D4np\Utils\Security\Sanitizer;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -62,9 +63,9 @@ final class SanitizerTest extends TestCase
     private function seeded(): DatabaseConnection
     {
         $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
-        $connection->execute('CREATE TABLE t (v TEXT)');
+        $connection->execute(new SqlStatement('CREATE TABLE t (v TEXT)'));
         foreach (['100%', '100X', '1000', 'a_b', 'axb', 'plain'] as $value) {
-            $connection->execute('INSERT INTO t (v) VALUES (?)', [$value]);
+            $connection->execute(new SqlStatement('INSERT INTO t (v) VALUES (?)', [$value]));
         }
 
         return $connection;


### PR DESCRIPTION
## Summary

Roadmap item **10.1**, opening **Milestone 10** (Persistence). Adds
`D4np\Utils\Database\SqlStatement` — an immutable value pairing SQL text with its bound
parameters — and makes it the **only** shape `DatabaseConnection::select()`, `selectOne()`
and `execute()` accept, retiring the `(string $sql, array $parameters = [])` pair.

## Motivation

RFC-0002's survey found 199 sites in a legacy query-factory where a value was
string-interpolated into SQL text, against 0 sites where one was bound. This library's own
`(string, array)` signature never had that vulnerability — every value already binds as a
real parameter under ADR-0014's real prepares — but it also never *prevented* the mistake
structurally: nothing in that shape distinguishes "forgot to bind" from "nothing to bind",
and every one of the estate's 199 sites would type-check against it too. The two items after
this one, `Persistence\Repository` and `TableGateway` (10.3–10.4), exist specifically to
accept hand-written SQL from callers less careful than this suite's own tests — the exact
shape the estate got wrong. `SqlStatement` gives them (and everyone else) exactly one type to
accept, and exactly one place — its own constructor call — where text and parameters are
still two separate variables that could be paired incorrectly.

**Stated plainly, because the item's own tags could otherwise imply more:** this PR closes
no live vulnerability. ADR-0039's Consequences section says so directly. The value is where a
future reviewer has to look, not a wire-level fix.

## Changes

- **`src/main/php/d4np/utils/Database/SqlStatement.php`** — new. `public readonly string
  $sql`, `public readonly array $parameters = []`.
- **`DatabaseConnection::select()/selectOne()/execute()`** — signature changes from
  `(string $sql, array $parameters = [])` to `(SqlStatement $statement)`. The private `run()`
  helper follows. No behavior change — same `prepare()`/`execute()` calls, same
  `DatabaseException` wrapping.
- **`QueryBuilder::get()/first()`** — build `new SqlStatement($this->toSql(), $this->bindings)`
  internally.
- **`Transaction`** — docblock example updated to the new call shape (no production code path
  there calls the connection's query methods).
- **Migrated in the same PR**: `DatabaseConnectionTest`, `InjectionTest`, `QueryBuilderTest`,
  `TransactionTest`, `SanitizerTest` — every direct call site, ~40 across the five files.
  Behavior of every test is unchanged; only the call shape is.
- **`SqlStatementTest`** — new, minimal: the class has no behavior beyond pairing two
  readonly values, so there is nothing more to assert (sql/parameters round-trip, default
  empty parameters, named parameters kept by name).
- **`docs/adr/0039-...md`** — the decision, its cost (a pre-1.0 breaking change, migrated
  here), and four rejected alternatives (a parallel method that doesn't close the door;
  enforcing this only at `Repository`, which a consumer can route around; a runtime
  non-empty-parameters heuristic, which cannot distinguish a legitimate parameter-free
  statement from a forgotten bind; naming collisions with `QueryBuilder`'s "query" and
  `PDOStatement`).
- **Spec → r7**: FR-33 realized to the letter it already stated ("the only shape connection-
  side execution accepts"); §5 Public Interface updated.
- **CHANGELOG**: `Added` (the new type) and `Changed` (the breaking signature, with the
  "nothing changes at the wire level" caveat repeated for anyone who only reads the
  changelog).
- **ROADMAP**: 10.1 checked, with the same "what this does and does not close" framing.

**No new deptrac edge.** `SqlStatement` stays in `Database`; `Persistence` (items 10.2–10.4)
will consume it as one of *its own* two named edges, decided in that item's own ADR.

## Design Patterns

- None newly catalogued. `SqlStatement` follows this codebase's existing readonly-value-object
  convention (`ParameterMetadata`, `ClassMetadata`) rather than adopting a named pattern —
  consistent with items 9.3/9.4/9.5 (`Url`, `Csv`, `FileSequence`), none of which added a
  patterns-catalogue entry either.

## Verification

- [x] `vendor/bin/phpunit` — 1604 tests (+3 from `SqlStatementTest`), 3445 assertions, 9
      pre-existing skips, all green
- [x] `vendor/bin/phpstan analyse` (max level) — no errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 of 191 files need changes
- [x] `vendor/bin/deptrac analyse` — 0 violations, 0 uncovered, 170 allowed (unchanged shape)
- [x] `python tools/consistency_lint.py` passes
- [ ] `tools/action_pin_lint.py` — N/A, no workflow files touched
- [x] Leak-gate grep over the staged diff: zero matches (hygiene check; no company-survey
      material touches this item)
- [ ] `tools/bc_gate.py` — N/A to this PR; it gates the release workflow against a tagged
      previous version, and no core release exists yet (item 8.3's own documented
      precondition)

## Documentation Impact

- [x] README.md — unchanged (no milestone-table change; M10 stays in progress)
- [x] ROADMAP.md — 10.1 checked
- [x] ADR added — **ADR-0039**
- [ ] docs/patterns/README.md — unchanged (see Design Patterns)
- [x] Spec updated — r7
- [x] CHANGELOG.md — `Added` + `Changed`
- [x] PR metadata set — assignee (owner), label `enhancement`, milestone `v0.9.0`

## Lesson

Lesson: a security ADR is allowed to say "this closes a mistake nothing here has made yet" —
stating that a decision fixes nothing live is not a weaker ADR, it is a more honest one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
