### PR TITLE
test(persistence): T-13, and the corpus that was protecting only the older builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **Spec §7's T-13 suite** (roadmap item **10.5**; spec **r12**) — 578 tests proving, at the PDO
+  boundary, that every `TableGateway`/`Repository`/`MutationBuilder` path sends **placeholders
+  only**, with the payload appearing solely in the bound-parameter array. Two legs: the value
+  corpus across every value-accepting surface (including inside a transaction and with a
+  `RowNormalizer` configured), and the hostile-identifier corpus across every surface where a
+  column name can arrive from a caller — the latter asserting not just the refusal but that
+  **nothing was prepared**, since a refusal issued after the driver already had the statement
+  would pass any exception assertion. Adds three consequence assertions a boundary check cannot
+  make: the payload round-trips through hydration intact, a tautology criterion matches and
+  deletes nothing, and an `UPDATE`'s `SET` values bind **before** its `WHERE` criteria.
+
+### Changed
+
+- **One injection corpus, shared** (item 10.5) — the value and identifier payload lists move into
+  a single `InjectionPayloads` fixture used by T-02, T-13 and both builder suites. `MutationBuilder`
+  had shipped with a **shorter copy** of the identifier corpus at item 10.4 (ten payloads against
+  the read builder's nineteen), so the newer builder was being held to the weaker list while both
+  suites stayed green — the same "two rules, the weaker decides" failure ADR-0044 argues about for
+  the allowlist itself. No production behaviour changes; the write builder now faces 21 identifier
+  payloads instead of 10.
+
 - **`D4np\Utils\Persistence\TableGateway`** (spec r11 **FR-35**, RFC-0002; roadmap item **10.4**;
   **ADR-0044**; patterns catalogue: *Table Data Gateway*, the catalogue's first entry) — one
   object per table: `find()`, `all()`, `findBy()`, `findOneBy()`, `insert()`, `update()`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -908,6 +908,23 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       escaped set is now a CI artifact with a per-mutator breakdown but is **not** chased here;
       and the MSI cannot be measured on the maintainer's machine (no coverage driver — the
       same limit as the suite's 9 skips and item 9.6's benchmark caveat).*
+- [ ] 10.9 Decide what the >10% regression gate should do about **I/O-bound and memory-hard
+      subjects**, which it currently cannot measure to that precision. Filed from evidence
+      produced by item 10.5, a **test-only** PR whose diff touches no file under `src/main`
+      (verified, not assumed): the gate failed with
+      `FileSequenceBench::benchSequenceNext 75.503 → 105.779 µs (+40.10%)` and
+      `HashBench::benchVerifyArgon2id 113465.370 → 129072.012 µs (+13.75%)`, and **the same
+      commit passed on re-run** (run 31114681269). Both subjects stayed far inside their
+      absolute budgets; only the relative comparison fired. This is not the stored-baseline
+      problem ADR-0030 already solved — base and HEAD were measured on the same runner, as that
+      ADR requires — so it is a second, narrower finding: **a same-runner A/B is still not
+      precise enough for a subject dominated by filesystem locking or by memory-hard hashing**,
+      where the shared runner's noise is in the same order as the budget. Options to weigh (none
+      chosen here): a per-subject threshold, best-of-N for the two classes, excluding them from
+      the relative gate while keeping their absolute ceilings, or accepting re-runs as the
+      documented protocol. Whichever is picked, **a gate that cries wolf on a docs-and-tests PR
+      teaches people to re-run until green**, which is the failure mode worth spending an item on
+      — route: standard / medium (adr)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — The verb that was never there, and a defect campaign that proved nothing](docs/journal/2026/08/2026-08-06-table-gateway.md).
+  [2026-08-06 — The corpus that protected the older builder](docs/journal/2026/08/2026-08-06-t13-gateway-injection.md).
 
 ## Model & effort routing (advisory)
 
@@ -820,10 +820,29 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       noticed in two untouched tests. 1770 tests (+119); 10 planted defects, 10 caught — and the
       **first run of that campaign was itself invalid** (the new files were untracked, so the
       restore step silently did nothing and defects accumulated), redone against a staged index.
-- [ ] 10.5 T-13 injection suite over the gateway/statement paths: ADR-0017's 29-payload
+- [x] 10.5 T-13 injection suite over the gateway/statement paths: ADR-0017's 29-payload
       corpus re-run through `Repository`/`TableGateway`, placeholder-only text asserted at
       the PDO boundary via the `QueryLog` fixture (RFC-0002 T-13) (security) — size: M ·
-      route: frontier-reasoning / extra
+      route: frontier-reasoning / extra *(run at standard tier; mismatch accepted by the
+      maintainer and recorded)* · **spec r12**, **no new ADR** — the boundary decision is
+      ADR-0017's and this applies it, which is worth saying rather than minting an ADR to look
+      thorough. *578 tests under `--group T-13`. **The item found a defect it had itself
+      introduced one PR earlier:** item 10.4 shipped `MutationBuilderTest` with its **own,
+      shorter identifier corpus** — ten payloads where `QueryBuilderTest` had nineteen — so the
+      newer builder was held to the weaker list while both suites stayed green. That is the
+      "two rules, the weaker decides" argument ADR-0044 makes about the allowlist, reproduced
+      one layer up in the tests. Both corpora now live in one `InjectionPayloads` fixture shared
+      by T-02, T-13 and the builder suites; unification alone added **21 identifier cases to the
+      write builder** and two to the read builder. **The identifier leg asserts more than the
+      refusal:** the log must be **empty** — a hostile column name rejected *after* the statement
+      reached the driver would satisfy every exception assertion while having already run the
+      injection, and no round-trip test can see the difference. **The value leg adds what a
+      boundary check cannot say:** the payload round-trips through hydration intact, a tautology
+      criterion matches and deletes nothing, and an `UPDATE`'s two parameter groups bind in order
+      — swap `SET` and `WHERE` and the statement still runs, affects a plausible row count, and
+      writes the criterion into the column. 7 planted defects, 7 caught, including one aimed at
+      the suite's own vacuity guard; the restore step worked this time because item 10.4's lesson
+      (stage the files first) was applied.*
 - [ ] 10.6 phpbench: NFR-09 gateway-vs-hand-written-PDO ratio (`bench_ratio_gate` pattern,
       ADR-0011 precedent) (RFC-0002) (step:optimize) — size: S · route: fast / medium
 - [x] 10.7 Make FR-33's guarantee **mechanical** instead of organizational: annotate

