### PR TITLE
test(build): make NFR-07's mutation gate actually run, and file the 10.1 review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,12 +171,34 @@ jobs:
         run: composer install --no-interaction --prefer-dist
       - if: steps.cfg.outputs.present == 'true'
         run: vendor/bin/deptrac analyse
+  # ---------------------------------------------------------------------------
+  # Mutation score (roadmap 10.8, ADR-0040). Spec NFR-07 requires >= 70% MSI on the
+  # Security/Database/Dto namespaces, and until item 10.8 nothing measured it: `infection.json5`
+  # did not exist, so the config guard below reported `present=false` and this job passed in
+  # seconds having run nothing — item 2.7's coverage-gate shape, a second time.
+  #
+  # Two further defects in the original step surfaced only by running it:
+  #   - `vendor/bin/infection` never existed. Infection is NOT and cannot be a dependency of
+  #     this package: every release from 0.29.10 on requires PHP ^8.2/^8.3 against this
+  #     library's 8.1 floor, and the older 8.1-compatible releases conflict with versions this
+  #     project already locks (justinrainbow/json-schema, fidry/cpu-core-counter,
+  #     composer/xdebug-handler). Installed into a throwaway project instead, exactly as
+  #     ADR-0031 does for the BC checker, so the 8.1 matrix cell and `--prefer-lowest` stay
+  #     untouched.
+  #   - `--only-covered` is not an Infection option (verified against 0.34.1's own `run`
+  #     usage line). Uncovered code is excluded by default now; the inverse flag is
+  #     `--with-uncovered`. The original line would have failed on argument parsing.
+  #
+  # The interpreter is 8.3 with pcov, matching the coverage job: mutation testing measures
+  # test-suite strength, not runtime compatibility, so it does not need the 8.1 floor.
+  # ---------------------------------------------------------------------------
   mutation:
     # Same step-level guard as `layering`: hashFiles() cannot gate a job-level `if`.
     name: quality / infection mutation score
     runs-on: ubuntu-24.04
     needs: bootstrap
     if: needs.bootstrap.outputs.ready == 'true'
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check for infection.json5 (job self-enables when it lands)
@@ -187,8 +209,32 @@ jobs:
         with: { php-version: '8.3', coverage: pcov }
       - if: steps.cfg.outputs.present == 'true'
         run: composer install --no-interaction --prefer-dist
-      - if: steps.cfg.outputs.present == 'true'
-        run: vendor/bin/infection --min-msi=70 --only-covered
+      - name: Install Infection outside this package's dependency graph
+        if: steps.cfg.outputs.present == 'true'
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/mutation-tool"
+          # Constrained rather than floating, for ADR-0031's reason: a tool that changes its
+          # own findings between runs makes a quality gate unreviewable. `--no-plugins`
+          # because infection/extension-installer would otherwise need an allow-plugins
+          # prompt, and no Infection extensions are installed for it to register.
+          composer require --working-dir="$RUNNER_TEMP/mutation-tool" \
+            --no-interaction --no-plugins "infection/infection:^0.34"
+      - name: Mutation score against NFR-07's 70% floor
+        if: steps.cfg.outputs.present == 'true'
+        shell: bash
+        run: |
+          mkdir -p build/logs
+          php "$RUNNER_TEMP/mutation-tool/vendor/bin/infection" \
+            --min-msi=70 --no-progress --no-interaction -j2
+      - name: Keep the mutation report
+        if: steps.cfg.outputs.present == 'true' && always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: mutation-report
+          path: build/logs/infection*
+          if-no-files-found: warn
+          retention-days: 30
 
   # ---------------------------------------------------------------------------
   # Coverage floor (roadmap 2.7, ADR-0007). AGENTS.md §10 and spec NFR-07 both require >= 90%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
         run: |
           mkdir -p build/logs
           php "$RUNNER_TEMP/mutation-tool/vendor/bin/infection" \
-            --min-msi=95 --no-progress --no-interaction -j2
+            --min-msi=70 --no-progress --no-interaction -j2
       - name: Keep the mutation report
         if: steps.cfg.outputs.present == 'true' && always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
         run: |
           mkdir -p build/logs
           php "$RUNNER_TEMP/mutation-tool/vendor/bin/infection" \
