### PR TITLE
feat(bench): wire NFR-09 -- the gateway ratio against a hand-written PDO loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,11 @@ jobs:
         shell: bash
         run: |
           python3 tools/bench_ratio_gate.py build/logs/head.xml             --numerator benchHydrateWarm --denominator benchManualConstruction --max-ratio 3
+      - name: NFR-09 ratio — gateway fetch+normalize+hydrate vs hand-written PDO
+        if: steps.cfg.outputs.present == 'true'
+        shell: bash
+        run: |
+          python3 tools/bench_ratio_gate.py build/logs/head.xml             --numerator benchGatewayFetchNormalizeHydrate --denominator benchHandWrittenPdoLoop --max-ratio 1.5
       - name: Resolve the base commit to compare against
         if: steps.cfg.outputs.present == 'true'
         id: base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,21 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   subjects in one run) already covers a new pair. Both subjects share one `PDO` connection and
   a 100-row table seeded once, so the comparison is `TableGateway::all()` (select, normalize via
   `RowNormalizer`, hydrate through the warmed reflection cache) against a hand-written loop over
-  the identical read and the identical `trim()`-only normalization, applied by hand.
+  the identical read and the identical `trim()`-only normalization, applied by hand. **CI's
+  measured ratio is 1.85×, over the spec's <= 1.5× budget** — profiled honestly rather than
+  massaged; the gap traces to hydration's own already-optimized cost (item 7.1's accepted 2.40×
+  vs. manual construction, ADR-0013), diluted by shared fetch+normalize work both sides pay
+  equally. Filed as roadmap item **10.10** rather than decided unilaterally (a spec-budget or
+  hydration-optimization call, either of which is out of this item's `fast/medium` route).
+
+### Fixed
+
+- **`TableGateway::query()` no longer rebuilds its base query on every call** (found while
+  investigating NFR-09, above) — the table name and projected columns were re-run through
+  `Identifier`'s allowlist on every read even though neither can change after construction. Cached
+  per instance, the same shape as the existing projection cache and ADR-0020's driver-lookup fix.
+  A real, safe reduction in the gateway's own bookkeeping cost; not the fix for NFR-09's gap (see
+  above), and not a behavior change for any caller.
 
 - **Spec §7's T-13 suite** (roadmap item **10.5**; spec **r12**) — 578 tests proving, at the PDO
   boundary, that every `TableGateway`/`Repository`/`MutationBuilder` path sends **placeholders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **phpbench benchmark for NFR-09** (spec §3, RFC-0002; roadmap item **10.6**): `GatewayBench`
+  under `src/bench/php/d4np/utils/`, wired into the `bench_ratio_gate.py` cross-subject
+  comparison ADR-0011 established (`benchGatewayFetchNormalizeHydrate` /
+  `benchHandWrittenPdoLoop` ≤ 1.5×). No new ADR and no production code change: ADR-0011's
+  standing decision (a same-invocation ratio, since PHPBench's own `@Assert` cannot compare two
+  subjects in one run) already covers a new pair. Both subjects share one `PDO` connection and
+  a 100-row table seeded once, so the comparison is `TableGateway::all()` (select, normalize via
+  `RowNormalizer`, hydrate through the warmed reflection cache) against a hand-written loop over
+  the identical read and the identical `trim()`-only normalization, applied by hand.
+
 - **Spec §7's T-13 suite** (roadmap item **10.5**; spec **r12**) — 578 tests proving, at the PDO
   boundary, that every `TableGateway`/`Repository`/`MutationBuilder` path sends **placeholders
   only**, with the payload appearing solely in the bound-parameter array. Two legs: the value

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -864,7 +864,28 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       scale. **Local timing is informative only** (this machine's `vendor/bin/phpbench` fails
       its own environment-detection capture before any subject runs — the pre-existing,
       documented quirk items 4.5/4.6/9.6 all hit); CI's `ubuntu-24.04` run is what the ≤ 1.5×
-      gate is wired against.
+      gate is wired against. **CI's own numbers: 160.591 µs / 86.767 µs = 1.85× — the gate
+      FAILS, and item 10.10 is filed rather than the number massaged.** Profiling in-process
+      (real `Hydrator`/`RowNormalizer`, no benchmark harness, `hrtime`) before accepting the
+      miss found one real, safe win — `TableGateway::query()` re-ran `Identifier`'s allowlist
+      on the table name and every projected column on **every call**, though neither can
+      change after construction; cached per instance (perf commit, no ADR — the same
+      resolve-once shape as the existing `$projection` cache and ADR-0020's driver lookup).
+      It moved the ratio from **1.82× to 1.85×** — within run-to-run noise, because it was
+      never the dominant cost: of the ~416 µs total, `select()` alone costs ~114 µs,
+      `RowNormalizer::normalize()` adds ~98 µs, and **hydration adds ~184 µs — 44% of the
+      total, and the whole gap.** Both `select()` and `normalize()` cost the manual loop
+      roughly the same (it replicates the identical read and the identical `trim()`), so they
+      wash out of the ratio; hydration does not, because the manual side pays a direct
+      constructor call for the equivalent step. **The arithmetic that makes 1.5× very likely
+      unreachable as specified:** item 7.1 measured hydration itself, already through
+      ADR-0013's compiled-closure fast path (which `GatewayRow` qualifies for — builtin,
+      non-variadic, no-default constructor parameters), at **2.40× a manual constructor
+      call** — a floor this project spent a whole `standard/high` item (3.7) reaching and has
+      not since beaten. Diluted by the shared fetch+normalize cost, that floor propagates to
+      almost exactly the 1.82-1.85× measured here. Closing the remaining gap would mean
+      re-opening item 3.7's own optimization, which is out of this item's `fast/medium`
+      route — filed as item 10.10 instead of attempted here.*
 - [x] 10.7 Make FR-33's guarantee **mechanical** instead of organizational: annotate
       `SqlStatement::__construct()`'s `$sql` as `@param literal-string`, so PHPStan at max
       level — a gate this project already runs — *refuses* a value interpolated or
@@ -945,6 +966,24 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       documented protocol. Whichever is picked, **a gate that cries wolf on a docs-and-tests PR
       teaches people to re-run until green**, which is the failure mode worth spending an item on
       — route: standard / medium (adr)
+- [ ] 10.10 Decide what to do about NFR-09's `bench_ratio_gate` step being **red on `master`**:
+      `TableGateway::all()` measures **1.85×** a hand-written PDO loop (item 10.6) against the
+      spec's ≤ 1.5× budget, and one safe, real optimization (caching the gateway's base
+      `QueryBuilder` per instance, landed in the same PR) moved it from 1.82× to 1.85× — noise,
+      not progress, because the dominant cost was never there. Profiled before filing rather
+      than guessed: of ~416 µs total, `select()` costs ~114 µs and `RowNormalizer::normalize()`
+      ~98 µs — both paid roughly equally by the manual loop too, so they wash out of the
+      ratio — and **hydration adds ~184 µs, the entire gap**. Item 7.1 already measured
+      hydration itself (through ADR-0013's compiled-closure fast path, which `GatewayRow`
+      qualifies for) at **2.40× a manual constructor call**, a floor a whole `standard/high`
+      item was spent reaching; diluted by the shared fetch+normalize cost, that floor
+      arithmetically propagates to almost exactly 1.8×. Two honest paths, not one: **(a)**
+      revisit whether 1.5× was ever reachable given NFR-01's own accepted floor — a spec-scope
+      question (ADR-0040's rule: the spec owns its own numbers, not an agent unilaterally), or
+      **(b)** a further hydration investigation beyond item 3.7's — which would mean re-opening
+      a `standard/high` decision from a `fast/medium` item, the same over-reach item 10.9
+      already named as the wrong move. Filed rather than either decided here — route: standard
+      / medium (adr)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — The corpus that protected the older builder](docs/journal/2026/08/2026-08-06-t13-gateway-injection.md).
+  [2026-08-06 — Measuring the overhead a gateway is honest about](docs/journal/2026/08/2026-08-06-gateway-bench.md).
 
 ## Model & effort routing (advisory)
 
