### PR TITLE
ci(bench): exclude I/O-bound and memory-hard subjects from the regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,12 @@ jobs:
       - name: Regression gate — NFR-06's 10% budget
         if: steps.cfg.outputs.present == 'true' && steps.base.outputs.sha != ''
         shell: bash
-        run: python3 tools/bench_regression_gate.py build/logs/base.xml build/logs/head.xml --max-regression 10
+        run: |
+          python3 tools/bench_regression_gate.py build/logs/base.xml build/logs/head.xml \
+            --max-regression 10 \
+            --exclude "FileSequenceBench::benchSequenceNext" \
+            --exclude "HashBench::benchMakeArgon2id" \
+            --exclude "HashBench::benchVerifyArgon2id"
       - name: Keep the reports
         if: steps.cfg.outputs.present == 'true' && always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`tools/bench_regression_gate.py` gains `--exclude Benchmark::subject`** (spec NFR-06; roadmap
+  item **10.9**; **ADR-0045**): a repeatable flag that removes a named subject from the gate's
+  pass/fail decision while keeping it in the printed report (marked `skipped`, never silently
+  dropped). Wired in `ci.yml` for exactly three subjects — `FileSequenceBench::benchSequenceNext`,
+  `HashBench::benchMakeArgon2id`, `HashBench::benchVerifyArgon2id` — whose dominant cost (real
+  filesystem locking, or Argon2id's deliberate memory-hardness) made a same-runner A/B fire on
+  noise: item 10.5's test-only PR measured `+40.10%` and `+13.75%` on these two and passed
+  cleanly on re-run of the identical commit. Both stay fully covered by their own absolute budget
+  in `bench_budget_gate.py`, which is what NFR-10 and NFR-05 actually specify.
+
 - **phpbench benchmark for NFR-09** (spec §3, RFC-0002; roadmap item **10.6**): `GatewayBench`
   under `src/bench/php/d4np/utils/`, wired into the `bench_ratio_gate.py` cross-subject
   comparison ADR-0011 established (`benchGatewayFetchNormalizeHydrate` /

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-06 — Measuring the overhead a gateway is honest about](docs/journal/2026/08/2026-08-06-gateway-bench.md).
+  [2026-08-07 — A gate that cried wolf about noise it could name](docs/journal/2026/08/2026-08-07-regression-gate-exclusions.md).
 
 ## Model & effort routing (advisory)
 
@@ -949,7 +949,7 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       escaped set is now a CI artifact with a per-mutator breakdown but is **not** chased here;
       and the MSI cannot be measured on the maintainer's machine (no coverage driver — the
       same limit as the suite's 9 skips and item 9.6's benchmark caveat).*
-- [ ] 10.9 Decide what the >10% regression gate should do about **I/O-bound and memory-hard
+- [x] 10.9 Decide what the >10% regression gate should do about **I/O-bound and memory-hard
       subjects**, which it currently cannot measure to that precision. Filed from evidence
       produced by item 10.5, a **test-only** PR whose diff touches no file under `src/main`
       (verified, not assumed): the gate failed with
@@ -960,12 +960,24 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       problem ADR-0030 already solved — base and HEAD were measured on the same runner, as that
       ADR requires — so it is a second, narrower finding: **a same-runner A/B is still not
       precise enough for a subject dominated by filesystem locking or by memory-hard hashing**,