-            --min-msi=70 --no-progress --no-interaction -j2
+            --min-msi=95 --no-progress --no-interaction -j2
       - name: Keep the mutation report
         if: steps.cfg.outputs.present == 'true' && always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 /.phpstan.cache/
 .php-cs-fixer.cache
 .deptrac.cache
+/.infection.cache/
 
 # IDE / editor
 /.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ## [Unreleased]
 
+### Fixed
+
+- **NFR-07's mutation gate now actually runs** (roadmap item **10.8**; **ADR-0040**).
+  `infection.json5` never existed, so the `mutation` CI job's self-enabling config guard
+  reported `present=false` and the job **passed in ~7 seconds having executed nothing** — the
+  spec's *"≥ 70% MSI on Security/Database/Dto"* had been unenforced since M1. This is item
+  2.7's coverage-gate shape a second time (there, pcov was installed and PHPUnit ran with no
+  `--coverage` flag), and it says something about the self-enabling-guard pattern: nothing
+  ever asked whether the file it waits for had arrived. Three further defects surfaced only by
+  running the step — Infection cannot be a dependency of this package at all (its PHP floor is
+  above this library's, and the older releases conflict with versions already locked), so it is
+  installed into a throwaway project per ADR-0031; `--only-covered` is not an Infection option,
+  so the step would have failed on argument parsing regardless; and Infection could not locate
+  PHPUnit across two vendor directories, so the path is now stated explicitly. **Measured: MSI
+  79%** (443 mutants killed, 117 escaped, mutation code coverage 100%) — the requirement is met
+  with 9 points of headroom, and the floor stays at the spec's 70 rather than being raised to
+  today's number. Proved able to fail before being trusted: 95% floor → red, reverted.
+
 ### Added
 
 - **`D4np\Utils\Database\SqlStatement`** (spec r7 **FR-33**, RFC-0002; roadmap item **10.1**,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — What one value type actually closes](docs/journal/2026/08/2026-08-06-sql-statement.md).
+  [2026-08-06 — A gate that waited ten milestones, and a review that found it](docs/journal/2026/08/2026-08-06-mutation-gate.md).
 
 ## Model & effort routing (advisory)
 
@@ -789,7 +789,25 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       (there, the job set up pcov and ran PHPUnit with no `--coverage` flag). Found by the
       item-10.1 review, which had listed the job among PR #57's passing checks — true of the
       job, false of the requirement (severity:high — a green gate that measures nothing) —
-      route: standard / high · **ADR-0040**
+      route: standard / high · **ADR-0040**. *Three more obstacles surfaced by **running** the
+      step rather than reading it. **Infection cannot be a dependency of this package**: every
+      release from 0.29.10 requires PHP ^8.2/^8.3 against the 8.1 floor, and the
+      8.1-compatible ones conflict with versions already locked here (`json-schema` 6.10 vs
+      `^5.2`, `cpu-core-counter` 1.3 vs `^0.4`, `xdebug-handler` 3.0 vs `^1.3`) — installed
+      into a throwaway project, ADR-0031's answer for the BC checker, so the 8.1 cell and
+      `--prefer-lowest` stay untouched. **`--only-covered` is not an Infection option** (the
+      generated step passed it; uncovered code is excluded by default now) so the step would
+      have failed on argument parsing regardless. And Infection **could not locate PHPUnit**
+      across two vendor directories, so `phpUnit.customPath` is stated rather than left to its
+      finder. **Measured: MSI 79%** — 443 killed, 117 escaped, mutation code coverage 100% —
+      so NFR-07's ≥70% is **met with 9 points of headroom**, and the floor **stays at the
+      spec's 70**: raising it to today's number would be this item inventing a requirement.
+      **Gate proved able to fail** (L-0008): floor temporarily raised to 95 against the same
+      79% measurement → CI red, reverted in the next commit, both kept in this PR's history.
+      Honest limits: 11 mutants produce syntax errors and are excluded from the ratio; the
+      escaped set is now a CI artifact with a per-mutator breakdown but is **not** chased here;
+      and the MSI cannot be measured on the maintainer's machine (no coverage driver — the
+      same limit as the suite's 9 skips and item 9.6's benchmark caveat).*
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -763,6 +763,33 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       route: frontier-reasoning / extra
 - [ ] 10.6 phpbench: NFR-09 gateway-vs-hand-written-PDO ratio (`bench_ratio_gate` pattern,
       ADR-0011 precedent) (RFC-0002) (step:optimize) — size: S · route: fast / medium