@@ -843,8 +843,28 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       writes the criterion into the column. 7 planted defects, 7 caught, including one aimed at
       the suite's own vacuity guard; the restore step worked this time because item 10.4's lesson
       (stage the files first) was applied.*
-- [ ] 10.6 phpbench: NFR-09 gateway-vs-hand-written-PDO ratio (`bench_ratio_gate` pattern,
-      ADR-0011 precedent) (RFC-0002) (step:optimize) — size: S · route: fast / medium
+- [x] 10.6 phpbench: NFR-09 gateway-vs-hand-written-PDO ratio (`bench_ratio_gate` pattern,
+      ADR-0011 precedent) (RFC-0002) (step:optimize) — size: S · route: fast / medium ·
+      **no new ADR** — the ratio-gate mechanism is ADR-0011's, applied to a new pair of
+      subjects, same as item 9.6 applied ADR-0030's harness rather than re-arguing it.
+      *`GatewayBench` measures `TableGateway::all()` (fetch + normalize-via-`RowNormalizer` +
+      hydrate, 100 rows) against a hand-written loop over the same shared `PDO` connection and
+      table — the identical `SELECT`, the identical `trim()`-only normalization applied by
+      hand under the same `is_string()` guard `RowNormalizer` itself uses, and a direct
+      `new GatewayRow(...)` with no reflection. Both subjects share one connection (SQLite
+      `:memory:` cannot be reopened) and one 100-row table, seeded once outside every timed
+      iteration — item 3.5's warm-cache convention, applied to a warmed `ReflectionCache` and
+      one discarded warm-up call so the gateway's own lazily-cached column projection is paid
+      for before the clock starts, exactly as NFR-01's benchmark warms reflection first.
+      **The comparison choice worth stating:** the manual loop reads via `$pdo->query()`
+      rather than `DatabaseConnection::select()`, because the statement has no bound value at
+      all — nobody hand-rolling this read would reach for a prepared statement over a literal
+      `SELECT`, and the gateway is not exempt from real prepares (ADR-0014) just because this
+      benchmark exists. That asymmetry is the overhead NFR-09 is measuring, not a thumb on the
+      scale. **Local timing is informative only** (this machine's `vendor/bin/phpbench` fails
+      its own environment-detection capture before any subject runs — the pre-existing,
+      documented quirk items 4.5/4.6/9.6 all hit); CI's `ubuntu-24.04` run is what the ≤ 1.5×
+      gate is wired against.
 - [x] 10.7 Make FR-33's guarantee **mechanical** instead of organizational: annotate
       `SqlStatement::__construct()`'s `$sql` as `@param literal-string`, so PHPStan at max
       level — a gate this project already runs — *refuses* a value interpolated or