--- a/docs/journal/2026/08/2026-08-06-t13-gateway-injection.md
+++ b/docs/journal/2026/08/2026-08-06-t13-gateway-injection.md
@@ -56,6 +56,24 @@ The restore step worked this time. Item 10.4's campaign silently restored nothin
 files were untracked; the fix, applied here from the start, is to `git add` before planting. Same
 lesson, one PR later, and cheap to apply because it was written down.
 
+## The benchmark gate failed on a PR with no production code in it
+
+CI came back red on `benchmark / reproducible perf`:
+`benchSequenceNext 75.503 → 105.779 µs (+40.10%)` and
+`benchVerifyArgon2id 113465 → 129072 µs (+13.75%)`, both against a 10% budget.
+
+This PR's diff touches **no file under `src/main`** — checked with
+`git diff origin/master...HEAD --name-only | grep src/main`, which returns nothing, rather than
+assumed from "it's a test PR". Neither `FileSequence` nor `Hash` has a line in it. The same commit
+then passed on re-run.
+
+So it is noise — but noise worth a number, because ADR-0030 already solved the *stored baseline*
+version of this problem and this failure happened **inside** its same-runner A/B design. The two
+subjects that fired are the two whose cost is not CPU work: filesystem locking and memory-hard
+hashing, where a shared runner's variance lands in the same order as the budget. Filed as item
+**10.9** with both measurements and the run id, because the dangerous outcome is not a red build —
+it is a team that learns to re-run until green.
+
 ## No ADR, deliberately
 
 The decision T-13 rests on — that the PDO boundary is a sufficient place to prove binding, because

