### PR TITLE
feat(database): constrain SQL text by type, and name the one escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ## [Unreleased]
 
+### Changed
+
+- **`SqlStatement`'s constructor is now private, behind three named entry points** (spec r8
+  **FR-33**; roadmap item **10.7**; **ADR-0041**, amending **ADR-0039**):
+  `SqlStatement::literal()` for text written out in the source, `::fromQueryBuilder()` for a
+  built query, `::composed()` for text assembled at runtime. `new SqlStatement(...)` no longer
+  exists — a **second pre-1.0 break to this class in two PRs**, and the honest reading is that
+  one PR should have shipped both.
+  The point is that FR-33's guarantee is now **mechanical**: `literal()` takes a
+  `literal-string`, so the PHPStan max level this project already runs on every PR **refuses**
+  interpolated (`"… {$value} …"`), concatenated (`'…' . $value`), `sprintf()`-ed and
+  `implode()`-ed statement text — verified by planting all four, and by confirming four
+  legitimate shapes still pass, including the hand-written dialect SQL with a positional
+  predicate that FR-33 exists to allow. ADR-0039 had rejected a *runtime* assertion while
+  writing that a type-level guarantee was what this needed, and never considered the static
+  one; item 10.7 is that omission closed. `composed()` is the single escape hatch — deliberately
+  not named `unsafe*()`, since values still bind through real prepares — and has **zero uses
+  inside this library**, which is what makes `grep composed(` the review list.
+
 ### Fixed
 
 - **NFR-07's mutation gate now actually runs** (roadmap item **10.8**; **ADR-0040**).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — A gate that waited ten milestones, and a review that found it](docs/journal/2026/08/2026-08-06-mutation-gate.md).
+  [2026-08-06 — The guarantee the previous item wrote about and did not build](docs/journal/2026/08/2026-08-06-literal-string.md).
 
 ## Model & effort routing (advisory)
 
@@ -763,7 +763,7 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       route: frontier-reasoning / extra
 - [ ] 10.6 phpbench: NFR-09 gateway-vs-hand-written-PDO ratio (`bench_ratio_gate` pattern,
       ADR-0011 precedent) (RFC-0002) (step:optimize) — size: S · route: fast / medium
-- [ ] 10.7 Make FR-33's guarantee **mechanical** instead of organizational: annotate
+- [x] 10.7 Make FR-33's guarantee **mechanical** instead of organizational: annotate
       `SqlStatement::__construct()`'s `$sql` as `@param literal-string`, so PHPStan at max
       level — a gate this project already runs — *refuses* a value interpolated or
       concatenated into statement text. **Filed by the item-10.1 review, which found the
@@ -780,8 +780,26 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       conspicuously-named escape hatch for genuinely composed SQL (`IN (?,?,?)` built with
       `implode()` is not a `literal-string` and is a legitimate pattern). **Should land
       before 10.3/10.4** — `Repository` and `TableGateway` are the callers the guarantee