--- a/docs/journal/2026/08/2026-08-06-gateway-bench.md
+++ b/docs/journal/2026/08/2026-08-06-gateway-bench.md
@@ -44,6 +44,58 @@ number is recorded in the follow-up commit to this PR, once it exists — the sa
 items 9.6 and 3.7 used: wire first, record the real measurement second, so a reader never has to
 take a number on faith from a machine that cannot run the tool.
 
+## The number, and the fix that wasn't enough
+
+CI's real number: **1.85×**, against the 1.5× budget. This is red, and it stays red in this PR —
+not because nothing was tried, but because what was tried was profiled first and turned out not
+to touch the actual cost.
+
+Profiling in-process — the real `Hydrator` and `RowNormalizer`, `hrtime`, no benchmark harness in
+the loop — found one legitimate win before accepting the miss: `TableGateway::query()` built a
+fresh `QueryBuilder` on every single call, which re-ran `Identifier`'s allowlist on the table name
+(already checked once, in the constructor) and on every projected column, every time — pure
+repetition, since neither can change after construction. Cached per instance, safely: `QueryBuilder`
+is immutable and every fluent method already returns a `clone`, so a caller chaining off the shared
+cached base can never see or corrupt what the next caller gets. It moved the ratio from 1.82× to
+1.85× — noise, not progress.
+
+That was the tell that the real cost lay elsewhere. Breaking the ~416 µs total down: `select()`
+alone costs ~114 µs, `RowNormalizer::normalize()` adds ~98 µs — and **hydration adds ~184 µs, 44%
+of the total and the entire gap**, because the manual loop pays roughly the same for the read and
+the trim (it replicates both by hand) but pays almost nothing for its equivalent of hydration — a
+direct `new GatewayRow(...)` call.
+
+That number was not a surprise once one more fact was checked: item 7.1 already measured hydration
+itself, through ADR-0013's compiled-closure fast path (which `GatewayRow` qualifies for — builtin,
+non-variadic, no-default parameters), at **2.40× a manual constructor call**. That is not an
+unoptimized number — it is the floor a whole `standard/high` item (3.7) was spent reaching, and
+nothing has beaten it since. Diluted by the shared fetch+normalize cost both subjects pay, that
+floor arithmetically propagates to almost exactly the 1.8× measured here. NFR-09's 1.5× budget was,
+very likely, never reachable as specified — not because this item under-delivered, but because it
+asks a gateway that must hydrate to beat a comparison that does not, by a margin smaller than
+hydration's own accepted cost.
+
+**Filed as item 10.10 rather than decided here.** Two honest paths exist — revisit the budget
+(a spec-scope decision this project's own rule, ADR-0040, reserves for the maintainer, not an
+agent) or reopen hydration's optimization (a `standard/high`-sized decision, which a `fast/medium`
+item has no business making unilaterally — exactly the over-reach item 10.9 already named two
+items ago). Both are named; neither is chosen.
+
+## A two-hour detour that was not this project's problem
+
+Between pushing the wiring commit and CI running it at all, nothing happened for roughly two
+hours — a genuine, GitHub-wide Actions incident (webhook triggers throttled to aid recovery,
+confirmed against the public status feed rather than assumed from silence), not anything in this
+branch. Verified rather than guessed: `git diff origin/master...HEAD --name-only` showed the branch
+untouched by anything CI-relevant while waiting, and the incident's own status updates tracked the
+exact symptom seen here (no run appearing at all, as distinct from a run appearing and failing).
+Once GitHub declared webhook throughput restored and ten more minutes still produced nothing, the
+original event had been dropped rather than delayed — an empty, no-op commit was pushed to
+generate a fresh `synchronize` event, which is what finally got this PR's first real run to start.
+Worth recording as its own class of "not a code problem": distinguish a dropped webhook from a
+merely slow one by checking the platform's own status before waiting indefinitely on a retry that
+was never coming.
+
 ## No new ADR, deliberately
 
 The mechanism here — a same-invocation ratio computed by `bench_ratio_gate.py` because PHPBench's