-      where the shared runner's noise is in the same order as the budget. Options to weigh (none
-      chosen here): a per-subject threshold, best-of-N for the two classes, excluding them from
-      the relative gate while keeping their absolute ceilings, or accepting re-runs as the
-      documented protocol. Whichever is picked, **a gate that cries wolf on a docs-and-tests PR
-      teaches people to re-run until green**, which is the failure mode worth spending an item on
-      — route: standard / medium (adr)
+      where the shared runner's noise is in the same order as the budget — route: standard /
+      medium (adr) · **ADR-0045**. *Decided: **exclude, keep the absolute budget as the real
+      gate**, over a wider per-subject threshold (arbitrary, still not principled), best-of-N
+      (multiplies every PR's benchmark cost to fix two subjects), or accepting re-runs (the
+      item's own framing already rejected this: "a gate that cries wolf ... teaches people to
+      re-run until green"). `bench_regression_gate.py` gains a repeatable `--exclude
+      Benchmark::subject` — the subject still prints in the report, marked `skipped` rather than
+      silently dropped (the same absence-is-failure discipline this tool already holds to for
+      missing reports). Excludes exactly three: `FileSequenceBench::benchSequenceNext`,
+      `HashBench::benchMakeArgon2id`, `HashBench::benchVerifyArgon2id` — `benchMakeBcrypt` stays
+      in the relative gate, since bcrypt's cost is pure CPU time with no memory contention and
+      it has not shown this failure mode; being slow and being noisy-relative-to-itself are
+      different properties, and the ADR states the criterion (real I/O with locking, or a
+      deliberately memory-hard primitive) so this is a rule, not three names bolted on.
+      Verified directly (this tool has no pytest suite, matching every other `tools/*.py` gate):
+      a synthetic fixture reproducing item 10.5's exact numbers now reports `skipped` and exits
+      0 with `--exclude`, still exits 1 without it, and an `--exclude` naming a subject absent
+      from the report fails loudly rather than silently meaning nothing.*
 - [ ] 10.10 Decide what to do about NFR-09's `bench_ratio_gate` step being **red on `master`**:
       `TableGateway::all()` measures **1.85×** a hand-written PDO loop (item 10.6) against the
       spec's ≤ 1.5× budget, and one safe, real optimization (caching the gateway's base

--- a/docs/adr/0045-exclude-io-bound-and-memory-hard-subjects-from-the-relative-gate.md
+++ b/docs/adr/0045-exclude-io-bound-and-memory-hard-subjects-from-the-relative-gate.md
@@ -1,0 +1,134 @@
+# ADR-0045: Exclude I/O-bound and memory-hard subjects from the relative regression gate
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item 10.9 · spec NFR-06, NFR-10, NFR-05 ·
+  [ADR-0030](0030-same-runner-ab-because-a-stored-baseline-cannot-carry-a-10-percent-gate.md)
+  (the same-runner A/B this narrows, and the gate this amends) ·
+  [ADR-0018](0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md) and
+  [ADR-0024](0024-assert-the-work-factor-not-the-wall-clock.md) (the absolute-vs-relative split
+  this extends)
+
+## Context
+
+ADR-0030 measured that a same-runner A/B leaves NFR-06's 10% regression threshold roughly six
+times the noise floor it has to clear — for the subjects it measured. Item 10.5, a **test-only**
+PR whose diff touched no file under `src/main` (verified: `git diff origin/master...HEAD
+--name-only | grep src/main` returned nothing), failed that same gate anyway:
+
+```
+FileSequenceBench::benchSequenceNext: 75.503 -> 105.779 (+40.10%)
+HashBench::benchVerifyArgon2id: 113465.370 -> 129072.012 (+13.75%)
+```
+
+The identical commit passed cleanly on re-run. Neither subject is new to this project's noise
+budget by design — `FileSequenceBench` already carries `RetryThreshold(5)`, and `HashBench`
+already carries `RetryThreshold(20)`, both above this project's typical `5`, presumably because
+someone already suspected these two were noisier. Raising the *within-run* retry tolerance did
+not stop the *cross-run* (base vs. HEAD) comparison from firing.
+
+This is not ADR-0030's problem restated: base and HEAD were measured on the same runner, exactly
+as that ADR requires, and every other subject in the same run — including the whole `HydrationBench`
+and `QueryBuilderBench` families — passed without incident. It is a narrower, second finding: **a
+same-runner A/B is still not precise enough for a subject whose dominant cost is filesystem
+locking or memory-hard hashing.**
+
+The mechanism explains why, for each subject:
+
+- **`FileSequenceBench::benchSequenceNext`** measures `FileSequence::next()`, whose cost is an
+  `flock()` acquire, a read, and an atomic rewrite-via-rename (`File::update()`, ADR-0005/0038).
+  On a shared CI runner this touches the filesystem layer directly — page cache state, disk queue
+  depth from other work on the same VM, and the underlying storage backend's own latency
+  variance, none of which the PHP process controls or can retry its way around.
+- **`HashBench::benchVerifyArgon2id` / `benchMakeArgon2id`** measure Argon2id, which is
+  **deliberately memory-hard** (NFR-05, ADR-0022/0024) — its whole security property is that it
+  contends for the machine's memory bandwidth. A shared runner's other tenants (or even the CI
+  job's own earlier steps) leave a memory-pressure signature that a CPU-bound benchmark like
+  `HydrationBench` never sees.
+
+Both properties are exactly why the spec budgets them **absolutely**, not relatively: NFR-10 is a
+ceiling (≤ 200 µs), NFR-05 is a range (50–200 ms) already enforced by `bench_budget_gate.py`
+(ADR-0030 §2). The relative gate on top of that was asking these two subjects for 10%-precision
+their underlying mechanism cannot supply on shared hardware — a demand the spec itself never made
+of them.
+
+## Decision
+
+**`tools/bench_regression_gate.py` gains a repeatable `--exclude Benchmark::subject` flag.** An
+excluded subject is removed from the pass/fail decision but **not** from the report: it prints
+with a `skipped` marker instead of a percentage, and a `NOTICE` line names it and points at its
+absolute budget — the same "absence is failure, but an exclusion is not an absence" discipline the
+`new`/`disappeared` handling already holds to. `ci.yml`'s regression-gate step excludes exactly
+three subjects:
+
+```
+--exclude "FileSequenceBench::benchSequenceNext"
+--exclude "HashBench::benchMakeArgon2id"
+--exclude "HashBench::benchVerifyArgon2id"
+```
+
+**The criterion, stated so this stays a rule rather than three names bolted on:** a subject
+qualifies for `--exclude` when its dominant, unavoidable cost is (a) real filesystem I/O with
+locking — not CPU work that happens to touch a file, but a lock-acquire/write/fsync-class
+operation — or (b) a primitive that is deliberately memory-hard or work-factor-hard by security
+design (Argon2id today; any future KDF or password hash joins it on the same reasoning). A subject
+that is merely *slow* does not qualify — `HashBench::benchMakeBcrypt` stays in the relative gate,
+because bcrypt's cost is pure CPU time-cost with no memory contention, and it has not shown this
+failure mode. Being slow in absolute terms and being *noisy relative to itself* are different
+properties; only the second earns an exclusion.
+
+**Both excluded classes keep every other protection this project has for them:**
+
+- Their absolute ceiling/range in `bench_budget_gate.py` runs unchanged, on every PR.
+- The nightly workflow (ADR-0030 §3) still runs their absolute budgets; it never ran the relative
+  comparison at all, so nothing changes there.
+- `RetryThreshold` stays elevated for both, since it still helps the *within-run* measurement even
+  though it cannot fix the *cross-run* comparison.
+
+## Alternatives Considered
+
+1. **A wider per-subject threshold** (e.g. 50% for these two) — rejected: arbitrary, still not
+   principled against a bad-luck spike, and it would silently normalize "sometimes this fires for
+   no reason" instead of naming the reason and removing the check that cannot be satisfied.
+2. **Best-of-N full measurement pairs** (run base+head N times, compare the best pair) — rejected:
+   multiplies the cost of *every* PR's benchmark job (which already re-installs and re-measures a
+   full second checkout) to fix noise in two specific subjects; the cost is paid by every
+   contributor for a problem two subjects have.
+3. **Accept re-runs as the documented protocol** — rejected, and the roadmap item that filed this
+   ADR said why: *"a gate that cries wolf on a docs-and-tests PR teaches people to re-run until
+   green,"* which is the exact failure mode a regression gate exists to prevent becoming habitual.
+4. **Drop the two subjects from CI entirely** — rejected: their absolute budgets are real spec
+   requirements (NFR-10, NFR-05) and still need enforcing; only the *relative* comparison is
+   unreliable for them, not the subject itself.
+5. **A dedicated statistical test (e.g. more revs, higher retry threshold) instead of exclusion**
+   — considered and rejected as unproven: `RetryThreshold(20)` was already elevated on `HashBench`
+   before this incident and did not prevent the cross-run failure, because retry threshold governs
+   agreement *within* one phpbench run, not the gap between two separate runs measured minutes
+   apart with different ambient load on the VM.
+
+## Consequences
+
+**Easier:** the regression gate stops producing a documented false-positive class on PRs that
+never touch the affected code; a contributor no longer needs institutional memory of "just re-run
+it, that one's flaky" to trust a red check.
+
+**Harder / accepted:** a genuine regression *in* `FileSequence::next()`'s or `Hash::make()`'s own
+logic (as opposed to environmental noise) will not be caught by the 10% relative gate — only by
+its absolute budget, which has far more headroom (per ADR-0030's own table, 2.4–3.4× on the
+subjects it measured) and therefore catches a **larger** regression later than the relative gate
+would have. This is the accepted trade named in Alternative 4: the relative gate's whole value is
+catching *slow drift* the absolute ceiling cannot see (ADR-0030 §2's *"twenty commits at +9% each
+pass every one of its checks"* argument) — for these two subjects specifically, that value was
+never real, because the gate could not distinguish drift from noise in the first place.
+
+**Watch for:** any future benchmark whose dominant cost is I/O-with-locking or a memory-hard
+primitive should be evaluated against this ADR's criterion at the time it is added, rather than
+discovered by a false-positive PR the way this one was.
+
+## References
+
+- ROADMAP item 10.5 (the evidence), item 10.9 (this decision)
+- ADR-0030 (the gate this amends), ADR-0005/ADR-0038 (`File`'s locking, the mechanism behind
+  `FileSequence`'s cost), ADR-0022/ADR-0024 (Argon2id's memory-hardness and why NFR-05 is
+  work-factor-gated, not wall-clock-gated)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,3 +60,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0042](0042-trim-is-the-only-default-and-the-transcode-runs-first.md) | Trim is the only default, and the transcode runs first | Accepted |
 | [0043](0043-two-named-edges-out-of-persistence-and-no-catch-at-all.md) | Two named edges out of Persistence, and no catch at all | Accepted |
 | [0044](0044-the-write-builder-querybuilder-never-had-and-one-allowlist-for-both.md) | The write builder `QueryBuilder` never had, and one allowlist for both | Accepted |
+| [0045](0045-exclude-io-bound-and-memory-hard-subjects-from-the-relative-gate.md) | Exclude I/O-bound and memory-hard subjects from the relative regression gate | Accepted |

--- a/docs/journal/2026/08/2026-08-07-regression-gate-exclusions.md
+++ b/docs/journal/2026/08/2026-08-07-regression-gate-exclusions.md
@@ -1,0 +1,76 @@
+# 2026-08-07 — A gate that cried wolf about noise it could name
+
+Roadmap item **10.9**, closed. Route `standard / medium (adr)` — the roadmap's own filing
+deliberately did not escalate this to `frontier-reasoning` the way item 1.10 did for an
+open-ended policy question, because the decision space here was narrow: four enumerated options,
+evidence already gathered by item 10.5. Session model Sonnet 5, a tier mismatch against the
+`standard` route (resolves to Opus 5 per the catalog) — the human switched models explicitly
+mid-session via `/model`, which is model authority exercised, not a mismatch to second-guess.
+
+## The question was never "is this noise" — that was settled already
+
+Item 10.5 already proved the two failures were noise, not regressions: a test-only PR with an
+empty `src/main` diff failed the gate at `+40.10%` and `+13.75%`, and the identical commit passed
+on re-run. What item 10.9 actually asked was what to *do* about a gate that can produce that
+result — and the roadmap text was explicit that "just re-run it" is the wrong answer, because a
+gate a contributor learns to route around by retrying is a gate that has stopped protecting
+anything.
+
+## Why retry tolerance didn't already fix it
+
+Both flaky subjects already carry an elevated `RetryThreshold` — `FileSequenceBench` at 5,
+`HashBench` at 20 (double this project's typical 5) — which means someone had already noticed
+these two were noisier and reached for the obvious lever. It didn't stop the failure, and
+understanding *why* is what made the fix specific rather than a blanket workaround:
+`RetryThreshold` governs agreement **within** one phpbench invocation's iterations. The failure
+here is a **cross-run** comparison — base measured, then head measured, minutes apart, on
+whatever the VM's memory pressure and disk queue happened to be at each moment. No amount of
+in-run retrying touches that gap.
+
+The two subjects' own mechanism explains the gap directly. `FileSequence::next()` is an
+`flock()`-guarded read-modify-write against a real file — filesystem latency variance the PHP
+process doesn't control. `Hash::verify()`/`make()` on Argon2id is **deliberately** memory-hard;
+that is the security property NFR-05 exists to protect, and it is exactly what makes the subject
+sensitive to a shared runner's ambient memory pressure in a way a CPU-bound hydration benchmark
+never is.
+
+## The exclusion is a criterion, not three names
+
+The temptation with a fix like this is to special-case the two failing subjects and move on. The
+ADR states the reason instead: a subject qualifies for `--exclude` when its dominant cost is real
+I/O with locking, or a primitive that is deliberately memory-hard by security design — not merely
+"this one happened to be slow once." `HashBench::benchMakeBcrypt` stays in the relative gate on
+that test: bcrypt is CPU time-cost only, no memory contention, and has not shown the failure mode.
+The next person adding a benchmark for, say, a file-locking primitive or a KDF has something to
+check it against rather than a precedent to imitate blindly.
+
+## What the fix actually is
+
+`bench_regression_gate.py --exclude Benchmark::subject`, repeatable. An excluded subject still
+appears in the printed report — marked `skipped` rather than a percentage — because a silent drop
+would be indistinguishable from the tool simply forgetting the subject existed, and this tool's
+own docstring already commits to "absence is failure, never a pass" for missing reports and
+subjects. An `--exclude` naming something absent from the report fails loudly for the same reason:
+an exclusion that quietly means nothing once a subject is renamed is worse than no exclusion.
+
+Both excluded subjects keep everything else: their absolute budget in `bench_budget_gate.py` (the
+actual spec requirement — NFR-10's ceiling, NFR-05's range) runs unchanged on every PR, and the
+nightly workflow's absolute-budget pass is untouched, since it never ran the relative comparison
+to begin with (ADR-0030 §3).
+
+## Verified without a test suite, matching every other tool here
+
+No `tools/*.py` gate in this repo has a pytest suite — `consistency_lint.py`, `bench_ratio_gate.py`
+and the rest are all verified by direct invocation, recorded in the ADR or journal that introduces
+them (ADR-0030's own "gates proven to fail before being trusted" table is the precedent). Followed
+here: a synthetic fixture reproducing item 10.5's exact numbers confirms three cases — `--exclude`
+reports `skipped` and exits 0, the same fixture without `--exclude` still exits 1 (the underlying
+check is unchanged), and `--exclude` naming an absent subject fails loudly rather than silently.
+
+## Lesson
+
+A retry-threshold bump is a hint that a benchmark's own mechanism is noisier than the project's
+default, not a fix for a comparison the retry never touches. When the second lever (raising the
+threshold further) also wouldn't touch the actual gap, that is the signal to ask what class of
+cost the subject has that the gate's whole design assumption doesn't hold for — and to write that
+class down, so the next flaky subject is recognized rather than rediscovered.

--- a/tools/bench_regression_gate.py
+++ b/tools/bench_regression_gate.py
@@ -31,6 +31,22 @@ A subject present at HEAD but absent from the baseline is reported as **new** an
 a benchmark added by the very change under test has nothing it could have regressed against. A
 subject that has *disappeared* is likewise reported, because a benchmark deleted quietly is how a
 regression stops being visible.
+
+**`--exclude` (roadmap item 10.9, ADR-0045).** Measured, not assumed: item 10.5's own CI run — a
+test-only PR touching no file under `src/main` — failed this gate at
+`FileSequenceBench::benchSequenceNext +40.10%` and `HashBench::benchVerifyArgon2id +13.75%`, and
+the identical commit passed on re-run. Not ADR-0030's stored-baseline problem (base and HEAD were
+measured on the same runner, as that ADR requires) — a narrower one: a same-runner A/B is still
+not precise enough for a subject dominated by filesystem locking or by memory-hard hashing, where
+the runner's own noise floor sits in the same order as the 10% budget. `--exclude NAME`
+(repeatable, `Benchmark::subject` form) drops a named subject from the **pass/fail** decision
+without dropping it from the **report** — it prints with a `skipped` marker rather than a
+percentage, so an exclusion is a visible, auditable fact and never a silent one. The excluded
+subject stays fully covered by its own **absolute** budget in `bench_budget_gate.py`, which is
+what NFR-10 and NFR-05 actually specify (a ceiling, or a range); the relative check on top of that
+was demanding 10%-precision these two subjects' underlying mechanism cannot supply on a shared
+runner. ADR-0045 names the exact criterion for which subjects qualify, so this stays a rule, not
+a per-name carve-out.
 """
 
 import argparse
@@ -103,7 +119,17 @@ def main(argv=None):
         help="fail if any subject is slower than its baseline by more than this percentage "
         "(default 10, per spec NFR-06)",
     )
+    ap.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="Benchmark::subject",
+        help="report this subject but never fail on it (repeatable) — for a subject whose "
+        "absolute budget in bench_budget_gate.py is the real spec requirement and whose "
+        "same-runner variance exceeds --max-regression on its own (ADR-0045)",
+    )
     args = ap.parse_args(argv)
+    excluded = set(args.exclude)
 
     try:
         base = mode_times(args.baseline)
@@ -112,9 +138,19 @@ def main(argv=None):
         print(f"bench-regression gate: FAIL\n\n  {exc}")
         return 1
 
+    unknown_excludes = sorted(excluded - set(head))
+    if unknown_excludes:
+        print(
+            "bench-regression gate: FAIL\n\n  --exclude named a subject absent from "
+            f"{args.current}: {', '.join(unknown_excludes)}. An exclusion for a subject that "
+            "does not exist silently stops meaning anything the day the subject is renamed."
+        )
+        return 1
+
     rows = []
     regressions = []
     new_subjects = []
+    skipped = []
 
     for name in sorted(head):
         if name not in base:
@@ -132,7 +168,9 @@ def main(argv=None):
 
         delta = (after - before) / before * 100.0
         rows.append((name, before, after, delta))
-        if delta > args.max_regression:
+        if name in excluded:
+            skipped.append((name, before, after, delta))
+        elif delta > args.max_regression:
             regressions.append((name, before, after, delta))
 
     disappeared = sorted(set(base) - set(head))
@@ -142,6 +180,8 @@ def main(argv=None):
     for name, before, after, delta in rows:
         if before is None:
             print(f"{name.ljust(width)}  {'—':>10}  {after:>10.3f}  {'new':>9}")
+        elif name in excluded:
+            print(f"{name.ljust(width)}  {before:>10.3f}  {after:>10.3f}  {'skipped':>9}")
         else:
             print(f"{name.ljust(width)}  {before:>10.3f}  {after:>10.3f}  {delta:>+8.2f}%")
 
@@ -151,6 +191,12 @@ def main(argv=None):
         print(
             f"\nbench-regression gate: NOTICE — \"{name}\" was measured in the baseline and is "
             "gone at HEAD. A deleted benchmark is how a regression stops being visible."
+        )
+    for name, before, after, delta in skipped:
+        print(
+            f"\nbench-regression gate: NOTICE — \"{name}\" is excluded from pass/fail "
+            f"(ADR-0045); measured {delta:+.2f}% here. Its absolute budget in "
+            "bench_budget_gate.py is what actually gates it."
         )
 
     if regressions:


### PR DESCRIPTION
## Summary

Roadmap item **10.9** — the regression gate's known false-positive on I/O-bound and memory-hard
benchmark subjects, filed at item 10.5, decided here. `tools/bench_regression_gate.py` gains
`--exclude Benchmark::subject`; `ci.yml` excludes three specific subjects. **ADR-0045.**

## The problem, already proven

Item 10.5 — a test-only PR with an empty `src/main` diff — failed the >10% regression gate at:

```
FileSequenceBench::benchSequenceNext: 75.503 -> 105.779 (+40.10%)
HashBench::benchVerifyArgon2id: 113465.370 -> 129072.012 (+13.75%)
```

The identical commit passed cleanly on re-run. This isn't ADR-0030's stored-baseline problem
restated — base and HEAD were measured on the same runner, exactly as that ADR requires, and
every other subject in the same run passed. It's a narrower, second finding: a same-runner A/B is
still not precise enough for a subject dominated by filesystem locking or memory-hard hashing.

## Why raising retry tolerance further wouldn't help

Both subjects already carry an elevated `RetryThreshold` (`FileSequenceBench` at 5,
`HashBench` at 20, against this project's typical 5) — someone had already reached for the
obvious lever. It didn't stop the failure, because `RetryThreshold` governs agreement **within**
one phpbench invocation; this failure is a **cross-run** comparison, base measured then head
measured minutes apart under whatever memory pressure and disk queue the shared VM happened to
have at each moment. No in-run retry touches that gap.

## The fix is a criterion, not three names

A subject qualifies for `--exclude` when its dominant, unavoidable cost is real filesystem I/O
with locking, or a primitive that is **deliberately** memory-hard by security design (Argon2id —
the whole point of NFR-05). `HashBench::benchMakeBcrypt` deliberately stays **in** the relative
gate: bcrypt is pure CPU time-cost with no memory contention and hasn't shown this failure mode.
Being slow and being noisy-relative-to-itself are different properties; only the second earns an
exclusion. ADR-0045 states this so the next flaky subject is recognized against a rule, not
imitated as a precedent.

## Design

`--exclude` is repeatable and removes a subject from the **pass/fail** decision only — it still
prints in the report, marked `skipped` rather than a percentage. This tool's own docstring already
commits to "absence is failure, never a pass" for missing reports and subjects; silently dropping
an excluded subject from the report would violate that same discipline. An `--exclude` naming a
subject absent from the report **fails loudly**, so an exclusion can't quietly stop meaning
anything the day a subject is renamed.

Both excluded subjects keep everything else: their absolute budget in `bench_budget_gate.py` — the
actual spec requirement (NFR-10's ceiling, NFR-05's range) — runs unchanged on every PR, and the
nightly workflow is untouched (it never ran the relative comparison, per ADR-0030 §3).

## Changes

- **`tools/bench_regression_gate.py`** — `--exclude Benchmark::subject` (repeatable), an
  unknown-exclude guard, and a `skipped` report row.
- **`.github/workflows/ci.yml`** — three `--exclude` flags on the existing regression-gate step.
  No new `uses:` entries.
- **ADR-0045** — the criterion and the four rejected alternatives (wider threshold, best-of-N,
  dropping the subjects from CI entirely, relying on retry threshold alone).
- ROADMAP item 10.9 checked with the decision; CHANGELOG `Added`; journal checkpoint.
- No spec revision — NFR-06's wording is a general methodology statement that doesn't enumerate
  subjects; this is a methodology refinement recorded via ADR, the same shape ADR-0030 itself used
  for its own deviation from NFR-06's literal "nightly" wording.

## Design Patterns

- None added or changed.

## Verification

- [x] No `tools/*.py` gate in this repo has a pytest suite (checked); verified by direct
      invocation instead, matching ADR-0030's own precedent — three cases: a synthetic fixture
      reproducing item 10.5's exact numbers reports `skipped` and exits 0 with `--exclude`; the
      same fixture still exits 1 without it; `--exclude` naming an absent subject fails loudly
- [x] PHPStan max clean · PHP-CS-Fixer clean (no PHP under `src/` touched)
- [x] Full suite green (2400 tests, unchanged)
- [x] `python tools/action_pin_lint.py` OK (no new pinned actions)
- [x] `python tools/consistency_lint.py` OK
- [x] Leak-gate over the staged diff: zero matches

## Documentation Impact

- [x] ADR-0045 added and indexed
- [x] ROADMAP item 10.9 checked with the decision; journal checkpoint added
- [x] CHANGELOG `Added`
- [ ] Spec — unchanged (methodology refinement via ADR, not a spec correction)

## Lesson

A retry-threshold bump is a hint that a benchmark's own mechanism is noisier than this project's
default, not a fix for a comparison the retry never touches. When raising the threshold further
also wouldn't help, that's the signal to name the class of cost the gate's design doesn't hold for
— so the next flaky subject is recognized, not rediscovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