--- a/docs/journal/2026/08/2026-08-06-t13-gateway-injection.md
+++ b/docs/journal/2026/08/2026-08-06-t13-gateway-injection.md
@@ -1,0 +1,70 @@
+# 2026-08-06 — The corpus that protected the older builder
+
+Roadmap item **10.5**, spec §7's **T-13**. Route `frontier-reasoning / extra`; session model
+Opus 5, so a route mismatch, flagged before starting and accepted.
+
+## The first thing this suite found, it found in its own predecessor
+
+T-13's job is to re-run ADR-0017's payload corpus through the gateway. Before writing a line of
+it, I went to reuse the two corpora that already exist — and found there are *three*:
+`InjectionTest` holds 29 value payloads, `QueryBuilderTest` holds 19 hostile identifiers, and
+`MutationBuilderTest`, which **I wrote one PR earlier**, holds its own list of **ten**.
+
+So the newer of the two SQL builders was being tested against the weaker corpus. Both suites were
+green. Nothing was red, and nothing would have been red until a payload the short list omits —
+`UNION`, a subquery, a block comment, a unicode lookalike — turned out to matter.
+
+This is the argument ADR-0044 makes about the allowlist ("a copied rule is one edit from two
+rules, and the weaker one decides") reproduced one layer up, in the tests that check the
+allowlist, by the same author, in the next PR. Writing the rule down did not stop me from
+breaking it somewhere the rule did not literally apply.
+
+Both corpora now live in `Fixture\InjectionPayloads`, shared by T-02, T-13 and both builder
+suites. Unification alone gave the write builder **21 identifier cases instead of 10**, and gave
+the read builder two it did not have (`count(*)`, `id)`), which had arrived with the write
+builder. One list, so a payload added for one caller protects every caller.
+
+## What T-13 adds that the existing suites do not
+
+T-02 proved the boundary property for the paths that existed at item 4.4. Item 10.4's suite
+asserts what the *builder rendered* — a claim about a string. Between them sits everything a
+gateway adds: a projection, an assembled `WHERE`, a `SET` list, and two parameter groups in
+sequence.
+
+Three assertions in this suite could not have been written in either of the others:
+
+- **The identifier leg asserts an empty log.** A hostile column name must be refused *before
+  anything is prepared*. A gateway that built the statement, handed it to the driver and then
+  noticed would satisfy every `expectException` in the file while having already run the
+  injection — and no round-trip assertion can tell those apart.
+- **`SET` binds before `WHERE`.** Swap the two groups and the statement still runs, still affects
+  a plausible number of rows, and writes the *criterion* into the column. Every syntax-level
+  assertion in this file passes on that bug. It is caught by using two distinct payloads and
+  reading the row back.
+- **A tautology in a `DELETE` criterion deletes nothing.** The destructive statement of the
+  mechanism, and the one the surveyed estate was actually exposed to.
+
+## Verification
+
+578 tests under `--group T-13`; 2400 in the suite overall. Seven defects planted one at a time,
+seven caught: values interpolated on three separate paths, the read builder's `WHERE` interpolated
+and reached through the gateway, the allowlist bypassed, the two parameter groups swapped, and one
+aimed at the suite itself — emptying the log before asserting, to confirm the vacuity guard fires
+rather than passing on nothing.
+
+The restore step worked this time. Item 10.4's campaign silently restored nothing because the new
+files were untracked; the fix, applied here from the start, is to `git add` before planting. Same
+lesson, one PR later, and cheap to apply because it was written down.
+
+## No ADR, deliberately
+
+The decision T-13 rests on — that the PDO boundary is a sufficient place to prove binding, because
+real prepares are pinned — is ADR-0017's, made at item 4.4. This item applies it to new paths and
+adds no decision of its own. Spec r12 records what the suite actually covers, since the one-line
+description in the r3 addendum did not mention the identifier leg.
+
+## Lesson
+
+The rule you just wrote down applies to the code you write next, including the tests. ADR-0044
+argued against a duplicated allowlist and was merged the same day I duplicated the corpus that
+tests one — the second copy is always somewhere the rule did not literally name.

--- a/docs/specs/01_spec_utils.md
+++ b/docs/specs/01_spec_utils.md
@@ -3,7 +3,7 @@
 > Rendered from the intake interview (Phase 5). Frozen contract: diverging implementation
 > updates this spec in the same PR or adds an ADR superseding the relevant section.
 
-**Revision r11** — 2026-08-06. See [Revision history](#revision-history).
+**Revision r12** — 2026-08-06. See [Revision history](#revision-history).
 
 ## 1. Objective & Business Context
 
@@ -153,6 +153,20 @@ ADR-0017's 29-payload corpus re-run through Repository/TableGateway with the
 placeholder-only PDO-boundary assertion; T-14 FileSequence under concurrent processes (no
 duplicates, cap enforced); T-15 RowNormalizer policy table.
 
+**T-13, as delivered (r12, item 10.5)** — two legs, not one. The **value leg** is the corpus
+above through every value-accepting gateway path (`insert`, `find`, `findBy`, `findOneBy`,
+`update`, `updateBy`, `deleteBy`, `MutationBuilder` directly, `Repository::fetchAll` with
+hand-written SQL, inside `withTransaction`, and with a `RowNormalizer` configured), plus the
+consequence assertions a boundary check cannot make: the payload round-trips through hydration
+intact, a tautology criterion matches and deletes nothing, and **the two parameter groups of an
+`UPDATE` bind in order** (`SET` before `WHERE` — swapped, the statement still runs and writes the
+criterion into the column, which no syntax-level assertion would see). The **identifier leg** runs
+the hostile-identifier corpus over every surface where a column name can arrive from a caller —
+criteria keys and value keys on each operation, plus the table name — and asserts not only the
+refusal but that **nothing was prepared**: a refusal issued after the statement reached the driver
+is a refusal that arrived too late, and a round-trip assertion cannot tell the two apart. Both
+corpora live in one fixture shared by T-02, T-13 and the builder suites.
+
 Toolchain: built with Composer (PSR-4 autoload), tested with PHPUnit (Pest optional), checked with
 PHPStan max level (type soundness); PCOV for coverage, coverage target ≥ 90% line. Every functional and
 non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)).
@@ -164,6 +178,7 @@ non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.y
 |-----|------|--------|
 | r1 | 2026-08-03 | Frozen from the imported `.specs/d4np-php.md` v2.0 via RFC-0001 (naming mapping A-7). |
 | r2 | 2026-08-05 | §6/T-03: the `hash_equals` **timing test** is replaced by a **mechanism assertion**. Rationale below; see [ADR-0027](../adr/0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md). |
+| r12 | 2026-08-06 | §6: **T-13 stated as delivered** (item 10.5) — the suite has an identifier leg the one-line description did not mention, asserting that a hostile column name is refused **before anything is prepared**, and consequence assertions the boundary check cannot make (round-trip through hydration, a tautology that matches nothing, and `SET`-before-`WHERE` parameter order). No requirement changed; the spec now describes what exists. No new ADR: the boundary decision is [ADR-0017](../adr/0017-prove-binding-at-the-pdo-boundary-and-defer-t02s-like-leg.md)'s and this applies it. |
 | r11 | 2026-08-06 | §2/§5: **FR-35 corrected** — its "composed exclusively through QueryBuilder" (carried from RFC-0002) was not implementable, because `QueryBuilder` builds `SELECT` and only `SELECT`. Reads keep it; writes get **FR-33b** `MutationBuilder`, and the FR-07 allowlist is extracted into a shared `Identifier` so one rule serves both. Adds `SqlStatement::fromMutation()` as a fourth named door, leaving `composed()` at zero in-library uses. FR-35's normative behaviours recorded: empty criteria refused, the DTO projected rather than `SELECT *`, the table allowlisted at construction. Honest limit recorded in the ADR: on SQLite a DTO/table mismatch is caught by strict hydration rather than the driver, and is invisible against an empty table. See [ADR-0044](../adr/0044-the-write-builder-querybuilder-never-had-and-one-allowlist-for-both.md). |
 | r10 | 2026-08-06 | §2/§3: FR-34 stated to the precision item 10.3 implemented (no catch anywhere — the requirement met by omission and asserted against the source; strict hydration kept with a protected seam; opt-in normalization, settling ADR-0042's deferral; a row count rather than a boolean). §3's dependency rule gains its **first two named cross-group edges**, `Persistence→Database` and `Persistence→Dto` — granted, not a general relaxation, and proved in three directions (both grants live, a non-granted edge refused, the inversion refused). See [ADR-0043](../adr/0043-two-named-edges-out-of-persistence-and-no-catch-at-all.md). |
 | r9 | 2026-08-06 | §2/§3: FR-36 stated to the precision item 10.2 implemented (the asymmetric defaults and why, the fixed step order, the column-naming strict failure, what is never touched); §3's `Persistence` group arrives with a **Support-only** edge, the two cross-group edges of RFC-0002 P-1 deliberately deferred to item 10.3 and **proved closed** by a planted `Persistence → Database` violation. Additive; see [ADR-0042](../adr/0042-trim-is-the-only-default-and-the-transcode-runs-first.md). |

--- a/src/test/php/d4np/utils/Database/Fixture/InjectionPayloads.php
+++ b/src/test/php/d4np/utils/Database/Fixture/InjectionPayloads.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Database\Fixture;
+
+/**
+ * The injection corpora — **one of each, shared by every suite that needs them** (item 10.5).
+ *
+ * They lived inside `InjectionTest` (values) and `QueryBuilderTest` (identifiers) until item 10.4
+ * added `MutationBuilder` and, with it, *a second, shorter identifier corpus* — ten payloads where
+ * the read builder faced nineteen. Both suites were green, and the write builder was tested
+ * against the weaker list: exactly the failure mode ADR-0044 argues about for the allowlist
+ * itself, reproduced one layer up in the tests. Extracting them here is the same fix applied to
+ * the same problem — one list, so a payload added for one caller protects every caller.
+ *
+ * Neither corpus is a list of scary strings. Each entry is a mechanism: quote break-out, comment
+ * truncation, stacked statements, `UNION` exfiltration, charset tricks that defeat client-side
+ * escaping, and the anchoring edge cases that defeat a hand-written allowlist.
+ */
+final class InjectionPayloads
+{
+    /**
+     * Fuzzed **values** — things that must reach the driver as bound parameters and never as
+     * statement text (spec §7 T-02 / T-13; ADR-0017).
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function values(): iterable
+    {
+        yield 'classic tautology' => ["' OR '1'='1"];
+        yield 'tautology, double quotes' => ['" OR ""="'];
+        yield 'stacked drop' => ["Robert'); DROP TABLE users;--"];
+        yield 'stacked delete' => ['1; DELETE FROM users'];
+        yield 'comment truncation (dash)' => ["admin'--"];
+        yield 'comment truncation (hash)' => ['admin\'#'];
+        yield 'block comment' => ["admin'/*"];
+        yield 'union exfiltration' => ["' UNION SELECT token FROM secrets --"];
+        yield 'union with null padding' => ["' UNION SELECT NULL, token FROM secrets --"];
+        yield 'backslash escape' => ["\\' OR 1=1 --"];
+        yield 'double backslash' => ["\\\\' OR 1=1 --"];
+        // The classic charset attack: 0xBF 0x27 is a valid GBK character whose second byte is a
+        // quote. It defeats a client-side escaper that does not know the connection charset --
+        // which is exactly the scenario ADR-0014's real-prepares pin removes.
+        yield 'GBK multibyte quote' => ["\xbf\x27 OR 1=1 --"];
+        yield 'null byte' => ["admin\0' OR 1=1"];
+        yield 'newline injection' => ["admin'\nOR 1=1"];
+        yield 'CRLF injection' => ["admin'\r\nOR 1=1"];
+        yield 'tab injection' => ["admin'\tOR 1=1"];
+        yield 'nested quotes' => ["''''''"];
+        yield 'percent wildcard' => ['100%'];
+        yield 'underscore wildcard' => ['a_b'];
+        yield 'sqlite pragma' => ["'; PRAGMA writable_schema = 1;--"];
+        yield 'sqlite attach' => ["'; ATTACH DATABASE '/tmp/x' AS x;--"];
+        yield 'unicode quote lookalike' => ["admin\u{2019} OR 1=1"];
+        yield 'emoji' => ['🙂 OR 1=1'];
+        yield 'very long' => [str_repeat("' OR 1=1 --", 500)];
+        yield 'only whitespace' => ['   '];
+        yield 'empty string' => [''];
+        yield 'json-ish' => ['{"$ne": null}'];
+        yield 'template expression' => ['${1+1}'];
+        yield 'sprintf token' => ['%s %d %%'];
+    }
+
+    /**
+     * Hostile **identifiers** — table and column names, which cannot be bound and must therefore
+     * be refused outright (spec FR-07; ADR-0015).
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function identifiers(): iterable
+    {
+        yield 'statement terminator' => ['id; DROP TABLE users'];
+        yield 'comment' => ['id -- '];
+        yield 'block comment' => ['id /* x */'];
+        yield 'union' => ['id UNION SELECT password FROM admins'];
+        yield 'quote break-out (double)' => ['id" FROM users; --'];
+        yield 'quote break-out (backtick)' => ['id` FROM users; --'];
+        yield 'quote break-out (bracket)' => ['id] FROM users; --'];
+        yield 'subquery' => ['(SELECT 1)'];
+        yield 'wildcard' => ['*'];
+        yield 'qualified name' => ['users.id'];
+        yield 'space' => ['user name'];
+        yield 'leading digit' => ['1id'];
+        yield 'empty' => [''];
+        yield 'whitespace only' => ['   '];
+        yield 'newline smuggling' => ["id\nDROP TABLE users"];
+        // PCRE's `$` matches before a trailing newline, so FR-07's allowlist transcribed
+        // literally admits this one. It did, until the pattern was anchored with `\z`.
+        yield 'trailing newline (the `$` anchor hole)' => ["id\n"];
+        yield 'trailing CRLF' => ["id\r\n"];
+        yield 'null byte' => ["id\0"];
+        yield 'unicode lookalike' => ['ｉd'];
+        // Arrived with the write builder at item 10.4, and now protects the read builder too —
+        // which is the point of there being one list.
+        yield 'function call' => ['count(*)'];
+        yield 'parenthesis' => ['id)'];
+    }
+}

--- a/src/test/php/d4np/utils/Database/InjectionTest.php
+++ b/src/test/php/d4np/utils/Database/InjectionTest.php
@@ -11,6 +11,7 @@ use D4np\Utils\Database\Sort;
 use D4np\Utils\Database\SqlStatement;
 use D4np\Utils\Database\Transaction;
 use D4np\Utils\Security\Sanitizer;
+use D4np\Utils\Tests\Database\Fixture\InjectionPayloads;
 use D4np\Utils\Tests\Database\Fixture\LoggedStatement;
 use D4np\Utils\Tests\Database\Fixture\QueryLog;
 use PDO;
@@ -65,47 +66,13 @@ final class InjectionTest extends TestCase
     }
 
     /**
-     * A corpus aimed at the ways SQL injection actually works, rather than a list of scary
-     * strings: quote break-out, comment truncation, stacked statements, UNION exfiltration,
-     * backslash and multibyte escaping tricks, and the encoding edge cases that defeat naive
-     * escapers.
+     * The value corpus, from the one place it lives (item 10.5).
      *
      * @return iterable<string, array{string}>
      */
     public static function payloads(): iterable
     {
-        yield 'classic tautology' => ["' OR '1'='1"];
-        yield 'tautology, double quotes' => ['" OR ""="'];
-        yield 'stacked drop' => ["Robert'); DROP TABLE users;--"];
-        yield 'stacked delete' => ['1; DELETE FROM users'];
-        yield 'comment truncation (dash)' => ["admin'--"];
-        yield 'comment truncation (hash)' => ['admin\'#'];
-        yield 'block comment' => ["admin'/*"];
-        yield 'union exfiltration' => ["' UNION SELECT token FROM secrets --"];
-        yield 'union with null padding' => ["' UNION SELECT NULL, token FROM secrets --"];
-        yield 'backslash escape' => ["\\' OR 1=1 --"];
-        yield 'double backslash' => ["\\\\' OR 1=1 --"];
-        // The classic charset attack: 0xBF 0x27 is a valid GBK character whose second byte is a
-        // quote. It defeats a client-side escaper that does not know the connection charset --
-        // which is exactly the scenario ADR-0014's real-prepares pin removes.
-        yield 'GBK multibyte quote' => ["\xbf\x27 OR 1=1 --"];
-        yield 'null byte' => ["admin\0' OR 1=1"];
-        yield 'newline injection' => ["admin'\nOR 1=1"];
-        yield 'CRLF injection' => ["admin'\r\nOR 1=1"];
-        yield 'tab injection' => ["admin'\tOR 1=1"];
-        yield 'nested quotes' => ["''''''"];
-        yield 'percent wildcard' => ['100%'];
-        yield 'underscore wildcard' => ['a_b'];
-        yield 'sqlite pragma' => ["'; PRAGMA writable_schema = 1;--"];
-        yield 'sqlite attach' => ["'; ATTACH DATABASE '/tmp/x' AS x;--"];
-        yield 'unicode quote lookalike' => ["admin\u{2019} OR 1=1"];
-        yield 'emoji' => ['🙂 OR 1=1'];
-        yield 'very long' => [str_repeat("' OR 1=1 --", 500)];
-        yield 'only whitespace' => ['   '];
-        yield 'empty string' => [''];
-        yield 'json-ish' => ['{"$ne": null}'];
-        yield 'template expression' => ['${1+1}'];
-        yield 'sprintf token' => ['%s %d %%'];
+        yield from InjectionPayloads::values();
     }
 
     /**

--- a/src/test/php/d4np/utils/Database/MutationBuilderTest.php
+++ b/src/test/php/d4np/utils/Database/MutationBuilderTest.php
@@ -8,6 +8,7 @@ use D4np\Utils\Database\DatabaseConnection;
 use D4np\Utils\Database\MutationBuilder;
 use D4np\Utils\Database\SqlStatement;
 use D4np\Utils\Support\DatabaseException;
+use D4np\Utils\Tests\Database\Fixture\InjectionPayloads;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
@@ -162,20 +163,18 @@ final class MutationBuilderTest extends TestCase
     // ---- the allowlist, on every identifier surface ---------------------------------------------
 
     /**
+     * The identifier corpus — the shared one.
+     *
+     * This suite shipped with a **shorter copy** at item 10.4: ten payloads where the read builder
+     * faced nineteen, so the newer of the two builders was held to the weaker list while both
+     * suites stayed green. Item 10.5 unified them into {@see InjectionPayloads}, which is the
+     * argument ADR-0044 makes about the allowlist, applied to the corpus that tests it.
+     *
      * @return iterable<string, array{string}>
      */
     public static function hostileIdentifiers(): iterable
     {
-        yield 'statement terminator'   => ['id; DROP TABLE users'];
-        yield 'comment'                => ['id -- '];
-        yield 'quote'                  => ['id"'];
-        yield 'backtick'               => ['id`'];
-        yield 'space'                  => ['user name'];
-        yield 'qualified name'         => ['users.id'];
-        yield 'trailing newline'       => ["id\n"];
-        yield 'leading digit'          => ['1id'];
-        yield 'empty'                  => [''];
-        yield 'parenthesis'            => ['count(*)'];
+        yield from InjectionPayloads::identifiers();
     }
 
     #[DataProvider('hostileIdentifiers')]