@@ -55,5 +107,8 @@ worth noticing: not every item earns one, and forcing the ceremony would cheapen
 
 ## Lesson
 
-A fairness decision in a comparative benchmark deserves the same treatment as a security decision:
-name the asymmetry you kept, and say why, before someone "fixes" it into meaninglessness.
+Two lessons, not one. A fairness decision in a comparative benchmark deserves the same treatment
+as a security decision: name the asymmetry you kept, and say why, before someone "fixes" it into
+meaninglessness. And a small, real, safe optimization that moves a number by noise is itself a
+finding — it is what proves the cost lies somewhere else, and profiling before filing is what told
+the difference between "unoptimized" and "already at this project's own accepted floor."

--- a/docs/journal/2026/08/2026-08-06-gateway-bench.md
+++ b/docs/journal/2026/08/2026-08-06-gateway-bench.md
@@ -1,0 +1,59 @@
+# 2026-08-06 — Measuring the overhead a gateway is honest about
+
+Roadmap item **10.6**, closing Milestone 10 alongside the follow-up item 10.9 filed at 10.5. Route
+`fast / medium`; session model Sonnet 5, no mismatch — the first item this session that matched
+its route on the first try.
+
+## The comparison had to survive one honest question first
+
+NFR-09 asks for the gateway's fetch-normalize-hydrate path against *"a hand-written PDO loop doing
+the same work"*. Before writing a subject, the question worth settling was what "the same work"
+actually means, because a benchmark that quietly does less work on one side is not measuring
+overhead — it is measuring the gap it created.
+
+Two decisions followed from taking that literally:
+
+- **The manual loop trims strings by hand**, under the exact `is_string($value)` guard
+  `RowNormalizer::normalize()` uses. A version that skipped normalization on the manual side would
+  make the gateway pay for work its opponent never did.
+- **The manual loop reads via `$pdo->query()`, not a prepared statement.** This one needed a
+  decision, not just a mirror: the read has no bound value at all, and nobody hand-rolling a
+  literal `SELECT` reaches for `prepare()`/`execute()` over `query()`. The gateway does not get
+  that shortcut — `DatabaseConnection::select()` always prepares, because ADR-0014 pins real
+  prepares as the connection's own security default and this benchmark is not a reason to bypass
+  it. That asymmetry — one round trip the hand-written loop skips and the gateway cannot — **is**
+  part of what NFR-09 is pricing, not an unfair thumb on the scale. Naming it here is what stops a
+  future reader from "fixing" the fairness by giving the manual loop back its shortcut.
+
+Both subjects share one `PDO` connection and one 100-row table, seeded once outside every timed
+iteration — item 3.5's warm-cache convention, extended here to a warmed `ReflectionCache` and one
+discarded warm-up call so the gateway's own lazily-cached column projection is paid for before the
+clock starts.
+
+## What the local number is worth, and why CI's is the one that counts
+
+Direct PHP timing on this machine measured a ratio near 1.9×, over the 1.5× budget. This is
+**not** treated as the answer: `vendor/bin/phpbench`'s own CLI fails its environment-detection
+capture on this box before any subject runs — the same pre-existing quirk items 4.5, 4.6 and 9.6
+all hit and all deferred to CI for the same reason. A local number that cannot even get PHPBench to
+start is not a number to act on; it went into this journal as a sanity check that the benchmark
+*runs* and produces a plausible order of magnitude, nothing more.
+
+CI's Linux run is what the `bench_ratio_gate.py --max-ratio 1.5` step actually gates on, and that
+number is recorded in the follow-up commit to this PR, once it exists — the same two-commit shape
+items 9.6 and 3.7 used: wire first, record the real measurement second, so a reader never has to
+take a number on faith from a machine that cannot run the tool.
+
+## No new ADR, deliberately
+
+The mechanism here — a same-invocation ratio computed by `bench_ratio_gate.py` because PHPBench's
+own `@Assert` cannot compare two subjects in one run — is ADR-0011's, from item 3.5. This item
+applies it to a new pair of subjects and decides no new tradeoff; item 9.6 made the identical call
+for ADR-0030's harness, and T-13 made it for ADR-0017's boundary decision two items ago. Three
+items in a row now that shipped real work with no ADR, each saying so and why — which is itself
+worth noticing: not every item earns one, and forcing the ceremony would cheapen the ones that do.
+
+## Lesson
+
+A fairness decision in a comparative benchmark deserves the same treatment as a security decision:
+name the asymmetry you kept, and say why, before someone "fixes" it into meaninglessness.