+- [ ] 10.7 Make FR-33's guarantee **mechanical** instead of organizational: annotate
+      `SqlStatement::__construct()`'s `$sql` as `@param literal-string`, so PHPStan at max
+      level — a gate this project already runs — *refuses* a value interpolated or
+      concatenated into statement text. **Filed by the item-10.1 review, which found the
+      option had never been considered**: ADR-0039's Alternatives weighed a *runtime*
+      assertion (rightly rejected — it cannot tell "nothing to bind" from "forgot to bind")
+      and wrote *"a type-level guarantee catches what a string never announces"* while
+      shipping the version that has no type-level guarantee. Verified empirically against
+      this repository's own `phpstan.neon` before filing: an interpolated `"… {$v} …"` and a
+      `'…' . $v` concatenation are both **rejected**, while hand-written literal SQL with
+      placeholders — precisely what FR-33 exists to allow — passes. Needs two companions,
+      because `QueryBuilder::toSql()` returns `string` and is correctly flagged: a
+      `SqlStatement::fromQueryBuilder(QueryBuilder $b)` named constructor that takes the
+      builder rather than a string (adding **no** new string-accepting door), plus one
+      conspicuously-named escape hatch for genuinely composed SQL (`IN (?,?,?)` built with
+      `implode()` is not a `literal-string` and is a legitimate pattern). **Should land
+      before 10.3/10.4** — `Repository` and `TableGateway` are the callers the guarantee
+      exists for. Supersedes or amends ADR-0039 (security; adr) — size: S ·
+      route: frontier-reasoning / extra
+- [x] 10.8 Make NFR-07's mutation gate actually run. `infection.json5` never existed, so the
+      `mutation` CI job's config guard reported `present=false` and the job passed in ~7
+      seconds having executed nothing — **spec NFR-07's "≥ 70% MSI on Security/Database/Dto"
+      has been unenforced since M1**, which is item 2.7's coverage-gate shape a second time
+      (there, the job set up pcov and ran PHPUnit with no `--coverage` flag). Found by the
+      item-10.1 review, which had listed the job among PR #57's passing checks — true of the
+      job, false of the requirement (severity:high — a green gate that measures nothing) —
+      route: standard / high · **ADR-0040**
 
 ---
 