-      exists for. Supersedes or amends ADR-0039 (security; adr) — size: S ·
-      route: frontier-reasoning / extra
+      exists for. Supersedes or amends ADR-0039 (security; adr) —
+      route: frontier-reasoning / extra · **ADR-0041** (amends ADR-0039), **spec r8**. *Shipped
+      the filed plan with one design change forced by this project's own rules: an annotated
+      **public** constructor could not be reached by the escape hatch without an analyser
+      suppression, which is forbidden here — so the **constructor is private** and the class
+      exposes exactly three named entry points (`literal()`, `fromQueryBuilder()`,
+      `composed()`), needing **no suppression of any kind**. `composed()` has **zero in-library
+      uses** by construction — that is why `fromQueryBuilder()` takes the builder *object*
+      rather than its `toSql()` string, so `grep composed(` stays a list of places a human had
+      to think. **Proved non-vacuous, 4 planted / 4 caught**: interpolation, concatenation,
+      `sprintf()` and `implode()` into `literal()` are all rejected by PHPStan max — while four
+      legitimate shapes still pass, including the one that mattered most before committing,
+      **hand-written dialect SQL with a positional substring predicate**, which is FR-33's
+      whole reason to exist. Tested as a **mechanism** (ADR-0027's pattern): the annotation's
+      presence, the constructor's privacy, and the exact public static surface are asserted
+      from the source, because no runtime test can exercise a static property. **Second pre-1.0
+      break to this class in two PRs** (51 call sites moved) — named in ADR-0041 as the process
+      finding it is: one PR should have shipped both, and did not because ADR-0039 never weighed
+      the static alternative. Also found by running it: PHPStan parses an ignore-comment tag
+      **inside prose** and fails on it, so the class docblock cannot name one verbatim.*
 - [x] 10.8 Make NFR-07's mutation gate actually run. `infection.json5` never existed, so the
       `mutation` CI job's config guard reported `present=false` and the job passed in ~7
       seconds having executed nothing — **spec NFR-07's "≥ 70% MSI on Security/Database/Dto"

--- a/docs/adr/0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md
+++ b/docs/adr/0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md
@@ -1,6 +1,16 @@
 # ADR-0039: SQL text and its parameters become one value, not two arguments
 
-- **Status:** Accepted
+- **Status:** Accepted — **amended by
+  [ADR-0041](0041-constrain-sql-text-by-type-and-name-the-one-escape-hatch.md)** (item 10.7).
+  This decision stands; two things in it did not. Its Alternatives section rejected a *runtime*
+  assertion while writing *"a type-level guarantee catches what a string never announces"*, and
+  never considered the static one — PHPStan's `literal-string`, which this repository's own
+  `max` level enforces and which ADR-0041 verified rejects interpolation while still permitting
+  the hand-written dialect SQL FR-33 exists for. And the claim below that the constructor is
+  *"exactly one place"* where text and parameters could be mispaired is a half-truth:
+  `new SqlStatement(...)` is written at every call site, so the count of risky sites never
+  dropped, only their greppability improved. Annotated rather than silently edited, per the
+  precedent ADR-0020 set for ADR-0018.
 - **Date:** 2026-08-06
 - **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
 - **Related:** ROADMAP item 10.1 (opens Milestone 10) · spec r3 FR-33 (RFC-0002) ·

--- a/docs/adr/0041-constrain-sql-text-by-type-and-name-the-one-escape-hatch.md
+++ b/docs/adr/0041-constrain-sql-text-by-type-and-name-the-one-escape-hatch.md
@@ -1,0 +1,132 @@
+# ADR-0041: Constrain SQL text by type, and name the one escape hatch
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Amends:** [ADR-0039](0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md)
+  — whose decision (SQL text and parameters are one value, and the only shape
+  `DatabaseConnection` executes) **stands**; what changes is who enforces it
+- **Related:** ROADMAP item 10.7, filed by the item-10.1 review · spec r3 **FR-33** (RFC-0002) ·
+  [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) (the allowlist
+  that makes `QueryBuilder`'s composed text safe) ·
+  [ADR-0027](0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md) (asserting
+  a mechanism from the source, the pattern reused for the test here) ·
+  [ADR-0014](0014-pin-pdo-defaults-on-a-consumer-owned-connection.md) (real prepares) ·
+  roadmap items 10.3–10.4, the callers this exists for
+
+## Context
+
+ADR-0039 wrote, in its own Alternatives section, that *"a type-level guarantee catches what a
+string never announces; a runtime heuristic cannot"* — and then shipped a `SqlStatement` whose
+constructor took a plain `string`. It considered and correctly rejected a **runtime** assertion
+(counting placeholders cannot distinguish a legitimately parameter-free statement from a
+forgotten bind) and **never considered the static one**. That omission is the finding the
+item-10.1 review filed as item 10.7.
+
+The static option exists and this repository already runs the tool that enforces it: PHPStan's
+`literal-string` type, at the `max` level `phpstan.neon` pins. Verified against this
+repository's own configuration before the item was filed, and again here with four planted
+mistakes and four cases that must keep working:
+
+| probe | verdict |
+|---|---|
+| `literal("… name = '{$userValue}'")` — interpolation | **rejected** |
+| `literal('… name = ' . $userValue)` — concatenation | **rejected** |
+| `literal(sprintf('… name = %s', $userValue))` | **rejected** |
+| `literal('… IN (' . implode(',', $values) . ')')` | **rejected** |
+| `literal('… WHERE id = ?', [1])` | passes |
+| `literal('SELECT * FROM users' . ' WHERE id = ?', [1])` — literal ‖ literal | passes |
+| `literal('SELECT c FROM stock WHERE code[1, ?] = ?', [$len, $code])` — hand-written dialect SQL | **passes** |
+| `composed('… IN (' . implode(',', array_fill(0, count($v), '?')) . ')', $v)` | passes |
+
+The seventh row is the one that mattered most before committing to this: FR-33 exists *because*
+hand-written dialect SQL is legitimate (the surveyed estate uses positional substring
+predicates `QueryBuilder` deliberately does not model). `literal-string` permits it. Being
+hand-written was never the problem; being **assembled from values** is, and that is precisely
+the line the type draws.
+
+ADR-0039 also claimed the constructor was *"exactly one place"* where text and parameters could
+be mispaired. That was a half-truth the review corrected: `new SqlStatement(...)` is written at
+**every** call site, so the count of risky sites never dropped — only their greppability
+improved.
+
+## Decision
+
+Constrain the text by type, and make the constructor private so no unconstrained way in
+survives. `SqlStatement` exposes exactly three named constructors, and which one a call site
+uses **is** the review signal:
+
+| entry point | promises | enforced by |
+|---|---|---|
+| `SqlStatement::literal(literal-string $sql, array $parameters = [])` | the text is a compile-time literal | **PHPStan**, on every PR |
+| `SqlStatement::fromQueryBuilder(QueryBuilder $builder)` | the text came from the builder | `QueryBuilder`'s allowlist (ADR-0015) and its own suite |
+| `SqlStatement::composed(string $sql, array $parameters = [])` | the caller asserts the assembled text holds no untrusted value | **a human, at review** |
+
+`composed()` has **zero uses inside this library**. That is the load-bearing property, not an
+accident of the current code: `grep composed(` is meant to return exactly the places where a
+person had to think, and every in-library call would dilute that list. It is why
+`fromQueryBuilder()` takes the *builder object* rather than its `toSql()` string — the
+library's own composed SQL then needs no escape hatch at all.
+
+The private constructor is what makes this work **with no suppression of any kind** — no
+analyser-ignore comment, no inline type override, both of which this project forbids outright.
+The private constructor's parameter is a plain `string`; each public entry point states in its
+own signature what it promises. Had the annotated constructor stayed public, `composed()` could
+only have called it by overriding the analyser, and a guarantee that has to be suppressed to
+implement is not a guarantee.
+
+## Alternatives Considered
+
+- **Keep `__construct` public and annotated, and let `composed()` suppress the analyser** —
+  rejected: forbidden by this project's own rules, and self-defeating. The suppression would
+  sit permanently inside the class whose entire purpose is to not need one.
+- **Ship only `literal()` and `fromQueryBuilder()`, with no escape hatch** — rejected: a bulk
+  `INSERT … VALUES (?,?),(?,?)` or an `IN (?,?,?)` whose placeholder count follows the data
+  cannot be a literal, and `QueryBuilder` does not model bulk inserts. Consumers would be
+  pushed into suppressing the analyser on *their* side, which is the same hole one repository
+  further away.
+- **Name the escape hatch `unsafeRaw()` / `unsafeSql()`** — rejected. Nothing about it is unsafe
+  by construction: values still bind through ADR-0014's real prepares, and the only lost
+  property is PHPStan's ability to prove the text held no runtime value. A name that cries wolf
+  on every legitimate bulk insert is a name that gets ignored on the one call that deserved
+  attention. `composed()` says what actually happened.
+- **`QueryBuilder::toStatement()` using `composed()` internally**, instead of
+  `fromQueryBuilder()` — rejected on the property above: it is *truthful* (the builder's text
+  genuinely is composed at runtime) and needs no new coupling, but it puts two in-library calls
+  into `grep composed(` and turns the review list into something with routine entries in it.
+  The small coupling inside one group buys a signal that stays clean.
+- **A `#[SensitiveParameter]`-style attribute, or a custom PHPStan rule** — rejected as
+  reinvention: `literal-string` is the ecosystem's existing answer, understood by both PHPStan
+  and Psalm, and needs no rule of ours to maintain.
+
+## Consequences
+
+- **A second breaking change to this class in two PRs**, and worth naming rather than
+  smoothing: item 10.1 retired `(string, array)` for `new SqlStatement(...)`, and item 10.7 now
+  retires `new SqlStatement(...)` for `SqlStatement::literal(...)`. Both are pre-1.0 MINOR
+  breaks SemVer §4 permits, and 51 call sites moved mechanically — but the honest reading is
+  that one PR should have shipped both, and the reason it did not is that ADR-0039 never
+  weighed the static alternative. That is the process finding, not just the code one.
+- The guarantee now **fails a CI gate** instead of relying on a convention every future call
+  site has to re-earn. Items 10.3–10.4 (`Repository`, `TableGateway`) are the callers it exists
+  for, and they inherit it before they are written — which is why this item was sequenced
+  ahead of them.
+- **Tested as a mechanism, per ADR-0027.** No runtime test can exercise a static property, so
+  `SqlStatementTest` asserts from the source that the `literal-string` annotation is present,
+  that the constructor is still private, and that the public static surface is exactly the
+  three named constructors — the last pinned so a fourth entry point is a deliberate act with
+  a test to update. The proof that PHPStan *acts* on the annotation is the planted-probe table
+  above, run here, not inferred.
+- `literal-string` is a PHPDoc-only annotation: no runtime cost, no effect on the PHP 8.1
+  floor, and nothing for `--prefer-lowest` to resolve.
+- **Not closed by this:** a consumer who calls `composed()` carelessly is no safer than before.
+  The gate moves the failure from invisible to reviewable, and says so — the same honesty
+  ADR-0039 owed and this ADR keeps: `grep composed(` is a review aid, not a proof.
+
+## References
+
+- ADR-0039 (amended here; its Alternatives section is where the omission is visible)
+- FR-33, spec r3 — *"hand-written dialect SQL always travels with its binds"*, the requirement
+  the seventh probe row confirms is still satisfiable
+- PHPStan `literal-string`: the ecosystem type this decision leans on rather than reinventing
+- Planted-probe run, 2026-08-06: 4 mistakes rejected, 4 legitimate shapes accepted

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,3 +56,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0038](0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md) | One lock across the read and the write, and a sequence that refuses to wrap | Accepted |
 | [0039](0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md) | SQL text and its parameters become one value, not two arguments | Accepted |
 | [0040](0040-install-the-mutation-tester-outside-the-graph-and-keep-nfr07s-own-number.md) | Install the mutation tester outside the dependency graph, and keep NFR-07's own number | Accepted |
+| [0041](0041-constrain-sql-text-by-type-and-name-the-one-escape-hatch.md) | Constrain SQL text by type, and name the one escape hatch (amends 0039) | Accepted |

--- a/docs/journal/2026/08/2026-08-06-literal-string.md
+++ b/docs/journal/2026/08/2026-08-06-literal-string.md
@@ -1,0 +1,76 @@
+# 2026-08-06 — The guarantee the previous item wrote about and did not build
+
+Roadmap item **10.7**, filed two sessions ago by the review of item 10.1 and taken now at the
+maintainer's direction, ahead of 10.2, because `Repository` and `TableGateway` (10.3–10.4) are
+the callers it exists for and should inherit it before they are written.
+
+## What the item was
+
+ADR-0039 wrote *"a type-level guarantee catches what a string never announces; a runtime
+heuristic cannot"* — and shipped a constructor taking a plain `string`. Its Alternatives section
+rejected a **runtime** placeholder-counting assertion, correctly, and never considered the
+**static** option that this repository already has a gate for: PHPStan's `literal-string`, at the
+`max` level `phpstan.neon` pins.
+
+## The design change the project's own rules forced
+
+The filed plan said "annotate the constructor". That does not survive contact with the escape
+hatch: `composed()` has to accept runtime-assembled text, and if the annotated constructor were
+public, `composed()` could only reach it by overriding the analyser — which this project forbids
+outright (no ignore comments, no inline type overrides, stated in PHPStan's own output here).
+
+A guarantee that must be suppressed to implement is not a guarantee. So the **constructor is
+private**, and the class exposes exactly three named entry points, each stating in its own
+signature what it promises: `literal()` (PHPStan checks), `fromQueryBuilder()` (ADR-0015's
+allowlist checks), `composed()` (a human checks, at review). No suppression anywhere.
+
+`fromQueryBuilder()` takes the **builder object**, not its `toSql()` string, for one specific
+reason: it keeps `composed()`'s in-library usage count at **zero**. `grep composed(` is supposed
+to return the places where a person had to think; two routine library calls in that list would
+be two too many. The alternative — `QueryBuilder` calling `composed()` itself, which would have
+been *truthful*, its text genuinely is composed — was rejected on exactly that.
+
+## Proving it, since the whole item is a claim about a static property
+
+Four mistakes planted, four caught: interpolation, concatenation, `sprintf()`, and `implode()`
+into `literal()`. And four legitimate shapes confirmed still passing, of which the third was the
+one worth checking before committing to any of this:
+
+```
+literal('SELECT c FROM stock WHERE code[1, ?] = ?', [$len, $code])    -- passes
+```
+
+Hand-written dialect SQL with a positional substring predicate: **FR-33's entire reason to
+exist**, and `literal-string` permits it. Being hand-written was never the problem; being
+assembled from values is. Had that row failed, the item would have had to be redesigned rather
+than shipped, which is why it was probed rather than assumed.
+
+The runtime tests assert the **mechanism** instead, per ADR-0027: that the annotation is present,
+that the constructor is still private, and that the public static surface is exactly those three
+names — the last pinned so a fourth entry point is a deliberate act with a test to update.
+Deleting the annotation leaves every other test in the suite green, which is precisely why that
+assertion exists.
+
+## Two costs, named rather than smoothed
+
+**A second breaking change to the same class in two PRs.** Item 10.1 retired `(string, array)`;
+this retires `new SqlStatement(...)`. 51 call sites moved, mechanically, and pre-1.0 permits
+both — but one PR should have shipped both, and the reason it did not is that ADR-0039 never
+weighed the static alternative. That is a process finding, not a code one, and ADR-0041 says so
+in its own Consequences.
+
+**And `composed()` remains exactly as unchecked as everything was before it.** A consumer who
+calls it carelessly is no safer. The gate moves that failure from invisible to reviewable, which
+is worth doing and is not the same as preventing it.
+
+## A small thing found only by running it
+
+PHPStan parses an ignore-comment tag **wherever it appears, including inside prose**, and fails
+the analysis on it. The class docblock originally explained the design by naming the tag it does
+not need; that sentence had to be rewritten to describe the tag instead of spelling it.
+
+## Lesson
+
+When an ADR says what the right mechanism would be and then ships something else, that sentence
+is the finding — read your own Alternatives sections as a checklist of what you decided not to
+verify.

--- a/docs/specs/01_spec_utils.md
+++ b/docs/specs/01_spec_utils.md
@@ -3,7 +3,7 @@
 > Rendered from the intake interview (Phase 5). Frozen contract: diverging implementation
 > updates this spec in the same PR or adds an ADR superseding the relevant section.
 
-**Revision r7** — 2026-08-06. See [Revision history](#revision-history).
+**Revision r8** — 2026-08-06. See [Revision history](#revision-history).
 
 ## 1. Objective & Business Context
 
@@ -50,7 +50,7 @@ MailException).
 - FR-30 Lookup: immutable code→label map; label() throws on a missing key, labelOr()/tryLabel() tolerant
 - FR-31 Str additions: collapseWhitespace(), nullIfBlank(), transcode() (strict default, lossy opt-in), multibyte-safe padLeft()/padRight(), shortClassName(), pascalCase()
 - FR-32 FileSequence: rolling counter with an explicit cap (SequenceExhaustedException); never wraps silently. The whole read-modify-write runs under ONE exclusive lock via File::update() — read()+write() as two separately locked calls loses an increment, which for a sequence is a duplicate identifier (ADR-0038). A corrupt state file is refused, not reset (resetting re-issues the whole window) and is left on disk as evidence; an absent or blank file is a legitimate fresh start. The window is a caller-supplied opaque string (no timezone decision inside the library); recorded limit: windows cannot be ordered, so ANY window change resets — callers must supply a monotonically advancing window. peek()/remaining() are advisory and unlocked.
-- FR-33 SqlStatement (Database): immutable SQL+params value — the only shape connection-side execution accepts; hand-written dialect SQL always travels with its binds
+- FR-33 SqlStatement (Database): immutable SQL+params value — the only shape connection-side execution accepts; hand-written dialect SQL always travels with its binds. Enforced by TYPE, not by convention (r8, ADR-0041): private constructor, three named entry points — literal() taking a `literal-string` (PHPStan max refuses interpolated or concatenated text, and still permits hand-written dialect SQL with placeholders), fromQueryBuilder() taking the builder object so no SQL text crosses as a bare argument, and composed() as the single named escape hatch for runtime-assembled text, with zero in-library uses so `grep composed(` is the review list
 - FR-34 Repository (Persistence): fetchAll/fetchOne/execute/withTransaction; rows normalized (FR-36) then hydrated via the shared Hydrator; every failure throws DatabaseException
 - FR-35 TableGateway (Persistence): Table Data Gateway over QueryBuilder — identifiers allowlisted, values bound, by construction
 - FR-36 RowNormalizer (Persistence): strict/lossy charset transcode + trim + empty→null as one explicit, testable policy object
@@ -135,7 +135,7 @@ r3 (RFC-0002) additions:
 
 - D4np\Utils\Persistence\ — Repository (fetchAll/fetchOne/execute/withTransaction), TableGateway (select/insert/update/delete), RowNormalizer
 - D4np\Utils\Mail\ — EmailAddress, MailMessage, Mailer, NativeMailer
-- D4np\Utils\Database\ — + SqlStatement (r7: the only shape `DatabaseConnection`'s query methods accept, ADR-0039) · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, SequenceExhaustedException, File::writeStream(), File::update(), Str additions (FR-31)
+- D4np\Utils\Database\ — + SqlStatement::literal()/fromQueryBuilder()/composed() (r7: the only shape `DatabaseConnection`'s query methods accept, ADR-0039; r8: private constructor, text constrained by `literal-string`, ADR-0041) · D4np\Utils\Http\ — + HttpClient, Router, ApiEnvelope · D4np\Utils\Security\ — + Crypto, SecretKey · D4np\Utils\Errors\ — + Level, LevelFilteredLogger, MultiLogger, LoggerFactory · D4np\Utils\Support\ — + Url, Csv, Delimiter, CsvSerializable, Lookup, FileSequence, SequenceExhaustedException, File::writeStream(), File::update(), Str additions (FR-31)
 
 
 ## 6. Verification & Test Strategy
@@ -162,6 +162,7 @@ non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.y
 |-----|------|--------|
 | r1 | 2026-08-03 | Frozen from the imported `.specs/d4np-php.md` v2.0 via RFC-0001 (naming mapping A-7). |
 | r2 | 2026-08-05 | §6/T-03: the `hash_equals` **timing test** is replaced by a **mechanism assertion**. Rationale below; see [ADR-0027](../adr/0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md). |
+| r8 | 2026-08-06 | §2/§5: FR-33's guarantee moves from convention to **type** (item 10.7) — `SqlStatement`'s constructor becomes private behind `literal()` (a `literal-string`, enforced by the PHPStan max level CI already runs), `fromQueryBuilder()` and `composed()`. Verified by planting four interpolation mistakes (all rejected) against four legitimate shapes including hand-written dialect SQL (all accepted). A second pre-1.0 break to the same class, migrated in the same PR. See [ADR-0041](../adr/0041-constrain-sql-text-by-type-and-name-the-one-escape-hatch.md), which amends ADR-0039. |
 | r7 | 2026-08-06 | §2/§5: FR-33 realized as the only shape `DatabaseConnection::select()`/`selectOne()`/`execute()` accept — the `(string, array)` pair is retired in favor of one `SqlStatement` argument (item 10.1, opens Milestone 10). A pre-1.0 breaking change to the `Database` group's public signature, permitted and migrated in the same PR. See [ADR-0039](../adr/0039-sql-text-and-its-parameters-become-one-value-not-two-arguments.md). |
 | r6 | 2026-08-06 | §2/§6: FR-32 stated to the precision item 9.5 implemented (one lock across the read-modify-write, corrupt state refused rather than reset, the caller-supplied window and its recorded ordering limit); FR-22/23 gains `File::update()`, without which a safe counter cannot be built from this library's primitives; §6 gains suite **T-14** (multi-process concurrency: each number issued exactly once, cap holds). Additive; see [ADR-0038](../adr/0038-one-lock-across-the-read-and-the-write-and-a-sequence-that-refuses-to-wrap.md). |
 | r5 | 2026-08-06 | §2: FR-28/FR-29 stated to the precision item 9.4 implemented (PHP's backslash escape disabled, the single-empty-field and zero-column shapes, blank-line handling, the enforced header/row pairing, the guard's leader set); FR-22/23 gains `File::writeStream()`, without which a streaming CSV could not honour NFR-12; `CsvException` added to the exception enumeration. Additive; see [ADR-0037](../adr/0037-disable-phps-escape-character-and-keep-the-formula-guard-opt-in.md). |

--- a/src/main/php/d4np/utils/Database/QueryBuilder.php
+++ b/src/main/php/d4np/utils/Database/QueryBuilder.php
@@ -340,7 +340,7 @@ final class QueryBuilder
      */
     public function get(): array
     {
-        return $this->connection->select(new SqlStatement($this->toSql(), $this->bindings));
+        return $this->connection->select(SqlStatement::fromQueryBuilder($this));
     }
 
     /**
@@ -352,7 +352,7 @@ final class QueryBuilder
      */
     public function first(): ?array
     {
-        return $this->connection->selectOne(new SqlStatement($this->toSql(), $this->bindings));
+        return $this->connection->selectOne(SqlStatement::fromQueryBuilder($this));
     }
 
     /**

--- a/src/main/php/d4np/utils/Database/SqlStatement.php
+++ b/src/main/php/d4np/utils/Database/SqlStatement.php
@@ -6,35 +6,107 @@ namespace D4np\Utils\Database;
 
 /**
  * An immutable pairing of SQL text and the parameters bound to it (spec r3 FR-33, RFC-0002;
- * ADR-0039).
+ * ADR-0039, amended by ADR-0041).
  *
- * **The narrow waist, not a new safety mechanism.** The surveyed estate's query-factory
- * classes never had a type that forced text and parameters to travel together: a method
- * signature of `execute(string $sql, array $params = [])` does not stop a caller from
- * writing `execute("... {$value} ...")` and leaving `$params` empty — nothing in that shape
- * distinguishes "I forgot to bind" from "there is nothing to bind". That is exactly the
- * estate's failure mode (199 interpolation sites, 0 bound parameters), and no amount of
- * discipline at each of 199 call sites prevented it.
+ * **The guarantee is mechanical, not organizational.** The surveyed estate's query factories
+ * interpolated request values into SQL text at 199 sites while binding none, and a signature
+ * of `(string $sql, array $parameters = [])` cannot tell "there is nothing to bind" from "I
+ * forgot to bind" — every one of those 199 sites would type-check against it. So the text
+ * this class accepts is constrained by *type*: {@see self::literal()} takes a
+ * `literal-string`, which PHPStan at max level — a gate this repository already runs on every
+ * PR — **refuses** for an interpolated `"… {$value} …"` or a `'…' . $value` concatenation,
+ * while accepting hand-written SQL with placeholders, which is exactly what FR-33 exists to
+ * allow.
  *
- * `SqlStatement` does not make binding safer at the byte level — `DatabaseConnection`
- * already only ever executes through real prepares (ADR-0014), so a value bound through
- * either shape was equally safe on the wire. What it changes is where a reviewer has to
- * look: after this class exists, {@see DatabaseConnection}'s query methods accept **only**
- * a `SqlStatement`, so there is exactly one place in this codebase where SQL text and
- * parameters are still two separate variables that could be assembled wrongly —
- * {@see QueryBuilder::toSql()}/{@see QueryBuilder::bindings()} and this class's own
- * constructor call. Every other caller, present and future ({@see \D4np\Utils\Persistence}'s
- * upcoming `Repository`, roadmap 10.3), receives or builds a `SqlStatement` and cannot
- * un-pair it.
+ * There are three ways in, and which one a call site uses is the review signal:
+ *
+ * | constructor | what it promises | who checks |
+ * |---|---|---|
+ * | {@see self::literal()} | the text is a compile-time literal | **PHPStan** |
+ * | {@see self::fromQueryBuilder()} | the text came from {@see QueryBuilder} | that class's allowlist (ADR-0015) |
+ * | {@see self::composed()} | the caller asserts the assembled text holds no untrusted value | **a human, at review** |
+ *
+ * `composed()` has **zero uses inside this library**, deliberately — that is what makes
+ * `grep composed(` a list of exactly the places a person had to think, rather than a list
+ * diluted by the library's own routine calls.
+ *
+ * The constructor is private so that no fourth, unconstrained way in exists. That is also what
+ * lets the named constructors above widen the type with **no suppression of any kind** — no
+ * analyser-ignore comment, no inline type override, both of which this project forbids: the
+ * private constructor's own parameter is a plain `string`, and each public entry point states
+ * in its signature what it is promising.
+ *
+ * (Naming an ignore-comment tag verbatim in this docblock is not possible, incidentally —
+ * PHPStan parses one wherever it appears, including inside prose, and fails on it. Found by
+ * writing this sentence the obvious way first.)
  */
 final class SqlStatement
 {
     /**
      * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
      */
-    public function __construct(
+    private function __construct(
         public readonly string $sql,
-        public readonly array $parameters = [],
+        public readonly array $parameters,
     ) {
+    }
+
+    /**
+     * A statement whose text is written out in the source, with `?` or `:name` placeholders
+     * for every value.
+     *
+     * **The normal way to build one.** `$sql` is a `literal-string`: PHPStan accepts a quoted
+     * string and the concatenation of quoted strings, and rejects any text that a runtime
+     * value reached — so the mistake this class exists to prevent is a static-analysis
+     * failure rather than a convention. Dialect SQL that {@see QueryBuilder} does not model is
+     * welcome here; being hand-written is not the problem, being *assembled from values* is.
+     *
+     * @param literal-string           $sql
+     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
+     */
+    public static function literal(string $sql, array $parameters = []): self
+    {
+        return new self($sql, $parameters);
+    }
+
+    /**
+     * The statement a {@see QueryBuilder} represents.
+     *
+     * Takes the builder rather than its `toSql()` string on purpose: no SQL text crosses this
+     * boundary as a bare argument, so the library's own composed SQL needs no escape hatch and
+     * {@see self::composed()} keeps its zero in-library usage count. The text is safe for
+     * ADR-0015's reason — identifiers pass the allowlist and are driver-quoted, values are
+     * bound — which is a property of `QueryBuilder`, asserted by its own suite, not of this
+     * method.
+     */
+    public static function fromQueryBuilder(QueryBuilder $builder): self
+    {
+        return new self($builder->toSql(), $builder->bindings());
+    }
+
+    /**
+     * A statement whose text was assembled at runtime.
+     *
+     * **The escape hatch, and the only one.** It exists because some legitimate SQL cannot be
+     * a literal: a bulk `INSERT … VALUES (?,?),(?,?),…` or an `IN (?,?,?)` whose placeholder
+     * count depends on the data has to be built with `implode()`, and `implode()`'s result is
+     * not a `literal-string` however safe its inputs were.
+     *
+     * Calling this is an assertion **by the caller** that the assembled text contains no value
+     * from outside the program — that everything variable in it is a placeholder, and every
+     * value travels in `$parameters`. PHPStan cannot check that, which is the entire reason
+     * this method is named rather than being the constructor: `grep composed(` is the review
+     * list.
+     *
+     * Deliberately **not** called `unsafe*()`. Nothing here is unsafe by construction — values
+     * still bind through {@see DatabaseConnection}'s real prepares (ADR-0014) — and a name that
+     * cries wolf on every legitimate bulk insert is a name that gets ignored on the one call
+     * that deserved attention.
+     *
+     * @param array<string|int, mixed> $parameters bound as parameters — never interpolated
+     */
+    public static function composed(string $sql, array $parameters = []): self
+    {
+        return new self($sql, $parameters);
     }
 }

--- a/src/main/php/d4np/utils/Database/Transaction.php
+++ b/src/main/php/d4np/utils/Database/Transaction.php
@@ -20,8 +20,8 @@ use Throwable;
  *
  * ```php
  * $total = (new Transaction($connection))->run(function (DatabaseConnection $db): int {
- *     $db->execute(new SqlStatement('UPDATE accounts SET balance = balance - ? WHERE id = ?', [100, 1]));
- *     $db->execute(new SqlStatement('UPDATE accounts SET balance = balance + ? WHERE id = ?', [100, 2]));
+ *     $db->execute(SqlStatement::literal('UPDATE accounts SET balance = balance - ? WHERE id = ?', [100, 1]));
+ *     $db->execute(SqlStatement::literal('UPDATE accounts SET balance = balance + ? WHERE id = ?', [100, 2]));
  *
  *     return 2;
  * });

--- a/src/test/php/d4np/utils/Database/DatabaseConnectionTest.php
+++ b/src/test/php/d4np/utils/Database/DatabaseConnectionTest.php
@@ -32,7 +32,7 @@ final class DatabaseConnectionTest extends TestCase
     private function connect(): DatabaseConnection
     {
         $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
-        $connection->execute(new SqlStatement('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)'));
+        $connection->execute(SqlStatement::literal('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)'));
 
         return $connection;
     }
@@ -67,9 +67,9 @@ final class DatabaseConnectionTest extends TestCase
     public function testSelectReturnsAssociativeArraysOnly(): void
     {
         $connection = $this->connect();
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
 
-        $rows = $connection->select(new SqlStatement('SELECT name, age FROM users'));
+        $rows = $connection->select(SqlStatement::literal('SELECT name, age FROM users'));
 
         // FETCH_BOTH would additionally carry 0 and 1; asserting the exact key set is the point.
         self::assertSame([['name' => 'Grace', 'age' => 45]], $rows);
@@ -82,7 +82,7 @@ final class DatabaseConnectionTest extends TestCase
     public function testThePinnedFetchModeAppliesToStatementsRunOnTheRawPdo(): void
     {
         $connection = $this->connect();
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
 
         // No fetch mode passed anywhere here: whatever comes back is the pinned default's doing.
         $statement = $connection->pdo()->query('SELECT name, age FROM users');
@@ -147,33 +147,33 @@ final class DatabaseConnectionTest extends TestCase
 
     public function testSelectOneReturnsNullRatherThanFalseWhenThereIsNoRow(): void
     {
-        self::assertNull($this->connect()->selectOne(new SqlStatement('SELECT * FROM users WHERE id = ?', [404])));
+        self::assertNull($this->connect()->selectOne(SqlStatement::literal('SELECT * FROM users WHERE id = ?', [404])));
     }
 
     public function testSelectOneReturnsTheFirstRow(): void
     {
         $connection = $this->connect();
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
 
-        self::assertSame(['id' => 1, 'name' => 'Ada', 'age' => 36], $connection->selectOne(new SqlStatement('SELECT * FROM users ORDER BY id')));
+        self::assertSame(['id' => 1, 'name' => 'Ada', 'age' => 36], $connection->selectOne(SqlStatement::literal('SELECT * FROM users ORDER BY id')));
     }
 
     public function testExecuteReportsAffectedRows(): void
     {
         $connection = $this->connect();
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
 
-        self::assertSame(2, $connection->execute(new SqlStatement('UPDATE users SET age = age + 1')));
+        self::assertSame(2, $connection->execute(SqlStatement::literal('UPDATE users SET age = age + 1')));
     }
 
     public function testNamedParametersBind(): void
     {
         $connection = $this->connect();
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (:name, :age)', ['name' => 'Ada', 'age' => 36]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (:name, :age)', ['name' => 'Ada', 'age' => 36]));
 
-        self::assertSame([['name' => 'Ada']], $connection->select(new SqlStatement('SELECT name FROM users WHERE age = :age', ['age' => 36])));
+        self::assertSame([['name' => 'Ada']], $connection->select(SqlStatement::literal('SELECT name FROM users WHERE age = :age', ['age' => 36])));
     }
 
     /**
@@ -188,23 +188,23 @@ final class DatabaseConnectionTest extends TestCase
         $connection = $this->connect();
         $payload = "Robert'); DROP TABLE users;--";
 
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]));
 
-        self::assertSame($payload, $connection->selectOne(new SqlStatement('SELECT name FROM users'))['name'] ?? null);
-        self::assertSame([['n' => 1]], $connection->select(new SqlStatement('SELECT COUNT(*) AS n FROM users')));
+        self::assertSame($payload, $connection->selectOne(SqlStatement::literal('SELECT name FROM users'))['name'] ?? null);
+        self::assertSame([['n' => 1]], $connection->select(SqlStatement::literal('SELECT COUNT(*) AS n FROM users')));
     }
 
     public function testAFailingStatementRaisesTheLibraryException(): void
     {
         $this->expectException(DatabaseException::class);
 
-        $this->connect()->select(new SqlStatement('SELECT * FROM a_table_that_does_not_exist'));
+        $this->connect()->select(SqlStatement::literal('SELECT * FROM a_table_that_does_not_exist'));
     }
 
     public function testTheFailureCarriesThePdoExceptionAsItsCause(): void
     {
         try {
-            $this->connect()->select(new SqlStatement('THIS IS NOT SQL'));
+            $this->connect()->select(SqlStatement::literal('THIS IS NOT SQL'));
             self::fail('expected a DatabaseException');
         } catch (DatabaseException $e) {
             self::assertInstanceOf(\PDOException::class, $e->getPrevious());
@@ -217,7 +217,7 @@ final class DatabaseConnectionTest extends TestCase
     public function testTheFailureMessageDoesNotEchoTheStatement(): void
     {
         try {
-            $this->connect()->select(new SqlStatement('SELECT * FROM missing_table WHERE secret = 1'));
+            $this->connect()->select(SqlStatement::literal('SELECT * FROM missing_table WHERE secret = 1'));
             self::fail('expected a DatabaseException');
         } catch (DatabaseException $e) {
             self::assertStringNotContainsString('secret', $e->getMessage());

--- a/src/test/php/d4np/utils/Database/InjectionTest.php
+++ b/src/test/php/d4np/utils/Database/InjectionTest.php
@@ -56,9 +56,9 @@ final class InjectionTest extends TestCase
         $pdo->setAttribute(PDO::ATTR_STATEMENT_CLASS, [LoggedStatement::class, [$this->log]]);
 
         $this->connection = new DatabaseConnection($pdo);
-        $this->connection->execute(new SqlStatement('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)'));
-        $this->connection->execute(new SqlStatement('CREATE TABLE secrets (token TEXT)'));
-        $this->connection->execute(new SqlStatement("INSERT INTO secrets (token) VALUES ('do-not-leak')"));
+        $this->connection->execute(SqlStatement::literal('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)'));
+        $this->connection->execute(SqlStatement::literal('CREATE TABLE secrets (token TEXT)'));
+        $this->connection->execute(SqlStatement::literal("INSERT INTO secrets (token) VALUES ('do-not-leak')"));
 
         // Only the payload traffic matters; drop the fixture's own setup from the log.
         $this->log->entries = [];
@@ -138,7 +138,7 @@ final class InjectionTest extends TestCase
     #[DataProvider('payloads')]
     public function testConnectionExecuteBindsRatherThanInterpolates(string $payload): void
     {
-        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', [$payload]));
+        $this->connection->execute(SqlStatement::literal('INSERT INTO users (name) VALUES (?)', [$payload]));
 
         $this->assertNeverInStatementText($payload);
     }
@@ -146,7 +146,7 @@ final class InjectionTest extends TestCase
     #[DataProvider('payloads')]
     public function testConnectionSelectBindsRatherThanInterpolates(string $payload): void
     {
-        $this->connection->select(new SqlStatement('SELECT * FROM users WHERE name = ?', [$payload]));
+        $this->connection->select(SqlStatement::literal('SELECT * FROM users WHERE name = ?', [$payload]));
 
         $this->assertNeverInStatementText($payload);
     }
@@ -154,7 +154,7 @@ final class InjectionTest extends TestCase
     #[DataProvider('payloads')]
     public function testConnectionSelectOneBindsRatherThanInterpolates(string $payload): void
     {
-        $this->connection->selectOne(new SqlStatement('SELECT * FROM users WHERE name = :name', ['name' => $payload]));
+        $this->connection->selectOne(SqlStatement::literal('SELECT * FROM users WHERE name = :name', ['name' => $payload]));
 
         $this->assertNeverInStatementText($payload);
     }
@@ -185,7 +185,7 @@ final class InjectionTest extends TestCase
     public function testBindingHoldsInsideATransaction(string $payload): void
     {
         (new Transaction($this->connection))->run(function () use ($payload): void {
-            $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', [$payload]));
+            $this->connection->execute(SqlStatement::literal('INSERT INTO users (name) VALUES (?)', [$payload]));
         });
 
         $this->assertNeverInStatementText($payload);
@@ -199,14 +199,14 @@ final class InjectionTest extends TestCase
     #[DataProvider('payloads')]
     public function testThePayloadRoundTripsAndTheSchemaSurvives(string $payload): void
     {
-        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', [$payload]));
+        $this->connection->execute(SqlStatement::literal('INSERT INTO users (name) VALUES (?)', [$payload]));
 
-        $row = $this->connection->selectOne(new SqlStatement('SELECT name FROM users WHERE name = ?', [$payload]));
+        $row = $this->connection->selectOne(SqlStatement::literal('SELECT name FROM users WHERE name = ?', [$payload]));
 
         self::assertSame($payload, $row['name'] ?? null);
-        self::assertSame([['n' => 1]], $this->connection->select(new SqlStatement('SELECT COUNT(*) AS n FROM users')));
+        self::assertSame([['n' => 1]], $this->connection->select(SqlStatement::literal('SELECT COUNT(*) AS n FROM users')));
         // Exfiltration and destruction both leave traces here.
-        self::assertSame([['n' => 1]], $this->connection->select(new SqlStatement('SELECT COUNT(*) AS n FROM secrets')));
+        self::assertSame([['n' => 1]], $this->connection->select(SqlStatement::literal('SELECT COUNT(*) AS n FROM secrets')));
     }
 
     /**
@@ -217,8 +217,8 @@ final class InjectionTest extends TestCase
      */
     public function testATautologyMatchesNothingBecauseItIsAValue(): void
     {
-        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', ['Ada']));
-        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', ['Grace']));
+        $this->connection->execute(SqlStatement::literal('INSERT INTO users (name) VALUES (?)', ['Ada']));
+        $this->connection->execute(SqlStatement::literal('INSERT INTO users (name) VALUES (?)', ['Grace']));
 
         $rows = (new QueryBuilder($this->connection, 'users'))
             ->where('name', Operator::Equals, "' OR '1'='1")
@@ -241,8 +241,8 @@ final class InjectionTest extends TestCase
      */
     public function testLikeWildcardsAreNeutralisedWhileTheValueStillBinds(): void
     {
-        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', ['secret-document']));
-        $this->connection->execute(new SqlStatement('INSERT INTO users (name) VALUES (?)', ['public-note']));
+        $this->connection->execute(SqlStatement::literal('INSERT INTO users (name) VALUES (?)', ['secret-document']));
+        $this->connection->execute(SqlStatement::literal('INSERT INTO users (name) VALUES (?)', ['public-note']));
 
         // Unescaped, a lone '%' still matches everything — it is legitimate pattern syntax, and
         // neutralising it unconditionally would break every prefix search in the library.

--- a/src/test/php/d4np/utils/Database/QueryBuilderTest.php
+++ b/src/test/php/d4np/utils/Database/QueryBuilderTest.php
@@ -35,7 +35,7 @@ final class QueryBuilderTest extends TestCase
     private function connection(): DatabaseConnection
     {
         $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
-        $connection->execute(new SqlStatement('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)'));
+        $connection->execute(SqlStatement::literal('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)'));
 
         return $connection;
     }
@@ -298,9 +298,9 @@ final class QueryBuilderTest extends TestCase
     public function testEndToEndAgainstARealDriver(): void
     {
         $connection = $this->connection();
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Ada', 36]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Alan', 41]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', ['Grace', 45]));
 
         $rows = (new QueryBuilder($connection, 'users'))
             ->select('name')
@@ -324,11 +324,11 @@ final class QueryBuilderTest extends TestCase
     {
         $connection = $this->connection();
         $payload = "'; DROP TABLE users; --";
-        $connection->execute(new SqlStatement('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]));
+        $connection->execute(SqlStatement::literal('INSERT INTO users (name, age) VALUES (?, ?)', [$payload, 1]));
 
         $row = (new QueryBuilder($connection, 'users'))->where('name', Operator::Equals, $payload)->first();
 
         self::assertSame($payload, $row['name'] ?? null);
-        self::assertSame([['n' => 1]], $connection->select(new SqlStatement('SELECT COUNT(*) AS n FROM users')));
+        self::assertSame([['n' => 1]], $connection->select(SqlStatement::literal('SELECT COUNT(*) AS n FROM users')));
     }
 }

--- a/src/test/php/d4np/utils/Database/SqlStatementTest.php
+++ b/src/test/php/d4np/utils/Database/SqlStatementTest.php
@@ -4,21 +4,39 @@ declare(strict_types=1);
 
 namespace D4np\Utils\Tests\Database;
 
+use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\Operator;
+use D4np\Utils\Database\QueryBuilder;
 use D4np\Utils\Database\SqlStatement;
+use PDO;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
 
 /**
- * `SqlStatement` — spec r3 FR-33 (RFC-0002), ADR-0039.
+ * `SqlStatement` — spec r3 FR-33 (RFC-0002), ADR-0039 as amended by ADR-0041.
  *
- * The class has no behaviour beyond pairing two readonly values, so what is worth asserting is
- * exactly that pairing: both fields are readable back unchanged, and a statement with nothing to
- * bind does not require a caller to say so.
+ * The value semantics are trivial and asserted first. What is *not* trivial, and what item 10.7
+ * exists for, is the `literal-string` constraint on {@see SqlStatement::literal()}: a
+ * static-analysis property that no runtime test can exercise, because by the time PHP is running
+ * the string is just a string.
+ *
+ * So it is asserted the way ADR-0027 asserts constant-time comparison — **as a mechanism, read
+ * from the source**. The proof that PHPStan actually rejects an interpolated argument is in
+ * ADR-0041, produced by planting the two mistakes and running the analyser; what the assertions
+ * below defend is that the annotation which makes that proof hold is still there, and that no
+ * fourth unconstrained way into the class has appeared beside it.
  */
+#[Group('T-02')]
 final class SqlStatementTest extends TestCase
 {
+    // ---- value semantics -----------------------------------------------------------------------
+
     public function testSqlAndParametersAreReadableBack(): void
     {
-        $statement = new SqlStatement('SELECT * FROM users WHERE id = ?', [42]);
+        $statement = SqlStatement::literal('SELECT * FROM users WHERE id = ?', [42]);
 
         self::assertSame('SELECT * FROM users WHERE id = ?', $statement->sql);
         self::assertSame([42], $statement->parameters);
@@ -26,15 +44,99 @@ final class SqlStatementTest extends TestCase
 
     public function testParametersDefaultToEmpty(): void
     {
-        $statement = new SqlStatement('SELECT 1');
-
-        self::assertSame([], $statement->parameters);
+        self::assertSame([], SqlStatement::literal('SELECT 1')->parameters);
     }
 
     public function testNamedParametersAreKeptByName(): void
     {
-        $statement = new SqlStatement('SELECT * FROM users WHERE age = :age', ['age' => 36]);
+        $statement = SqlStatement::literal('SELECT * FROM users WHERE age = :age', ['age' => 36]);
 
         self::assertSame(['age' => 36], $statement->parameters);
+    }
+
+    public function testComposedCarriesTextAndParametersLikeLiteralDoes(): void
+    {
+        // The shape the escape hatch exists for: a placeholder count that depends on the data,
+        // so the text cannot be a literal however safe its inputs are.
+        $values = ['a', 'b', 'c'];
+        $sql = 'SELECT * FROM users WHERE name IN (' . implode(', ', array_fill(0, count($values), '?')) . ')';
+
+        $statement = SqlStatement::composed($sql, $values);
+
+        self::assertSame('SELECT * FROM users WHERE name IN (?, ?, ?)', $statement->sql);
+        self::assertSame($values, $statement->parameters);
+    }
+
+    // ---- the mechanism (ADR-0041) --------------------------------------------------------------
+
+    /**
+     * The annotation is the whole guarantee. Removing it would leave every test in this suite
+     * green — the strings are literals either way — and silently reopen the class to
+     * interpolated text, which is exactly the failure ADR-0027 names for behavioural tests of
+     * a non-behavioural property.
+     */
+    public function testTheLiteralConstructorConstrainsItsSqlToALiteralString(): void
+    {
+        $doc = (new ReflectionMethod(SqlStatement::class, 'literal'))->getDocComment();
+
+        self::assertIsString($doc, 'literal() must carry a docblock: it is where the constraint lives');
+        self::assertMatchesRegularExpression(
+            '/@param\s+literal-string\s+\$sql/',
+            $doc,
+            'literal() must annotate $sql as literal-string, or PHPStan stops refusing interpolated SQL',
+        );
+    }
+
+    /**
+     * A public constructor would be a fourth way in, unconstrained, and would make the
+     * annotation above decorative — `new SqlStatement($anything)` would type-check.
+     */
+    public function testThereIsNoPublicConstructor(): void
+    {
+        $constructor = (new ReflectionClass(SqlStatement::class))->getConstructor();
+
+        self::assertNotNull($constructor);
+        self::assertTrue(
+            $constructor->isPrivate(),
+            'the constructor must stay private: it is the only parameter in this class not '
+            . 'constrained to a literal-string, and a public one would bypass literal()',
+        );
+    }
+
+    /**
+     * The named constructors are the complete public surface, and the list is pinned so that
+     * adding a fourth one is a deliberate act with a test to update rather than a quiet
+     * widening. `composed()` is the only one taking unconstrained text, which is what makes
+     * `grep composed(` the review list ADR-0041 relies on.
+     */
+    public function testTheOnlyWaysInAreTheThreeNamedConstructors(): void
+    {
+        $entryPoints = array_values(array_map(
+            static fn (ReflectionMethod $m): string => $m->getName(),
+            array_filter(
+                (new ReflectionClass(SqlStatement::class))->getMethods(ReflectionMethod::IS_PUBLIC),
+                static fn (ReflectionMethod $m): bool => $m->isStatic(),
+            ),
+        ));
+
+        sort($entryPoints);
+
+        self::assertSame(['composed', 'fromQueryBuilder', 'literal'], $entryPoints);
+    }
+
+    // ---- fromQueryBuilder ----------------------------------------------------------------------
+
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testFromQueryBuilderCarriesTheBuildersOwnSqlAndBindings(): void
+    {
+        $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
+        $builder = (new QueryBuilder($connection, 'users'))
+            ->where('name', Operator::Equals, 'Ada')
+            ->where('age', Operator::GreaterThan, 30);
+
+        $statement = SqlStatement::fromQueryBuilder($builder);
+
+        self::assertSame($builder->toSql(), $statement->sql);
+        self::assertSame($builder->bindings(), $statement->parameters);
     }
 }

--- a/src/test/php/d4np/utils/Database/TransactionTest.php
+++ b/src/test/php/d4np/utils/Database/TransactionTest.php
@@ -33,7 +33,7 @@ final class TransactionTest extends TestCase
     protected function setUp(): void
     {
         $this->connection = new DatabaseConnection(new PDO('sqlite::memory:'));
-        $this->connection->execute(new SqlStatement('CREATE TABLE t (v TEXT)'));
+        $this->connection->execute(SqlStatement::literal('CREATE TABLE t (v TEXT)'));
     }
 
     private function transaction(): Transaction
@@ -52,13 +52,13 @@ final class TransactionTest extends TestCase
 
                 return $row['v'];
             },
-            $this->connection->select(new SqlStatement('SELECT v FROM t ORDER BY rowid')),
+            $this->connection->select(SqlStatement::literal('SELECT v FROM t ORDER BY rowid')),
         );
     }
 
     private function insert(string $value): void
     {
-        $this->connection->execute(new SqlStatement('INSERT INTO t (v) VALUES (?)', [$value]));
+        $this->connection->execute(SqlStatement::literal('INSERT INTO t (v) VALUES (?)', [$value]));
     }
 
     public function testWorkIsCommittedWhenTheClosureReturns(): void
@@ -298,7 +298,7 @@ final class TransactionTest extends TestCase
             }
         };
         $connection = new DatabaseConnection($pdo);
-        $connection->execute(new SqlStatement('CREATE TABLE t (v TEXT)'));
+        $connection->execute(SqlStatement::literal('CREATE TABLE t (v TEXT)'));
 
         $original = new LogicException('the reason the caller needs');
         $caught = null;

--- a/src/test/php/d4np/utils/Security/SanitizerTest.php
+++ b/src/test/php/d4np/utils/Security/SanitizerTest.php
@@ -63,9 +63,9 @@ final class SanitizerTest extends TestCase
     private function seeded(): DatabaseConnection
     {
         $connection = new DatabaseConnection(new PDO('sqlite::memory:'));
-        $connection->execute(new SqlStatement('CREATE TABLE t (v TEXT)'));
+        $connection->execute(SqlStatement::literal('CREATE TABLE t (v TEXT)'));
         foreach (['100%', '100X', '1000', 'a_b', 'axb', 'plain'] as $value) {
-            $connection->execute(new SqlStatement('INSERT INTO t (v) VALUES (?)', [$value]));
+            $connection->execute(SqlStatement::literal('INSERT INTO t (v) VALUES (?)', [$value]));
         }
 
         return $connection;


### PR DESCRIPTION
## Summary

Roadmap item **10.7**: FR-33's guarantee stops being a convention and becomes a **type**.
`SqlStatement`'s constructor is now private behind three named entry points, and
`SqlStatement::literal()` takes a `literal-string` — so the PHPStan max level this project
already runs on every PR **refuses** interpolated, concatenated, `sprintf()`-ed or
`implode()`-ed statement text.

Taken ahead of 10.2 at the maintainer's direction: `Repository` and `TableGateway` (10.3–10.4)
are the callers the guarantee exists for, and they should inherit it before they are written.

## Motivation

ADR-0039 wrote *"a type-level guarantee catches what a string never announces; a runtime
heuristic cannot"* — and shipped a constructor taking a plain `string`. Its Alternatives section
weighed a **runtime** placeholder-counting assertion and rejected it correctly, then never
considered the **static** option. That omission is what the item-10.1 review filed as 10.7, and
this PR closes it.

## The design change the project's own rules forced

The filed plan said "annotate the constructor". That does not survive contact with the escape
hatch: `composed()` must accept runtime-assembled text, and if the annotated constructor were
public, `composed()` could only reach it by overriding the analyser — which this project forbids
outright (no ignore comments, no inline type overrides; PHPStan's own output says so). **A
guarantee that must be suppressed to implement is not a guarantee.**

So the constructor is **private**, and the class exposes exactly three named entry points:

| entry point | promises | enforced by |
|---|---|---|
| `SqlStatement::literal(literal-string $sql, …)` | the text is a compile-time literal | **PHPStan**, every PR |
| `SqlStatement::fromQueryBuilder(QueryBuilder $b)` | the text came from the builder | `QueryBuilder`'s allowlist (ADR-0015) |
| `SqlStatement::composed(string $sql, …)` | the caller asserts the assembled text holds no untrusted value | **a human, at review** |

`composed()` has **zero uses inside this library** — which is exactly why `fromQueryBuilder()`
takes the *builder object* rather than its `toSql()` string. `grep composed(` is meant to return
the places a person had to think; two routine library calls would dilute it. (The alternative —
`QueryBuilder` calling `composed()` itself, which would have been *truthful* — was rejected on
that, and the trade-off is recorded in ADR-0041.)

## Proved non-vacuous: 4 planted, 4 caught; 4 legitimate shapes, 4 passing

| probe | verdict |
|---|---|
| `literal("… name = '{$userValue}'")` | **rejected** |
| `literal('… name = ' . $userValue)` | **rejected** |
| `literal(sprintf('… name = %s', $userValue))` | **rejected** |
| `literal('… IN (' . implode(',', $values) . ')')` | **rejected** |
| `literal('… WHERE id = ?', [1])` | passes |
| `literal('SELECT * FROM users' . ' WHERE id = ?', [1])` | passes |
| `literal('SELECT c FROM stock WHERE code[1, ?] = ?', [$len, $code])` | **passes** |
| `composed('… IN (' . implode(…) . ')', $values)` | passes |

The seventh row is the one checked *before* committing to this design: hand-written dialect SQL
with a positional substring predicate is **FR-33's whole reason to exist**, and `literal-string`
permits it. Being hand-written was never the problem; being assembled from values is.

## Changes

- **`SqlStatement`** — private constructor; `literal()`, `fromQueryBuilder()`, `composed()`.
- **`QueryBuilder::get()/first()`** — now `SqlStatement::fromQueryBuilder($this)`.
- **51 call sites** migrated `new SqlStatement(…)` → `SqlStatement::literal(…)` across
  `Transaction`'s docblock and five test files.
- **`SqlStatementTest`** — value semantics, the escape hatch, `fromQueryBuilder()` fidelity, and
  three **mechanism assertions** (ADR-0027's pattern, since no runtime test can exercise a
  static property): the annotation is present, the constructor is still private, and the public
  static surface is exactly those three names — the last pinned so a fourth entry point is a
  deliberate act with a test to update. Deleting the annotation leaves every other test green,
  which is why that assertion exists.
- **ADR-0041**, amending **ADR-0039** — which is *annotated, not silently edited* (ADR-0020's
  precedent for ADR-0018), including its own half-truth that the constructor was "exactly one
  place": `new SqlStatement(...)` was written at every call site, so the risky-site count never
  dropped.
- **Spec → r8**, ROADMAP 10.7 checked, CHANGELOG under `Changed`, session journal.

## Two costs, named rather than smoothed

1. **A second breaking change to this class in two PRs.** Item 10.1 retired `(string, array)`;
   this retires `new SqlStatement(...)`. Pre-1.0 permits both (SemVer §4) — but one PR should
   have shipped both, and the reason it did not is ADR-0039's unexamined alternative. ADR-0041
   records that as the process finding it is.
2. **`composed()` is exactly as unchecked as everything was before it.** A consumer who calls it
   carelessly is no safer. This moves that failure from invisible to reviewable, which is worth
   doing and is not the same as preventing it.

## Design Patterns

- None newly catalogued. Named constructors over a private constructor is idiomatic PHP, not a
  catalogued pattern adoption; consistent with how items 9.3–9.5 and 10.1 were treated.

## Verification

- [x] `vendor/bin/phpstan analyse` (max level) — no errors on the clean tree; **4 planted
      mistakes rejected**, 4 legitimate shapes accepted (table above)
- [x] `vendor/bin/phpunit` — 1609 tests (+5), 3454 assertions, 9 pre-existing skips, green
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 of 191 files
- [x] `vendor/bin/deptrac analyse` — 0 violations, 0 uncovered, 170 allowed (no new edge;
      `SqlStatement` and `QueryBuilder` are both in `Database`)
- [x] `python tools/consistency_lint.py` passes
- [x] Leak-gate grep — clean (with word boundaries; "o**missio**n" is the documented false
      positive)
- [ ] `tools/action_pin_lint.py` — N/A, no workflow touched

## Documentation Impact

- [x] ADR added — **ADR-0041**; **ADR-0039 annotated** rather than edited
- [x] Spec updated — r8 (FR-33 and §5)
- [x] ROADMAP.md — 10.7 checked
- [x] CHANGELOG.md — under `Changed`
- [ ] README.md — unchanged (M10 still in progress)
- [ ] docs/patterns/README.md — unchanged (see Design Patterns)
- [x] PR metadata — assignee (owner), label `enhancement`, milestone `v0.9.0`

## Lesson

Lesson: when an ADR names the right mechanism and then ships something else, that sentence is
the finding — read your own Alternatives sections as a list of what you decided not to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