--- a/src/bench/php/d4np/utils/Fixture/GatewayRow.php
+++ b/src/bench/php/d4np/utils/Fixture/GatewayRow.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench\Fixture;
+
+use D4np\Utils\Dto\DataTransferObject;
+
+/**
+ * The flat row shape {@see \D4np\Utils\Bench\GatewayBench} projects — one property per column,
+ * because that is what `TableGateway` is for (a nested DTO or a `Collection` belongs behind a
+ * `Repository` subclass, not this class, per its own docblock).
+ */
+final class GatewayRow extends DataTransferObject
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+        public readonly ?int $age,
+        public readonly ?string $status,
+    ) {
+    }
+}

--- a/src/bench/php/d4np/utils/GatewayBench.php
+++ b/src/bench/php/d4np/utils/GatewayBench.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench;
+
+use D4np\Utils\Bench\Fixture\GatewayRow;
+use D4np\Utils\Database\DatabaseConnection;
+use D4np\Utils\Database\SqlStatement;
+use D4np\Utils\Persistence\RowNormalizer;
+use D4np\Utils\Persistence\TableGateway;
+use D4np\Utils\Support\ReflectionCache;
+use PDO;
+use PhpBench\Attributes as Bench;
+
+/**
+ * NFR-09: `Repository`/`TableGateway` fetch + normalize + hydrate 100 rows ≤ 1.5× a hand-written
+ * PDO loop doing the same work.
+ *
+ * **Same shape as NFR-01's ratio half** (roadmap 3.5), for the same reason: PHPBench's own
+ * `@Assert` compares a subject against a previous *tagged* run, never against a sibling subject
+ * in the same run, so the relative budget is computed by `tools/bench_ratio_gate.py` from the
+ * `--dump-file` XML rather than asserted in-process. Both subjects run on identical hardware in
+ * the same invocation, so clock-speed and virtualization noise apply to numerator and
+ * denominator alike and mostly cancel out of the ratio.
+ *
+ * **"The same work" is checked, not assumed.** The gateway subject does what `TableGateway::all()`
+ * actually does: select the projected columns, run every string value through a configured
+ * {@see RowNormalizer} (its default policy — trim only, ADR-0042), then hydrate through the
+ * shared, warmed {@see ReflectionCache} (ADR-0006). The hand-written subject reads the identical
+ * SQL against the identical connection, trims every string value itself — the same condition
+ * {@see RowNormalizer::normalize()} tests, `is_string($value)` — and constructs
+ * {@see GatewayRow} directly, with no reflection at all. A version of this benchmark that trimmed
+ * only the manual loop, or hydrated without a normalizer configured on the gateway side, would be
+ * measuring two different things and reporting the difference as gateway overhead.
+ *
+ * Both subjects share one `PDO` connection (`sqlite::memory:` cannot be reopened — a second `PDO`
+ * would see an empty database) and one 100-row table, seeded once outside every timed iteration,
+ * matching {@see HydrationBench}'s warm-cache convention: NFR-09 budgets steady-state cost, not
+ * the one-time price of the first reflection lookup or the first connection.
+ */
+#[Bench\BeforeMethods('setUp')]
+#[Bench\Iterations(10)]
+#[Bench\Revs(100)]
+#[Bench\RetryThreshold(5)]
+final class GatewayBench
+{
+    private const ROW_COUNT = 100;
+
+    private PDO $pdo;
+
+    private DatabaseConnection $connection;
+
+    /** @var TableGateway<GatewayRow> */
+    private TableGateway $gateway;
+
+    public function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->connection = new DatabaseConnection($this->pdo);
+        $this->connection->execute(SqlStatement::literal(
+            'CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, age INTEGER, status TEXT)',
+        ));
+
+        for ($i = 1; $i <= self::ROW_COUNT; $i++) {
+            // Padded with whitespace deliberately: NFR-09 budgets normalize() alongside fetch and
+            // hydrate, and a value with nothing to trim would let a broken normalizer measure as
+            // free. The value returned still has to match — assertible, not merely assumed.
+            $this->connection->execute(SqlStatement::literal(
+                'INSERT INTO items (id, name, age, status) VALUES (?, ?, ?, ?)',
+                [$i, "  Row {$i}  ", 20 + ($i % 50), $i % 7 === 0 ? null : ' active '],
+            ));
+        }
+
+        $cache = new ReflectionCache();
+        $cache->for(GatewayRow::class); // warmed once, outside every timed iteration
+
+        $this->gateway = new TableGateway(
+            $this->connection,
+            'items',
+            GatewayRow::class,
+            'id',
+            new RowNormalizer(),
+            $cache,
+        );
+
+        // One warm call, discarded, so the gateway's own lazily-resolved projection (cached on
+        // the instance after its first use — Persistence\TableGateway) is paid for here too.
+        $this->gateway->all();
+    }
+
+    /**
+     * The subject NFR-09 names: fetch, normalize, hydrate — 100 rows, through the library.
+     *
+     * @return list<GatewayRow>
+     */
+    public function benchGatewayFetchNormalizeHydrate(): array
+    {
+        return $this->gateway->all();
+    }
+
+    /**
+     * The comparison point NFR-09 names directly: the same read and the same trimming, written
+     * by hand against the same connection, with no reflection and no allowlist.
+     *
+     * @return list<GatewayRow>
+     */
+    public function benchHandWrittenPdoLoop(): array
+    {
+        $statement = $this->pdo->query('SELECT id, name, age, status FROM items');
+        $rows = $statement === false ? [] : $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        $hydrated = [];
+
+        foreach ($rows as $row) {
+            foreach ($row as $column => $value) {
+                // The exact condition RowNormalizer::normalize() applies: only string values are
+                // touched, so an int/null column passes through by identity.
+                if (is_string($value)) {
+                    $row[$column] = trim($value);
+                }
+            }
+
+            $hydrated[] = new GatewayRow(
+                (int) $row['id'],
+                (string) $row['name'],
+                $row['age'] === null ? null : (int) $row['age'],
+                $row['status'] === null ? null : (string) $row['status'],
+            );
+        }
+
+        return $hydrated;
+    }
+}