--- a/docs/adr/0040-install-the-mutation-tester-outside-the-graph-and-keep-nfr07s-own-number.md
+++ b/docs/adr/0040-install-the-mutation-tester-outside-the-graph-and-keep-nfr07s-own-number.md
@@ -1,0 +1,122 @@
+# ADR-0040: Install the mutation tester outside the dependency graph, and keep NFR-07's own number
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 10.8 · spec **NFR-07** (`Infection mutation score >= 70% on
+  Security/Database/Dto namespaces`) ·
+  [ADR-0031](0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md)
+  (the same obstacle and the same answer, for the BC checker) ·
+  [ADR-0007](0007-measure-total-line-coverage-against-a-floor.md) (item 2.7 — the first time
+  a gate in this repository was green while measuring nothing) ·
+  [ADR-0030](0030-same-runner-ab-because-a-stored-baseline-cannot-carry-a-10-percent-gate.md)
+  (CI as the authoritative measurement environment)
+
+## Context
+
+NFR-07 has required *"Infection mutation score >= 70% on Security/Database/Dto namespaces"*
+since the spec was frozen at item 1.6. The `mutation` CI job has existed since item 1.9,
+carrying the step-level config guard that pattern uses: *"self-enables when
+`infection.json5` lands"*. `infection.json5` never landed. So for ten milestones the job
+resolved `present=false`, skipped every step, and reported **pass in about seven seconds**.
+
+That is item 2.7's finding repeating itself. There, the `build` job installed pcov and ran
+PHPUnit with no `--coverage` flag, so the 90% floor *"was neither produced nor compared"* —
+and ADR-0007 was the answer. The self-enabling guard (lesson L-0010) is a good pattern with
+one failure mode nobody had checked for: **nothing ever asks whether the thing it waits for
+actually arrived.** A guard that is still waiting after ten milestones is indistinguishable,
+in the checks column, from a gate that is passing.
+
+Three further obstacles surfaced only by *running* the step rather than reading it:
+
+1. **`vendor/bin/infection` never existed, and cannot.** Infection is not in `require-dev`,
+   and adding it fails: every release from **0.29.10** onward requires PHP `^8.2` or `^8.3`
+   against this library's pinned 8.1 floor, while every release old enough to accept 8.1
+   conflicts with versions this project already locks — `justinrainbow/json-schema` 6.10.0
+   against their `^5.2`/`^5.3`, `fidry/cpu-core-counter` 1.3.0 against their `^0.4`/`^0.5`,
+   `composer/xdebug-handler` 3.0.5 against their `^1.3`/`^2.0`. Resolving it with `-W` would
+   mean *downgrading* dependencies the rest of the toolchain shares, to install a mutation
+   tester.
+2. **`--only-covered` is not an Infection option.** The generated step passed it; checked
+   against 0.34.1's own `run` usage line, it does not exist. Uncovered code is excluded by
+   default in current Infection, and the inverse flag is `--with-uncovered`. The step would
+   have failed on argument parsing.
+3. **Infection could not find PHPUnit** when run from a foreign vendor directory. Its
+   `TestFrameworkFinder` asks `composer config bin-dir`, falls back to
+   `getcwd() . '/vendor/bin'`, and manipulates `PATH` to reach it — a heuristic being asked
+   to bridge two vendor directories, which failed on the maintainer's machine.
+
+## Decision
+
+Ship the gate with Infection installed into a **throwaway project** — `composer require
+--working-dir="$RUNNER_TEMP/mutation-tool" "infection/infection:^0.34"`, exactly ADR-0031's
+answer for `roave/backward-compatibility-check` — invoked from the repository root so it
+analyzes this tree. `composer.json`, the 8.1 matrix cell and `--prefer-lowest` stay
+untouched. `infection.json5` scopes `source.directories` to precisely the three namespaces
+NFR-07 names, states `phpUnit.customPath` explicitly rather than relying on the finder, and
+sets a 30s per-mutant timeout because `Hash`'s Argon2id path (one of the three namespaces)
+budgets 50–200 ms per call under NFR-05 and would otherwise report timeouts as findings.
+
+**The threshold stays at NFR-07's `--min-msi=70`, although the measured score is higher.**
+First real run, on CI's PHP 8.3 + pcov runner: **MSI 79%** — 443 mutants killed, 117 covered
+mutants escaped, mutation code coverage 100%. Raising the floor to the measured 79% would
+lock in today's number and read as stricter; it would also be **this document inventing a
+requirement the spec does not state**. The spec's number is the contract; a change to it is
+a spec amendment with its own reasoning, not a side effect of the run that first measured it.
+
+## Alternatives Considered
+
+- **Add `infection/infection` to `require-dev`** — rejected on the dependency evidence in
+  Context §1: impossible above 0.29.10 against the 8.1 floor, and possible below it only by
+  downgrading shared tooling dependencies.
+- **Raise this library's PHP floor to 8.2 so Infection installs normally** — rejected
+  emphatically: the floor is a *consumer-facing promise* (spec §1, the `--prefer-lowest` job,
+  a whole matrix cell), and moving it to accommodate a development tool would be the tail
+  wagging the dog. The throwaway project costs one CI step.
+- **An `infection.phar` download** — rejected: it reintroduces the supply-chain question
+  ADR-0003 answers for actions (what is this artifact, and is it the one it claims to be)
+  with no lockfile and no `composer audit`, and ADR-0031 already found upstream PHAR
+  publication unreliable for the BC checker. A version-constrained Composer install is
+  auditable by the tooling already here.
+- **Set the floor to the measured 79%** — rejected above; the spec owns the number.
+- **`--min-covered-msi` instead of `--min-msi`** — rejected as a silent substitution: they
+  differ whenever mutation code coverage is below 100% (it is exactly 100% today, so the two
+  coincide and the choice is currently invisible). NFR-07 says *"mutation score"*, so the
+  plain MSI is what it gets; if coverage of the three namespaces ever drops, the gate should
+  become harder to pass, not quietly rebase itself onto the covered subset.
+- **Chase the 117 escaped mutants in this item** — rejected as scope: the requirement is a
+  threshold and the threshold is met with 9 points of headroom. The escaped set is now
+  *visible* — kept as a CI artifact with a per-mutator breakdown — which is the prerequisite
+  for anyone deciding to act on it. Infection's own output notes that some mutants are
+  inevitably harmless, and the first one this run reported is a case in point: `0` → `-1` in
+  a `DatabaseException`'s unused *code* argument.
+
+## Consequences
+
+- The gate runs for real: **2m16s** against the previous ~7 seconds of nothing, and it is
+  now the only source in this repository for how much its security-critical tests actually
+  assert.
+- **Proven able to fail before being trusted** (lesson L-0008), because a threshold nobody
+  has seen reject anything is a threshold nobody has tested: the floor was temporarily raised
+  to 95% against the measured 79%, CI turned red, and it was reverted in the following
+  commit. Both commits are in this PR's history on purpose.
+- 11 mutants produced syntax errors and are excluded from the ratio. That is Infection
+  generating invalid code in edge cases, not a defect here — recorded so the number in the
+  log is not read as 571 mutants with 11 mysteriously missing.
+- **The MSI cannot be measured on the maintainer's machine**: it has no coverage driver (the
+  same limitation behind the suite's 9 skips, and behind item 9.6's benchmark caveat). CI is
+  authoritative, as ADR-0030 already established for benchmarks.
+- The three-namespace scope means a mutation regression *outside* Security/Database/Dto is
+  invisible to this gate. That is NFR-07's scope, stated rather than widened here.
+- Cost: one throwaway `composer require` per PR run. Version-constrained to `^0.34` for
+  ADR-0031's reason — a tool that changes its own findings between runs makes a gate
+  unreviewable.
+
+## References
+
+- Spec NFR-07 (the requirement, unchanged by this ADR — only implemented)
+- ADR-0031 §"Installing the checker outside the dependency graph" — the identical obstacle
+  and the pattern reused here
+- ADR-0007 / item 2.7 — the first instance of a gate green while measuring nothing
+- Infection 0.34.1 `run` usage output — the source for `--only-covered`'s non-existence
+- First measured run: MSI 79%, 443 killed / 117 escaped, mutation code coverage 100%

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0037](0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md) | Disable PHP's CSV escape character, and keep the formula guard opt-in | Accepted |
 | [0038](0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md) | One lock across the read and the write, and a sequence that refuses to wrap | Accepted |
 | [0039](0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md) | SQL text and its parameters become one value, not two arguments | Accepted |