--- a/src/test/php/d4np/utils/Database/QueryBuilderTest.php
+++ b/src/test/php/d4np/utils/Database/QueryBuilderTest.php
@@ -11,6 +11,7 @@ use D4np\Utils\Database\Sort;
 use D4np\Utils\Database\SqlStatement;
 use D4np\Utils\Support\DatabaseException;
 use D4np\Utils\Tests\Database\Fixture\DriverLookupCountingPdo;
+use D4np\Utils\Tests\Database\Fixture\InjectionPayloads;
 use D4np\Utils\Tests\Database\Fixture\LoggedStatement;
 use D4np\Utils\Tests\Database\Fixture\PretendDriverPdo;
 use D4np\Utils\Tests\Database\Fixture\QueryLog;
@@ -128,34 +129,15 @@ final class QueryBuilderTest extends TestCase
     }
 
     /**
-     * The heart of FR-07. Each of these is a real way an identifier has been used to inject SQL;
-     * none of them can be bound as a parameter, so each must be refused outright.
+     * The heart of FR-07: each of these is a real way an identifier has been used to inject SQL,
+     * none can be bound as a parameter, and each must be refused outright. The list itself moved
+     * to {@see InjectionPayloads} at item 10.5, so the write builder is held to the same one.
      *
      * @return iterable<string, array{string}>
      */
     public static function hostileIdentifiers(): iterable
     {
-        yield 'statement terminator' => ['id; DROP TABLE users'];
-        yield 'comment' => ['id -- '];
-        yield 'block comment' => ['id /* x */'];
-        yield 'union' => ['id UNION SELECT password FROM admins'];
-        yield 'quote break-out (double)' => ['id" FROM users; --'];
-        yield 'quote break-out (backtick)' => ['id` FROM users; --'];
-        yield 'quote break-out (bracket)' => ['id] FROM users; --'];
-        yield 'subquery' => ['(SELECT 1)'];
-        yield 'wildcard' => ['*'];
-        yield 'qualified name' => ['users.id'];
-        yield 'space' => ['user name'];
-        yield 'leading digit' => ['1id'];
-        yield 'empty' => [''];
-        yield 'whitespace only' => ['   '];
-        yield 'newline smuggling' => ["id\nDROP TABLE users"];
-        // PCRE's `$` matches before a trailing newline, so FR-07's allowlist transcribed
-        // literally admits this one. It did, until the pattern was anchored with `\z`.
-        yield 'trailing newline (the `$` anchor hole)' => ["id\n"];
-        yield 'trailing CRLF' => ["id\r\n"];
-        yield 'null byte' => ["id\0"];
-        yield 'unicode lookalike' => ['ｉd'];
+        yield from InjectionPayloads::identifiers();
     }
 
     #[DataProvider('hostileIdentifiers')]