--- a/src/main/php/d4np/utils/Persistence/TableGateway.php
+++ b/src/main/php/d4np/utils/Persistence/TableGateway.php
@@ -92,6 +92,11 @@ class TableGateway extends Repository
      */
     private ?array $projection = null;
 
+    /**
+     * The base `SELECT <projection> FROM <table>` builder, resolved once — see {@see self::query()}.
+     */
+    private ?QueryBuilder $baseQuery = null;
+
     private readonly ReflectionCache $cache;
 
     /**
@@ -274,11 +279,23 @@ class TableGateway extends Repository
      * hand-written SQL. `protected` because it is a building block, not part of the gateway's
      * contract with its callers.
      *
+     * **The base builder is resolved once per instance, not once per call** (roadmap 10.6,
+     * NFR-09). Every call used to construct a fresh `QueryBuilder`, which re-runs
+     * {@see Identifier}'s allowlist on the table name — already checked once in
+     * {@see self::__construct()} — and again on every projected column, on every single read.
+     * Neither can have changed since construction, so re-checking them is pure repetition, not
+     * safety: caching costs nothing, because `QueryBuilder` is immutable and every fluent method
+     * already returns a `clone` rather than mutating `$this` — a caller chaining off the cached
+     * instance can never see, or corrupt, what the next caller receives. Found by profiling
+     * `GatewayBench` against NFR-09's 1.5× budget, the same discipline roadmap item 4.6 used for
+     * NFR-03: measured first, fixed what the profile actually named.
+     *
      * @throws DatabaseException if the table or a projected column fails the allowlist
      */
     protected function query(): QueryBuilder
     {
-        return (new QueryBuilder($this->connection, $this->table))->select(...$this->projection());
+        return $this->baseQuery ??= (new QueryBuilder($this->connection, $this->table))
+            ->select(...$this->projection());
     }
 
     /**


### PR DESCRIPTION
## Summary

Roadmap item **10.6** — `GatewayBench`, wiring spec §3's NFR-09: `TableGateway::all()` (fetch,
normalize, hydrate — 100 rows) measured against a hand-written PDO loop doing the same work, via
ADR-0011's cross-subject ratio mechanism (`bench_ratio_gate.py`, `--max-ratio 1.5`).

**⚠️ This PR's `benchmark / reproducible perf` check is red, honestly and by design — see
"The real number" below before merging.** Milestone 10 does **not** close with this PR; a new
follow-up item (10.10) is filed for the maintainer's decision.

## The real number

CI: `benchGatewayFetchNormalizeHydrate` **160.591 µs** / `benchHandWrittenPdoLoop` **86.767 µs**
= **1.85×**, over the spec's ≤ 1.5× budget.

Before accepting the miss, I profiled in-process (the real `Hydrator`/`RowNormalizer`, `hrtime`, no
benchmark harness) and found one legitimate, safe fix: `TableGateway::query()` rebuilt a fresh
`QueryBuilder` on every call, re-running `Identifier`'s allowlist on the table name and every
projected column every time, though neither can change after construction. Cached per instance
(commit `fb8ffba`) — safe because `QueryBuilder` is immutable and every fluent method already
returns a `clone`. **It moved the ratio from 1.82× to 1.85×** — noise, not progress, because it was
never the dominant cost.

Breaking down the ~416 µs total: `select()` costs ~114 µs, `RowNormalizer::normalize()` adds
~98 µs — both paid roughly equally by the manual loop, so they wash out of the ratio — and
**hydration adds ~184 µs, the entire gap**. That number stopped being surprising once cross-checked
against this project's own history: item 7.1 already measured hydration itself, through
ADR-0013's compiled-closure fast path (which `GatewayRow` qualifies for), at **2.40× a manual
constructor call** — a floor a whole `standard/high` item (3.7) was spent reaching and hasn't been
beaten since. Diluted by the shared fetch+normalize cost both subjects pay, that floor
arithmetically propagates to almost exactly the 1.8× measured here.

**NFR-09's 1.5× budget was very likely never reachable as specified** — not because this item
under-delivered, but because it asks a gateway that must hydrate to beat a comparison that does
not, by a margin smaller than hydration's own accepted cost.

**Filed as item 10.10, not decided here.** Two honest paths: revisit NFR-09's budget (a spec-scope
call ADR-0040 reserves for the maintainer) or reopen hydration's optimization beyond item 3.7 (a
`standard/high`-sized decision a `fast/medium` item has no business making unilaterally — the same
over-reach item 10.9 already flagged two items ago). Both named; neither chosen.

## The fairness decision worth naming (unchanged from the original design)

The manual loop reads via `$pdo->query()`, not a prepared statement — deliberate, since the read
has no bound value and nobody hand-rolling a literal `SELECT` reaches for `prepare()`/`execute()`
over `query()`. The gateway does **not** get that shortcut (`DatabaseConnection::select()` always
prepares, ADR-0014). That asymmetry is part of what NFR-09 prices, not a thumb on the scale. The
manual loop also trims by hand under the identical `is_string()` guard `RowNormalizer` uses, so
normalization cost is paid on both sides.

## A ~2-hour detour that was not this project's problem

Between the wiring push and CI running it at all, nothing happened for roughly two hours — a
GitHub-wide Actions incident (webhook triggers throttled to aid recovery), confirmed against the
public status feed, not this branch. `git diff origin/master...HEAD --name-only` stayed empty of
anything CI-relevant the whole time. Once GitHub declared webhook throughput restored and ten more
minutes still produced nothing, the original event had been dropped rather than delayed — an
empty commit (`cb8bb5d`) generated a fresh `synchronize` event, which is what finally started this
PR's first real run.

## Changes

- **`src/bench/php/d4np/utils/GatewayBench.php`** + **`Fixture/GatewayRow.php`** — the two
  subjects and the flat DTO they project.
- **`.github/workflows/ci.yml`** — one new step, `NFR-09 ratio — gateway fetch+normalize+hydrate
  vs hand-written PDO`, alongside the existing NFR-01 ratio step. No new `uses:` entries.
- **`src/main/php/d4np/utils/Persistence/TableGateway.php`** — the base-query caching fix (real,
  safe, small; see above for why it wasn't the answer).
- ROADMAP items 10.6 (checked, with the full finding) and **10.10** (new, filed); CHANGELOG
  `Added` + `Fixed`; journal checkpoint covering the benchmark design, the profiling, and the CI
  incident.
- No spec revision — NFR-09's wording already states exactly what this implements; the budget
  itself is what item 10.10 asks the maintainer to revisit.

## Design Patterns

- None added or changed.

## Verification

- [x] PHPStan max clean · PHP-CS-Fixer clean · full suite green (2400 tests, unchanged)
- [x] Gateway/Repository tests green after the caching fix (80 tests)
- [x] `python tools/action_pin_lint.py` OK (no new pinned actions)
- [x] `python tools/consistency_lint.py` OK
- [x] Leak-gate over the staged diff: zero matches
- [x] **`benchmark / reproducible perf` — FAILS, honestly, at 1.85× vs 1.5×** (see "The real
      number"); every other CI check passes (14/15)

## Documentation Impact

- [x] ROADMAP item 10.6 checked with the finding; item **10.10** filed
- [x] CHANGELOG `Added` + `Fixed`
- [ ] ADR — none for the wiring (applies ADR-0011); item 10.10 may produce one once the
      maintainer decides which path to take
- [ ] Spec — unchanged; the budget question is item 10.10's, not resolved here

## What I need from you

This PR ships real, verified work (the benchmark, the fairness design, a genuine small
optimization) but leaves a **known-red required check** with the reason fully profiled and
documented, matching this project's own precedent for NFR-03 (items 4.5→4.6→7.1: ship the honest
number, defer the rest). Please review item 10.10's two options and let me know whether to merge
with the documented gap now, or take a specific direction on the follow-up before merging.

## Lesson

Two lessons. A fairness decision in a comparative benchmark deserves the same treatment as a
security decision — name the asymmetry you kept, and say why. And a small, real, safe optimization
that moves a number by noise is itself a finding: it is what proves the cost lies elsewhere, and
profiling before filing is what tells "unoptimized" apart from "already at this project's own
accepted floor."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