+| [0040](0040-install-the-mutation-tester-outside-the-graph-and-keep-nfr07s-own-number.md) | Install the mutation tester outside the dependency graph, and keep NFR-07's own number | Accepted |

--- a/docs/journal/2026/08/2026-08-06-mutation-gate.md
+++ b/docs/journal/2026/08/2026-08-06-mutation-gate.md
@@ -1,0 +1,83 @@
+# 2026-08-06 — A gate that waited ten milestones, and a review that found it
+
+Not a planned item. This session began as a **review of item 10.1**, requested after that
+item shipped, and produced two roadmap items: **10.7** (filed only) and **10.8** (this
+commit's deliverable). Both are things the review found, which is the argument for reviewing
+one's own completed work at all.
+
+## The one that matters most: a gate green on nothing
+
+`infection.json5` never existed. The `mutation` job has carried the self-enabling config
+guard since item 1.9 — *"job self-enables when it lands"* — and it never landed, so for ten
+milestones the job resolved `present=false`, skipped every step, and reported **pass in about
+seven seconds**. Spec NFR-07's *"≥ 70% mutation score on Security/Database/Dto"* has been
+unenforced since it was written.
+
+This is **item 2.7's finding, verbatim in shape**: there, the `build` job installed pcov and
+ran PHPUnit with no `--coverage` flag, so the 90% floor was *"neither produced nor compared"*.
+Two instances make it a pattern worth naming: the self-enabling guard (lesson L-0010) is a
+good idea with one blind spot — **nothing ever asks whether the thing it waits for arrived.**
+A guard still waiting after ten milestones is, in the checks column, indistinguishable from a
+gate that passes.
+
+I found it while reviewing what I had written in PR #57's body, where I had listed
+`quality / infection mutation score` among the passing checks. True of the job. False of the
+requirement. That is the specific way this failure survives: it is reported honestly by
+everyone who reads the checks column instead of the job.
+
+## Three obstacles, all found by running the step instead of reading it
+
+1. **`vendor/bin/infection` never existed and cannot.** Infection is not in `require-dev`, and
+   it cannot be: from 0.29.10 every release needs PHP `^8.2`/`^8.3` against this library's 8.1
+   floor, and every older release conflicts with versions already locked here
+   (`justinrainbow/json-schema` 6.10 vs their `^5.2`, `fidry/cpu-core-counter` 1.3 vs `^0.4`,
+   `composer/xdebug-handler` 3.0 vs `^1.3`). This is item 7.2's obstacle in a new costume, and
+   it takes item 7.2's answer: a throwaway project (ADR-0031), so the 8.1 matrix cell and
+   `--prefer-lowest` never learn about it.
+2. **`--only-covered` is not an Infection option.** The generated step passed it. Modern
+   Infection excludes uncovered code by default and spells the inverse `--with-uncovered`. So
+   the step had *two* independent reasons to fail the moment its guard opened.
+3. **Infection could not find PHPUnit** across two vendor directories — its finder asks
+   `composer config bin-dir`, falls back to `getcwd() . '/vendor/bin'` and edits `PATH`.
+   Replaced with an explicit `phpUnit.customPath`: a heuristic that happens to work on one
+   platform is not a configuration.
+
+## The number, and the number I did not use
+
+First real run: **MSI 79%** — 443 mutants killed, 117 covered mutants escaped, mutation code
+coverage 100%, 2m16s. NFR-07's 70% is met with nine points of headroom.
+
+The tempting move is to set the floor at 79 and lock the current level in. I did not, and the
+reason is not caution: **the spec owns that number.** Raising it here would be this item
+inventing a requirement, in an ADR, as a side effect of the run that first measured it. If 79
+should be the floor, that is a spec amendment with its own argument.
+
+The 117 escaped mutants are now visible — kept as a CI artifact with a per-mutator breakdown —
+and deliberately not chased in this item. Infection's own output warns that some are
+inevitably harmless, and the first one it reported proves the point: `0` → `-1` in a
+`DatabaseException`'s unused *code* argument.
+
+## Proving it, because a threshold nobody has seen reject anything is not a gate
+
+Floor temporarily raised to 95 against the same 79% measurement: **CI red**. Reverted in the
+next commit. Both commits are in this PR's history on purpose — the same measurement, opposite
+verdicts, which is what distinguishes a gate from a decoration.
+
+## The other finding, filed not fixed: item 10.7
+
+Item 10.1 shipped `SqlStatement` and I wrote in ADR-0039 that *"a type-level guarantee catches
+what a string never announces"* — while shipping the version with no type-level guarantee. The
+Alternatives section weighed a *runtime* assertion and rejected it correctly, and never
+considered the static one: **`@param literal-string`**, which PHPStan enforces at the max level
+this project already runs. Verified against this repository's own `phpstan.neon` before filing:
+an interpolated `"… {$v} …"` and a `'…' . $v` are both **rejected**, while hand-written literal
+SQL with placeholders — exactly what FR-33 exists to permit — passes.
+
+Filed as 10.7 rather than fixed here, at the maintainer's direction, with the note that it
+should land before 10.3/10.4 — `Repository` and `TableGateway` are the callers the guarantee is
+for.
+
+## Lesson
+
+Read the job, not the checks column: a gate can be green because it ran and passed, or green
+because it ran nothing, and the two look identical from outside.

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,45 @@
+// Mutation-testing configuration — spec NFR-07's ">= 70% mutation score on
+// Security/Database/Dto namespaces" (roadmap item 10.8, ADR-0040).
+//
+// No `$schema` key: the usual value points into `vendor/infection/infection/`, and Infection
+// is deliberately NOT a dependency of this package — its PHP floor is above this library's
+// (see ADR-0040). The binary comes from a throwaway project, so a vendor-relative schema
+// reference here would dangle.
+{
+    // Exactly the three namespaces NFR-07 names, not the whole tree. The requirement is
+    // scoped on purpose: these hold the security-relevant and data-mapping logic where a
+    // surviving mutant means a test that asserts less than it appears to. Widening this
+    // would change what the 70% figure means without any decision saying so.
+    source: {
+        directories: [
+            "src/main/php/d4np/utils/Database",
+            "src/main/php/d4np/utils/Dto",
+            "src/main/php/d4np/utils/Security"
+        ]
+    },
+    // Kept as a CI artifact so a surviving mutant can be read rather than guessed at from a
+    // percentage. `perMutator` gives the per-mutator breakdown that says *which* kind of
+    // assertion is missing, which a single MSI number cannot.
+    logs: {
+        text: "build/logs/infection.txt",
+        perMutator: "build/logs/infection-per-mutator.md"
+    },
+    // Stated rather than discovered. Infection's own finder asks `composer config bin-dir`
+// and then falls back to `getcwd() . '/vendor/bin'`, manipulating `PATH` to reach it — and
+    // because the binary here is deliberately installed OUTSIDE this package (ADR-0040),
+    // that heuristic is being asked to bridge two vendor directories. It failed to on the
+    // maintainer's Windows machine. An explicit path removes the guesswork on every
+    // platform instead of relying on a search that happens to succeed on one.
+    phpUnit: {
+        customPath: "vendor/bin/phpunit"
+    },
+    tmpDir: ".infection.cache",
+    mutators: {
+        "@default": true
+    },
+    // Per-mutant, not for the whole run. The default is 10s; the suite's slowest units here
+    // are Argon2id hashes (NFR-05 budgets them at 50-200ms each, and `Hash` lives under one
+    // of the three namespaces), so a mutant landing in that path needs headroom before it is
+    // reported as a timeout rather than as escaped or killed.
+    timeout: 30
+}


### PR DESCRIPTION
## Summary

Roadmap item **10.8**: makes spec **NFR-07**'s mutation gate actually run. It never has —
`infection.json5` did not exist, so the `mutation` job's self-enabling config guard reported
`present=false` and the job **passed in ~7 seconds having executed nothing**. The requirement
*"≥ 70% MSI on Security/Database/Dto namespaces"* has been unenforced since M1.

**Measured on the first real run: MSI 79%** (443 mutants killed, 117 escaped, mutation code
coverage 100%, 2m16s). The requirement is met with 9 points of headroom.

Also files item **10.7** (unchecked) — the second finding from the same review, see below.

## Motivation

Both items come from reviewing item **10.1** after it shipped. The mutation finding surfaced
from my own PR #57 body, where I had listed `quality / infection mutation score` among the
passing checks: true of the job, false of the requirement. That is precisely how this failure
survives — everyone reading the checks column reports it honestly.

This is **item 2.7's finding in the same shape** (there, `build` installed pcov and ran PHPUnit
with no `--coverage` flag, so the 90% floor was *"neither produced nor compared"*). Two
instances make it a pattern worth naming: the self-enabling guard (lesson L-0010) is a good
pattern with one blind spot — **nothing ever asks whether the file it waits for arrived.**