--- a/src/test/php/d4np/utils/Persistence/Fixture/PersonGateway.php
+++ b/src/test/php/d4np/utils/Persistence/Fixture/PersonGateway.php
@@ -39,4 +39,30 @@ final class PersonGateway extends TableGateway
             Person::class,
         );
     }
+
+    /**
+     * `Repository::fetchAll()` reached with hand-written SQL — the path T-13 covers that the
+     * gateway's own methods do not, since here the caller supplies the statement.
+     *
+     * @return list<Person>
+     */
+    public function named(string $name): array
+    {
+        return $this->fetchAll(
+            SqlStatement::literal('SELECT id, name, age, status FROM people WHERE name = ?', [$name]),
+            Person::class,
+        );
+    }
+
+    /**
+     * A gateway write inside `Repository::withTransaction()`, so T-13 can assert that binding
+     * survives the transaction wrapper (T-02 asserts the same for the connection).
+     *
+     * @param array<array-key, mixed> $values
+     */
+    public function insertInTransaction(array $values): int
+    {
+        /** @var int */
+        return $this->withTransaction(fn (): int => $this->insert($values));
+    }
 }

--- a/src/test/php/d4np/utils/Persistence/GatewayInjectionTest.php
+++ b/src/test/php/d4np/utils/Persistence/GatewayInjectionTest.php
@@ -1,0 +1,429 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Persistence;
+
+use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\MutationBuilder;
+use D4np\Utils\Database\SqlStatement;
+use D4np\Utils\Persistence\RowNormalizer;
+use D4np\Utils\Persistence\TableGateway;
+use D4np\Utils\Support\DatabaseException;
+use D4np\Utils\Tests\Database\Fixture\InjectionPayloads;
+use D4np\Utils\Tests\Database\Fixture\LoggedStatement;
+use D4np\Utils\Tests\Database\Fixture\QueryLog;
+use D4np\Utils\Tests\Persistence\Fixture\Person;
+use D4np\Utils\Tests\Persistence\Fixture\PersonGateway;
+use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Spec §7's **T-13**: *"gateway/statement injection — ADR-0017's payload corpus re-run through
+ * `Repository`/`TableGateway`, placeholder-only text asserted at the PDO boundary via the
+ * `QueryLog` fixture"*.
+ *
+ * **Why this is not a copy of T-02.** T-02 proved the property for the paths that existed at item
+ * 4.4: `DatabaseConnection`'s three methods, two `QueryBuilder` clauses, and a transaction. Since
+ * then the composed path grew — `TableGateway` → `MutationBuilder`/`QueryBuilder` →
+ * `SqlStatement` → `DatabaseConnection` → PDO — and item 10.4's own suite stops one layer short:
+ * it asserts what the *builder rendered*, which is a claim about a string, not about what the
+ * driver was handed. Between the two lies everything a gateway adds — a projection, an assembled
+ * `WHERE`, a `SET` list, and the ordering of two parameter groups. This suite watches the
+ * boundary for all of it.
+ *
+ * Both corpora come from {@see InjectionPayloads}, the single list item 10.5 unified, so a
+ * payload added anywhere protects every caller.
+ *
+ * The identifier leg carries an assertion the value leg cannot: a refused column name must leave
+ * the log **empty**. Refusing an identifier after preparing a statement would be a refusal that
+ * arrives too late to matter, and no round-trip assertion can see the difference.
+ */
+#[Group('T-13')]
+#[RequiresPhpExtension('pdo_sqlite')]
+final class GatewayInjectionTest extends TestCase
+{
+    private QueryLog $log;
+
+    private DatabaseConnection $connection;
+
+    /** @var TableGateway<Person> */
+    private TableGateway $gateway;
+
+    protected function setUp(): void
+    {
+        $this->log = new QueryLog();
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_STATEMENT_CLASS, [LoggedStatement::class, [$this->log]]);
+
+        $this->connection = new DatabaseConnection($pdo);
+        $this->connection->execute(SqlStatement::literal(
+            'CREATE TABLE people (id INTEGER PRIMARY KEY, name TEXT, age INTEGER, status TEXT, secret TEXT)',
+        ));
+        $this->connection->execute(SqlStatement::literal('CREATE TABLE secrets (token TEXT)'));
+        $this->connection->execute(SqlStatement::literal("INSERT INTO secrets (token) VALUES ('do-not-leak')"));
+
+        $this->gateway = new TableGateway($this->connection, 'people', Person::class, 'id');
+
+        // Only the payload traffic matters; drop the fixture's own setup from the log.
+        $this->log->entries = [];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function payloads(): iterable
+    {
+        yield from InjectionPayloads::values();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function hostileIdentifiers(): iterable
+    {
+        yield from InjectionPayloads::identifiers();
+    }
+
+    /**
+     * The core assertion: at the last point where text and values are still separable, the
+     * payload is in the parameter array and nowhere in the statement text.
+     *
+     * ADR-0017 records why this boundary is sufficient — with `ATTR_EMULATE_PREPARES` pinned off
+     * (ADR-0014), PDO does not interpolate, so placeholder-only text here is placeholder-only
+     * text on the wire.
+     */
+    private function assertBoundNeverInlined(string $payload): void
+    {
+        $statements = $this->log->statements();
+
+        self::assertNotSame([], $statements, 'nothing was logged — the assertion would be vacuous');
+
+        // The empty string is degenerate for a substring check: every string contains it. The
+        // binding half below still applies, so it stays in the corpus and this half is skipped
+        // rather than fudged (T-02's reasoning, unchanged).
+        if ($payload !== '') {
+            foreach ($statements as $sql) {
+                self::assertStringNotContainsString(
+                    $payload,
+                    $sql,
+                    "the payload reached the driver inside the statement text:\n" . $sql,
+                );
+            }
+        }
+
+        self::assertContains($payload, $this->log->boundValues(), 'the payload was not bound as a parameter');
+    }
+
+    private function seed(int $id, string $name): void
+    {
+        $this->connection->execute(SqlStatement::literal(
+            'INSERT INTO people (id, name, age, status, secret) VALUES (?, ?, ?, ?, ?)',
+            [$id, $name, 1, 'active', 'x'],
+        ));
+        $this->log->entries = [];
+    }
+
+    // ---- TableGateway: every surface that takes a value ------------------------------------------
+
+    #[DataProvider('payloads')]
+    public function testGatewayInsertBindsTheValue(string $payload): void
+    {
+        $this->gateway->insert(['name' => $payload]);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testGatewayFindBindsTheKey(string $payload): void
+    {
+        $this->gateway->find($payload);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testGatewayFindByBindsTheCriterion(string $payload): void
+    {
+        $this->gateway->findBy(['name' => $payload]);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testGatewayFindOneByBindsTheCriterion(string $payload): void
+    {
+        $this->gateway->findOneBy(['name' => $payload]);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testGatewayUpdateBindsTheValueBeingWritten(string $payload): void
+    {
+        $this->seed(1, 'Ada');
+
+        $this->gateway->update(1, ['name' => $payload]);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testGatewayUpdateByBindsTheCriterion(string $payload): void
+    {
+        $this->gateway->updateBy(['name' => $payload], ['status' => 'reviewed']);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testGatewayDeleteByBindsTheCriterion(string $payload): void
+    {
+        $this->gateway->deleteBy(['name' => $payload]);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    // ---- MutationBuilder, reached directly --------------------------------------------------------
+
+    #[DataProvider('payloads')]
+    public function testMutationBuilderInsertBindsThroughTheConnection(string $payload): void
+    {
+        $this->connection->execute(SqlStatement::fromMutation(
+            MutationBuilder::insert($this->connection, 'people', ['name' => $payload]),
+        ));
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testMutationBuilderUpdateBindsBothGroups(string $payload): void
+    {
+        $this->connection->execute(SqlStatement::fromMutation(
+            MutationBuilder::update($this->connection, 'people', ['name' => $payload], ['name' => $payload]),
+        ));
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testMutationBuilderDeleteBindsTheCriterion(string $payload): void
+    {
+        $this->connection->execute(SqlStatement::fromMutation(
+            MutationBuilder::delete($this->connection, 'people', ['name' => $payload]),
+        ));
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    // ---- Repository, including inside a transaction ------------------------------------------------
+
+    #[DataProvider('payloads')]
+    public function testRepositoryFetchAllBindsTheValue(string $payload): void
+    {
+        (new PersonGateway($this->connection))->named($payload);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    #[DataProvider('payloads')]
+    public function testBindingHoldsInsideAGatewayTransaction(string $payload): void
+    {
+        (new PersonGateway($this->connection))->insertInTransaction(['name' => $payload]);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    /**
+     * A normalizer rewrites values *after* the driver returned them, so it cannot affect binding —
+     * but it is the one collaborator that touches payload bytes on the way out, and "cannot" is
+     * cheaper to assert than to argue.
+     */
+    #[DataProvider('payloads')]
+    public function testBindingHoldsWithANormalizerConfigured(string $payload): void
+    {
+        $gateway = new TableGateway(
+            $this->connection,
+            'people',
+            Person::class,
+            'id',
+            new RowNormalizer(),
+        );
+
+        $gateway->findBy(['name' => $payload]);
+
+        $this->assertBoundNeverInlined($payload);
+    }
+
+    // ---- the identifier leg -------------------------------------------------------------------------
+
+    /**
+     * Every gateway surface where a **column name** can arrive from the caller refuses a hostile
+     * one — and refuses it **before preparing anything**.
+     *
+     * The empty log is the part a round-trip test cannot see: a gateway that built the statement,
+     * sent it, and then noticed the identifier would pass any assertion about the exception while
+     * having already run the injection.
+     *
+     * @return iterable<string, array{callable(TableGateway<Person>, string): mixed}>
+     */
+    public static function columnSurfaces(): iterable
+    {
+        yield 'findBy criterion'    => [static fn (TableGateway $g, string $id): mixed => $g->findBy([$id => 'x'])];
+        yield 'findOneBy criterion' => [static fn (TableGateway $g, string $id): mixed => $g->findOneBy([$id => 'x'])];
+        yield 'insert column'       => [static fn (TableGateway $g, string $id): mixed => $g->insert([$id => 'x'])];
+        yield 'update value'        => [static fn (TableGateway $g, string $id): mixed => $g->update(1, [$id => 'x'])];
+        yield 'updateBy criterion'  => [static fn (TableGateway $g, string $id): mixed => $g->updateBy([$id => 'x'], ['name' => 'y'])];
+        yield 'updateBy value'      => [static fn (TableGateway $g, string $id): mixed => $g->updateBy(['name' => 'y'], [$id => 'x'])];
+        yield 'deleteBy criterion'  => [static fn (TableGateway $g, string $id): mixed => $g->deleteBy([$id => 'x'])];
+    }
+
+    /**
+     * @return iterable<string, array{string, callable(TableGateway<Person>, string): mixed}>
+     */
+    public static function identifierSurfaceMatrix(): iterable
+    {
+        foreach (self::identifiers() as $payloadName => [$identifier]) {
+            foreach (self::columnSurfaces() as $surfaceName => [$operation]) {
+                yield $surfaceName . ' / ' . $payloadName => [$identifier, $operation];
+            }
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    private static function identifiers(): iterable
+    {
+        yield from InjectionPayloads::identifiers();
+    }
+
+    /**
+     * @param callable(TableGateway<Person>, string): mixed $operation
+     */
+    #[DataProvider('identifierSurfaceMatrix')]
+    public function testAHostileColumnNameIsRefusedBeforeAnythingIsPrepared(
+        string $identifier,
+        callable $operation,
+    ): void {
+        try {
+            $operation($this->gateway, $identifier);
+            self::fail('the hostile identifier was accepted: ' . var_export($identifier, true));
+        } catch (DatabaseException) {
+            // The refusal is the expected outcome; what follows is the part worth asserting.
+        }
+
+        self::assertSame(
+            [],
+            $this->log->entries,
+            'the identifier was refused only after a statement had already been prepared',
+        );
+    }
+
+    #[DataProvider('hostileIdentifiers')]
+    public function testAHostileTableNameIsRefusedAtConstructionAndPreparesNothing(string $identifier): void
+    {
+        try {
+            new TableGateway($this->connection, $identifier, Person::class);
+            self::fail('the hostile table name was accepted: ' . var_export($identifier, true));
+        } catch (DatabaseException) {
+            // Expected — ADR-0044's fail-fast at wiring time.
+        }
+
+        self::assertSame([], $this->log->entries);
+    }
+
+    // ---- what the database actually did --------------------------------------------------------------
+
+    /**
+     * Binding is a claim about syntax; this is the claim about consequences. The payload survives
+     * a full write-read cycle through hydration, and neither table has been touched by it.
+     */
+    #[DataProvider('payloads')]
+    public function testThePayloadRoundTripsThroughHydrationAndTheSchemaSurvives(string $payload): void
+    {
+        $this->gateway->insert(['id' => 1, 'name' => $payload, 'age' => 1, 'status' => 'active']);
+
+        $person = $this->gateway->find(1);
+
+        self::assertInstanceOf(Person::class, $person);
+        self::assertSame($payload, $person->name);
+        self::assertCount(1, $this->gateway->all());
+        // Exfiltration and destruction both leave traces here.
+        self::assertSame(
+            [['n' => 1]],
+            $this->connection->select(SqlStatement::literal('SELECT COUNT(*) AS n FROM secrets')),
+        );
+    }
+
+    /**
+     * The practical statement of the mechanism: bound, a tautology is a name nobody has.
+     */
+    public function testATautologyCriterionMatchesNothing(): void
+    {
+        $this->seed(1, 'Ada');
+        $this->seed(2, 'Grace');
+
+        self::assertSame([], $this->gateway->findBy(['name' => "' OR '1'='1"]));
+        self::assertCount(2, $this->gateway->all());
+    }
+
+    /**
+     * …and the destructive version of the same point, which is the one the estate was exposed to:
+     * a payload in a `DELETE` criterion deletes nothing.
+     */
+    public function testATautologyInADeleteCriterionRemovesNothing(): void
+    {
+        $this->seed(1, 'Ada');
+        $this->seed(2, 'Grace');
+
+        self::assertSame(0, $this->gateway->deleteBy(['name' => "' OR '1'='1"]));
+        self::assertCount(2, $this->gateway->all());
+    }
+
+    /**
+     * **Parameter order across two groups**, which is this composed path's own failure mode and
+     * has no equivalent in T-02.
+     *
+     * `UPDATE … SET a = ? WHERE b = ?` binds two groups in sequence. Swap them and the statement
+     * still runs, still affects a plausible number of rows, and writes the *criterion* into the
+     * column — a silent wrong answer that every syntax-level assertion in this file would miss.
+     * So the two payloads are distinct and the resulting row is read back.
+     */
+    public function testTheSetValuesBindBeforeTheCriteriaAndTheRightRowChanges(): void
+    {
+        $this->seed(1, 'target');
+        $this->seed(2, 'bystander');
+
+        $affected = $this->gateway->updateBy(['name' => 'target'], ['name' => "written'--"]);
+
+        // Captured before the read-backs below, which bind their own key values into the same log.
+        self::assertSame(["written'--", 'target'], $this->log->boundValues());
+
+        self::assertSame(1, $affected);
+        self::assertSame("written'--", $this->gateway->find(1)?->name);
+        self::assertSame('bystander', $this->gateway->find(2)?->name);
+    }
+
+    /**
+     * One statement per operation, and every value in it a placeholder.
+     *
+     * A count is a coarse assertion, but it catches the shape no substring check can: a builder
+     * that inlined *some* values and bound others would still pass the containment test for the
+     * bound ones.
+     */
+    public function testEveryValueInAGatewayStatementIsAPlaceholder(): void
+    {
+        $this->gateway->updateBy(['name' => 'a', 'status' => 'b'], ['name' => 'c', 'age' => 4]);
+
+        $statements = $this->log->statements();
+        self::assertCount(1, $statements);
+        self::assertSame(4, substr_count($statements[0], '?'));
+        self::assertCount(4, $this->log->boundValues());
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item **10.5** — spec §7's **T-13**: ADR-0017's payload corpus re-run through
`Repository`/`TableGateway`/`MutationBuilder` with the placeholder-only assertion at the PDO
boundary. **578 tests** under `--group T-13`. Test-only change; no production behaviour is
modified.

## The suite found a defect in its own predecessor

Going to reuse the existing corpora, I found **three**, not two: 29 value payloads in
`InjectionTest`, 19 hostile identifiers in `QueryBuilderTest`, and **ten** in
`MutationBuilderTest` — which **item 10.4 shipped yesterday**. The newer of the two SQL builders
was being held to the weaker list, both suites green, and nothing would have gone red until a
payload the short list omits (`UNION`, a subquery, a block comment, a unicode lookalike) turned
out to matter.

That is the argument **ADR-0044** makes about the allowlist — *a copied rule is one edit from two
rules, and the weaker one decides* — reproduced one layer up, in the tests that check the
allowlist, by the same author, in the next PR. Both corpora now live in one `InjectionPayloads`
fixture shared by T-02, T-13 and both builder suites. **Unification alone gave the write builder
21 identifier cases instead of 10**, and the read builder two it lacked.

## What T-13 asserts that nothing else could

T-02 covered the paths that existed at item 4.4. Item 10.4's suite asserts what the builder
*rendered* — a claim about a string, one layer short of the driver. Between them sits everything a
gateway adds: a projection, an assembled `WHERE`, a `SET` list, and two parameter groups in
sequence.

- **The identifier leg asserts an empty log.** A hostile column name must be refused *before
  anything is prepared*. A gateway that prepared first and noticed second would satisfy every
  `expectException` in the file while having already run the injection — and no round-trip
  assertion can separate the two.
- **`SET` binds before `WHERE`.** Swapped, the statement still runs, still affects a plausible row
  count, and writes the *criterion* into the column: a silent wrong answer every syntax-level
  assertion here would miss. Caught with two distinct payloads and a read-back.
- **A tautology in a `DELETE` criterion deletes nothing** — the destructive statement of the
  mechanism, and the one the surveyed estate was exposed to.

Coverage: the value corpus runs across `insert`, `find`, `findBy`, `findOneBy`, `update`,
`updateBy`, `deleteBy`, `MutationBuilder` directly, `Repository::fetchAll` with hand-written SQL,
inside `withTransaction`, and with a `RowNormalizer` configured; the identifier corpus runs across
every criteria key, every value key and the table name.

## Changes

- **`src/test/.../Database/Fixture/InjectionPayloads.php`** — the one corpus (values +
  identifiers), with the merge history recorded in its docblock.
- **`src/test/.../Persistence/GatewayInjectionTest.php`** — T-13, `#[Group('T-13')]`.
- `InjectionTest`, `QueryBuilderTest`, `MutationBuilderTest` — providers now delegate to the
  fixture; their names, attributes and groups are unchanged.
- `PersonGateway` fixture — two methods so T-13 can reach `Repository::fetchAll()` with
  hand-written SQL and a gateway write inside `withTransaction()`.
- **spec r12** — §6 now describes T-13's identifier leg and consequence assertions, which the
  one-line r3 description did not mention. **No new ADR:** the decision this rests on is
  ADR-0017's; minting one to look thorough would be worse than saying so.

## Design Patterns

- None added or changed (test-only). The catalogue is untouched.

## Verification

- [x] **2400 tests** overall (+630); `--group T-13` **578**, `--group T-02` 359 — both green
- [x] PHPStan max clean · PHP-CS-Fixer clean · deptrac **0 violations / 0 uncovered / 253 allowed**
- [x] `python tools/consistency_lint.py` passes
- [x] Leak-gate over the staged diff: zero matches
- [x] **Seven planted defects, seven caught** — values interpolated on three paths, the read
      builder's `WHERE` interpolated and reached *through* the gateway, the allowlist bypassed,
      the parameter groups swapped, and one aimed at the suite itself: **emptying the log before
      asserting**, to confirm the vacuity guard fires rather than passing on nothing. The restore
      step worked this time because item 10.4's lesson (stage first, or `git checkout` silently
      restores nothing) was applied from the start.
- [ ] Mutation score — CI's job; no production code changed, so no movement expected

## Documentation Impact

- [x] Spec r12 (§6 T-13 as delivered)
- [x] ROADMAP item 10.5 checked with its findings; journal checkpoint added
- [x] CHANGELOG — `Added` (the suite) and `Changed` (the corpus unification)
- [ ] ADR — none, deliberately (see above)
- [ ] README / patterns — unchanged

## Lesson

Lesson: the rule you just wrote down applies to the code you write next, including the tests —
ADR-0044 argued against a duplicated allowlist and was merged the same day I duplicated the corpus
that tests one. The second copy is always somewhere the rule did not literally name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