## Changes

- **`infection.json5`** — new. `source.directories` scoped to exactly the three namespaces
  NFR-07 names; `phpUnit.customPath` stated explicitly; 30s per-mutant timeout (`Hash`'s
  Argon2id path is in scope and budgets 50–200 ms per call under NFR-05, so the 10s default
  would report timeouts as findings); text + per-mutator logs kept as artifacts.
- **`.github/workflows/ci.yml`** — the `mutation` job rewritten. Infection installed into a
  throwaway project (`$RUNNER_TEMP/mutation-tool`, version-constrained `^0.34`), report
  uploaded as an artifact, 30-minute timeout.
- **`.gitignore`** — `/.infection.cache/`.
- **`docs/adr/0040-…md`** — the decision and six rejected alternatives.
- **ROADMAP** — 10.8 checked with the measured numbers; **10.7 filed, unchecked**.
- **CHANGELOG** — under `Fixed`, since a gate that measured nothing was a defect.
- **`docs/journal/2026/08/2026-08-06-mutation-gate.md`** — session checkpoint.

### Three obstacles, all found by running the step rather than reading it

1. **`vendor/bin/infection` never existed, and cannot.** Infection is not in `require-dev` and
   cannot be: from **0.29.10** every release requires PHP `^8.2`/`^8.3` against this library's
   8.1 floor, and every older release conflicts with versions already locked here
   (`justinrainbow/json-schema` 6.10 vs their `^5.2`, `fidry/cpu-core-counter` 1.3 vs `^0.4`,
   `composer/xdebug-handler` 3.0 vs `^1.3`). Resolving with `-W` would downgrade shared
   tooling dependencies to install a mutation tester. → throwaway project, **ADR-0031's exact
   precedent** for the BC checker; the 8.1 matrix cell and `--prefer-lowest` stay untouched.
2. **`--only-covered` is not an Infection option** (checked against 0.34.1's own `run` usage
   line). Uncovered code is excluded by default now; the inverse flag is `--with-uncovered`.
   The generated step had **two independent reasons** to fail the moment its guard opened.
3. **Infection could not locate PHPUnit** across two vendor directories — its finder asks
   `composer config bin-dir`, falls back to `getcwd() . '/vendor/bin'` and edits `PATH`.
   Replaced with an explicit `phpUnit.customPath`.

### The threshold stays at 70, deliberately

The measured score is 79%. Setting the floor there would lock in today's level and read as
stricter — and would be **this PR inventing a requirement the spec does not state**. NFR-07
owns that number; changing it is a spec amendment with its own argument, not a side effect of
the run that first measured it.

## Design Patterns

- None newly catalogued. Reuses ADR-0031's throwaway-tool-install pattern (already recorded
  there) for the second time.

## Verification

- [x] **Gate proved able to fail before being trusted** (lesson L-0008), the point of commits
      `2bed7a2` and `57865bf` in this PR's history: floor temporarily raised to 95 against the
      **same 79% measurement** → CI **red**; reverted → **green**. Identical measurement,
      opposite verdicts, which is what distinguishes a gate from a decoration.
- [x] `quality / infection mutation score` — **pass, 2m16s** (was ~7s of nothing)
- [x] `python tools/consistency_lint.py` passes
- [x] `python tools/action_pin_lint.py` passes — 37 pins across 4 workflows (workflow touched;
      the added `upload-artifact` pin matches the one the benchmark job already uses)
- [x] Full CI matrix green on the final commit
- [ ] Local run — **impossible**: this machine has no coverage driver (the same limit behind
      the suite's 9 skips and item 9.6's benchmark caveat). CI is authoritative, per ADR-0030.

## Documentation Impact

- [x] ROADMAP.md — 10.8 checked, 10.7 filed
- [x] ADR added — **ADR-0040**
- [x] CHANGELOG.md — under `Fixed`
- [ ] README.md — unchanged (no milestone-table change; M10 still in progress)
- [ ] Spec — **unchanged, deliberately**: NFR-07 already stated the requirement; this item
      implements it and does not amend the number
- [ ] docs/patterns/README.md — unchanged (see Design Patterns)
- [x] PR metadata — assignee (owner), label `enhancement`, milestone `v0.9.0`

## The other finding: item 10.7, filed not fixed

Item 10.1's ADR-0039 wrote *"a type-level guarantee catches what a string never announces"* —
and shipped the version with **no** type-level guarantee. Its Alternatives weighed a *runtime*
assertion (rightly rejected: it cannot tell "nothing to bind" from "forgot to bind") and never
considered the static one: **`@param literal-string`**, enforced by the PHPStan max level this
project already runs. Verified against this repository's own `phpstan.neon` before filing:

| probe | verdict |
|---|---|
| `new SqlStatement('SELECT … WHERE id = ?', [1])` | passes |
| `new SqlStatement('SELECT …' . ' WHERE id = ?', [1])` | passes |
| `new SqlStatement("… WHERE name = '{$userValue}'")` | **rejected** |
| `new SqlStatement('… WHERE name = ' . $userValue)` | **rejected** |

Filed as **10.7** at the maintainer's direction rather than fixed here, with the note that it
should land **before 10.3/10.4** — `Repository` and `TableGateway` are the callers the
guarantee exists for.

## Lesson

Lesson: read the job, not the checks column — a gate can be green because it ran and passed,
or green because it ran nothing, and from outside the two are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
