### PR TITLE
docs(spec): NFR-09's budget contradicted NFR-01, so revise it -- 1.5x to 2.5x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
         if: steps.cfg.outputs.present == 'true'
         shell: bash
         run: |
-          python3 tools/bench_ratio_gate.py build/logs/head.xml             --numerator benchGatewayFetchNormalizeHydrate --denominator benchHandWrittenPdoLoop --max-ratio 1.5
+          python3 tools/bench_ratio_gate.py build/logs/head.xml             --numerator benchGatewayFetchNormalizeHydrate --denominator benchHandWrittenPdoLoop --max-ratio 2.5
       - name: Resolve the base commit to compare against
         if: steps.cfg.outputs.present == 'true'
         id: base

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,6 +71,15 @@ jobs:
           python3 tools/bench_ratio_gate.py build/logs/nightly.xml \
             --numerator benchHydrateWarm --denominator benchManualConstruction --max-ratio 3
 
+      # Item 10.6 wired this ratio into ci.yml but not here, so NFR-09 was the one ratio budget
+      # with no nightly watch. Added at item 10.10 alongside its revision (ADR-0046), since a
+      # nightly re-resolve of dependencies is exactly how a ratio drifts without any commit.
+      - name: NFR-09 ratio — gateway fetch+normalize+hydrate vs hand-written PDO
+        run: |
+          python3 tools/bench_ratio_gate.py build/logs/nightly.xml \
+            --numerator benchGatewayFetchNormalizeHydrate \
+            --denominator benchHandWrittenPdoLoop --max-ratio 2.5
+
       - name: Keep the report as the night's record
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ## [Unreleased]
 
+### Changed
+
+- **NFR-09's budget revised, ≤ 1.5× → ≤ 2.5×**, and its row shape written into the requirement
+  (spec **r13**; roadmap item **10.10**; **ADR-0046**; maintainer's decision). The original figure
+  contradicted NFR-01 on the same axis: NFR-09's scope *contains* hydration, yet 1.5× demanded
+  hydration at ≤ 1.91× manual construction while NFR-01 permits 3× and the measured, already
+  optimized figure is 2.40× (item 7.1, ADR-0013). Measured five times on CI at 1.71–1.85×. The
+  new ceiling is derived — above the 1.78× implied by NFR-01's own permission, 35% above the
+  observed maximum, and below 3× because shared fetch cost dilutes a containing scope toward 1.0.
+  Drift in these subjects is still caught by the >10% same-runner regression gate (ADR-0030),
+  which does not exclude them. NFR-09's ratio also now runs in `nightly.yml`, which item 10.6 had
+  missed.
+
 ### Added
 
 - **`tools/bench_regression_gate.py` gains `--exclude Benchmark::subject`** (spec NFR-06; roadmap

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-07 — A gate that cried wolf about noise it could name](docs/journal/2026/08/2026-08-07-regression-gate-exclusions.md).
+  [2026-08-07 — Two budgets that could not both be met](docs/journal/2026/08/2026-08-07-nfr09-budget-revision.md).
 
 ## Model & effort routing (advisory)
 
@@ -978,7 +978,7 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       a synthetic fixture reproducing item 10.5's exact numbers now reports `skipped` and exits
       0 with `--exclude`, still exits 1 without it, and an `--exclude` naming a subject absent
       from the report fails loudly rather than silently meaning nothing.*
-- [ ] 10.10 Decide what to do about NFR-09's `bench_ratio_gate` step being **red on `master`**:
+- [x] 10.10 Decide what to do about NFR-09's `bench_ratio_gate` step being **red on `master`**:
       `TableGateway::all()` measures **1.85×** a hand-written PDO loop (item 10.6) against the
       spec's ≤ 1.5× budget, and one safe, real optimization (caching the gateway's base
       `QueryBuilder` per instance, landed in the same PR) moved it from 1.82× to 1.85× — noise,
@@ -995,7 +995,38 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       **(b)** a further hydration investigation beyond item 3.7's — which would mean re-opening
       a `standard/high` decision from a `fast/medium` item, the same over-reach item 10.9
       already named as the wrong move. Filed rather than either decided here — route: standard
-      / medium (adr)
+      / medium (adr) · **ADR-0046**, **spec r13**. ***The maintainer chose path (a), revise the
+      budget: 1.5× → 2.5×.*** *The 1.5× figure **contradicted NFR-01 on the same axis** — NFR-09's
+      scope strictly contains hydration, yet 1.5× demanded hydration at **≤ 1.91×** manual
+      construction while NFR-01 permits **3×** and item 7.1 measured **2.40×** after item 3.7
+      spent a `standard/high` effort reaching it. Five CI runs measured **1.71/1.81/1.81/1.82/
+      1.85×** — ratio spread 8.2% while the absolute times spread ~36%, confirming ADR-0011's
+      reason for using a ratio at all. **2.5× is derived, not rounded:** above the 1.78×
+      structural ceiling implied by NFR-01's own permitted 3×, 35% above the observed maximum
+      (≈4× the ratio's own spread), and below NFR-01's 3× because shared fetch cost dilutes a
+      containing scope toward 1.0. **Two corrections to item 10.6 along the way.** Its profile
+      attributed the whole gap to hydration; re-measured with each stage in an **isolated
+      process**, hydration is **72%** and `RowNormalizer`'s per-value dispatch is a real **27%**
+      (+55.8 µs/100 rows) — the earlier single-process profile read `gateway->all()` at 884 µs
+      when measured last after ~10 000 prior iterations, against 416 µs isolated, a GC/ordering
+      artifact and **the fourth benchmark-scope error on record** here (ADR-0020, ADR-0028,
+      ADR-0030, now this). And ADR-0014's pinned real prepares — item 10.6's named asymmetry —
+      cost **0.4 µs**, essentially nothing; the fairness reasoning stood, the cost attribution
+      did not. Checked before accepting the miss as structural: `GatewayRow` **does** compile to
+      ADR-0013's fast path. **Row width is now in the NFR** because it changes the answer: 4
+      columns hydrate at 3.17× where 10 properties manage 2.98× — less work to amortize the
+      hydrator's fixed dispatch over. Also fixes an item 10.6 omission: NFR-09's ratio now runs
+      in `nightly.yml` too, where a dependency re-resolve can move it with no commit. Residual
+      `RowNormalizer` cost filed as item 10.11.*
+- [ ] 10.11 Reduce `RowNormalizer`'s per-row dispatch cost, newly attributed at item 10.10:
+      **+55.8 µs per 100 rows** against an inline trim loop — 27% of NFR-09's total gateway
+      overhead, and the only part of it that is not hydration. The cost is a policy object's
+      price (ADR-0042: one `normalize()` call per row, then a per-value branch through
+      `normalizeValue()`), paid even on the default policy where the only active step is `trim`.
+      Options to weigh: a fast path when the configured policy is trim-only, hoisting the
+      per-value branch decisions out of the loop into the constructor, or accepting it as the
+      documented price of explicitness. **Not a correctness question** — the policy semantics
+      (ADR-0042's ordering and defaults) must not change — route: fast / medium (step:optimize)
 
 ---
 

--- a/docs/adr/0046-nfr09s-budget-contradicted-nfr01-on-the-same-axis.md
+++ b/docs/adr/0046-nfr09s-budget-contradicted-nfr01-on-the-same-axis.md
@@ -1,0 +1,163 @@
+# ADR-0046: NFR-09's budget contradicted NFR-01 on the same axis
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Deciders:** **maintainer (`@danielPoloWork`) — the choice between revising this budget and
+  re-opening hydration optimization was explicitly theirs** (ADR-0040's rule: the spec owns its
+  own numbers); agent acting as tech-lead for the derivation
+- **Related:** ROADMAP item 10.10 (this decision), item 10.6 (which measured the miss and filed
+  it) · spec **NFR-09** (revised here, r13), **NFR-01**, **NFR-06** ·
+  [ADR-0011](0011-benchmark-scope-and-the-measured-hydration-ratio.md) (the ratio-gate mechanism
+  this re-parameterizes) · [ADR-0013](0013-compile-a-hydration-closure-for-the-scalar-shape.md)
+  (the compiled fast path both subjects here use) ·
+  [ADR-0030](0030-same-runner-ab-because-a-stored-baseline-cannot-carry-a-10-percent-gate.md)
+  (the regression gate that still protects these subjects) ·
+  [ADR-0045](0045-exclude-io-bound-and-memory-hard-subjects-from-the-relative-gate.md) (the
+  thin-margin lesson this budget deliberately does not repeat) ·
+  [ADR-0042](0042-trim-is-the-only-default-and-the-transcode-runs-first.md) (`RowNormalizer`,
+  whose overhead this measurement newly attributes)
+
+## Context
+
+Item 10.6 wired NFR-09's ratio gate and it failed: `TableGateway::all()` measured **1.85×** a
+hand-written PDO loop against a **≤ 1.5×** budget. Item 10.6 declined to decide what to do,
+filing item 10.10 with two paths — revise the budget (a spec-scope call ADR-0040 reserves for the
+maintainer) or re-open hydration optimization beyond item 3.7. **The maintainer chose to revise
+the budget.** This ADR records the derivation, because "the maintainer picked the easier option"
+is only an acceptable record if the number that replaces it is defensible.
+
+### The measurements
+
+Five CI runs (`ubuntu-24.04`, the authoritative environment per ADR-0030):
+
+| run | numerator (µs) | denominator (µs) | ratio |
+|---|---|---|---|
+| 31133875720 | 153.492 | 84.312 | 1.82× |
+| 31134501611 | 160.591 | 86.767 | 1.85× |
+| 31134934611 | 151.664 | 83.944 | 1.81× |
+| 31153428964 | 150.703 | 83.382 | 1.81× |
+| 31154404368 | 118.000 | 69.112 | 1.71× |
+
+Median **1.81×**, max **1.85×**, spread **8.2%** — note the absolute times spread ~36% across the
+same runs while the ratio spread only 8.2%, which is ADR-0011's argument for using a ratio,
+confirmed rather than assumed.
+
+### Where the overhead actually lives
+
+Item 10.6's profile attributed the gap entirely to hydration. That was measured on a **single
+process that ran every stage in sequence**, and re-measuring found it wrong: with each stage
+isolated in its own process, `gateway->all()` measures 416 µs, but measured *last* after ~10 000
+prior iterations it reads **884 µs** — a GC/ordering artifact. This is the fourth benchmark-scope
+error on record here (ADR-0020, ADR-0028, ADR-0030's `--php-disable-ini`, now this), and the
+correction changes the attribution:
+
+| stage (isolated process, 100 rows) | µs | overhead vs the manual side |
+|---|---|---|
+| read — gateway (prepared) vs manual (`query()`) | 113.8 / 113.5 | **+0.4** (negligible) |
+| normalize — `RowNormalizer` vs an inline trim loop | +99.9 / +44.1 | **+55.8** |
+| build — hydration vs direct construction | +202.8 / +54.9 | **+147.9** |
+| **total gap** | 416.6 / 212.5 | **+204.2** |
+
+So hydration is **72%** of the gap, not all of it; `RowNormalizer`'s per-value object dispatch is
+a real **27%**. ADR-0014's pinned real prepares — which item 10.6 named as the asymmetry NFR-09
+was pricing — cost **0.4 µs**, essentially nothing. Item 10.6's fairness reasoning stands; its
+cost attribution did not.
+
+### Why the ratio could not have been 1.5×
+
+Solving the same decomposition for the budget:
+
+```
+floor if hydration were FREE (cost == manual construction)   1.27×   ← RowNormalizer alone
+ratio with hydration at NFR-01's permitted 3×                1.78×
+ratio with hydration at the achieved 2.40× (item 7.1)        1.63×
+measured                                                     1.71–1.85×
+```
+
+And inverted — **what 1.5× demanded**: hydration ≤ 104.9 µs, i.e. **≤ 1.91× manual construction**.
+
+NFR-01 permits hydration at **3×** manual construction. Item 3.7 spent a `standard/high` effort
+reaching **2.40×** (ADR-0013's compiled closure), and nothing has beaten it since. **NFR-09's
+scope strictly contains NFR-01's** — hydration is a step inside fetch+normalize+hydrate — yet
+NFR-09 demanded *stricter* overhead of that inner step than NFR-01 itself does. The two budgets
+were in direct contradiction, and NFR-09 was the one that could not be satisfied.
+
+Both subjects were checked for a missed optimization before accepting this: `GatewayRow` **does**
+compile to ADR-0013's fast path (verified against `HydrationCompiler::isEligible()` — all four
+parameters builtin, non-variadic, no defaults). The gap is structural, not a regression.
+
+### The row-width effect, which the old wording missed
+
+Measured on one machine, same conditions: `GatewayRow` (4 columns) hydrates at **3.17×** its own
+manual construction, while `TenScalarPropsDto` (10 properties) hydrates at **2.98×**. Fewer
+columns means less work to amortize the hydrator's fixed per-call dispatch over, so **a narrower
+row is a harder ratio**, not an easier one. NFR-01 states its shape ("10 scalar props"); NFR-09
+did not, and its subject sits at a harder point of that curve.
+
+## Decision
+
+**NFR-09's budget becomes ≤ 2.5×, and its row shape becomes part of the requirement**
+(spec r13): *"fetch + normalize + hydrate 100 rows of a 4-column row DTO ≤ 2.5× a hand-written
+PDO loop doing the same work."* `ci.yml`'s ratio step moves from `--max-ratio 1.5` to `2.5`.
+
+**Why 2.5× and not another number**, stated so the figure is derived rather than rounded:
+
+- **Above the structural ceiling.** With hydration at NFR-01's own permitted 3×, the pipeline
+  ratio is 1.78×; a budget below that would re-create the contradiction this ADR exists to
+  remove.
+- **Above the observed maximum with real headroom.** Max observed 1.85×; 2.5× is **35% above**
+  it, roughly four times the ratio's own 8.2% run-to-run spread.
+- **Below NFR-01's 3×.** The shared fetch cost mathematically dilutes the ratio toward 1.0, so a
+  pipeline containing hydration must be permitted *less* overhead than hydration alone. A budget
+  at or above 3× would be unprincipled in the opposite direction.
+- **Still catches what the budget is for.** A genuine doubling of gateway cost lands near 3.6×
+  and fails. The budget's job is "is this design fundamentally too expensive", not "did this PR
+  make it slower" — that second question belongs to the >10% regression gate (ADR-0030), which
+  still covers both `GatewayBench` subjects; they are **not** in ADR-0045's exclusion list.
+
+## Alternatives Considered
+
+1. **2.0×** — rejected. Only 8% above the observed max, which is exactly the ratio's own measured
+   spread. Item 9.6 already flagged a 9% margin as "the thinnest of any gated NFR in this
+   project" and warned it would read as a regression when it fired; ADR-0045 then spent a whole
+   item cleaning up after exactly that failure mode. Choosing it again knowingly would be
+   choosing a known-flaky gate.
+2. **3.0×, matching NFR-01** — rejected as unprincipled: it is only reachable if fetch and
+   normalize cost nothing, which measurement says is 51% of the manual side's total.
+3. **Keep 1.5× and exclude the subject from the gate** (ADR-0045's mechanism) — rejected. That
+   mechanism is for subjects whose *measurement* is too noisy to gate; this subject's measurement
+   is stable (8.2%). The number was wrong, not the instrument, and excluding it would leave
+   NFR-09 asserting nothing while looking enforced.
+4. **Re-open hydration optimization** (item 10.10's path b) — **not chosen by the maintainer**,
+   and recorded as still available: even a perfect hydrator only reaches 1.27× on this shape, so
+   optimization alone could not have rescued the 1.5× figure either. Both paths were needed to
+   reach 1.5×, and only one of them exists.
+5. **A row-width-dependent formula** — rejected as over-engineering: NFR-01 budgets one
+   representative shape and so does this, now that the shape is stated.
+
+## Consequences
+
+**Easier:** NFR-09 is enforceable, so `master` stops carrying a permanently red required check —
+which is worth more than the strictness given up, because a check that is always red is a check
+nobody reads.
+
+**Harder / accepted:** a real 35% regression in gateway overhead now passes the ratio gate. The
+mitigation is structural rather than hopeful: the >10% same-runner regression gate covers these
+subjects on every PR (ADR-0030), so drift is caught there — the ratio gate's remaining job is the
+design-level claim, and that is the claim 2.5× now makes honestly.
+
+**Newly attributed, not yet acted on:** `RowNormalizer` costs +55.8 µs per 100 rows against an
+inline trim — 27% of the total gap, and a fixable one (its per-value dispatch is a policy object's
+price, ADR-0042). Filed as roadmap item **10.11** rather than folded into a spec-revision item.
+
+**Process note.** Item 10.6 reported "hydration is the entire gap" from a profile whose stages
+shared one process. It was directionally right and quantitatively wrong, and only a re-measurement
+in isolated processes surfaced the 884-vs-416 µs artifact. A benchmark decomposition is a
+benchmark, and gets the same scepticism as one.
+
+## References
+
+- Spec NFR-09 (r13), NFR-01, NFR-06 · ROADMAP items 10.6, 10.10, 10.11
+- ADR-0011 (ratio mechanism), ADR-0013 (compiled hydration), ADR-0030 (regression gate),
+  ADR-0042 (`RowNormalizer`), ADR-0045 (thin margins), ADR-0040 (the spec owns its own numbers)
+- CI runs 31133875720, 31134501611, 31134934611, 31153428964, 31154404368

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,3 +61,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0043](0043-two-named-edges-out-of-persistence-and-no-catch-at-all.md) | Two named edges out of Persistence, and no catch at all | Accepted |
 | [0044](0044-the-write-builder-querybuilder-never-had-and-one-allowlist-for-both.md) | The write builder `QueryBuilder` never had, and one allowlist for both | Accepted |
 | [0045](0045-exclude-io-bound-and-memory-hard-subjects-from-the-relative-gate.md) | Exclude I/O-bound and memory-hard subjects from the relative regression gate | Accepted |
+| [0046](0046-nfr09s-budget-contradicted-nfr01-on-the-same-axis.md) | NFR-09's budget contradicted NFR-01 on the same axis | Accepted |

--- a/docs/journal/2026/08/2026-08-07-nfr09-budget-revision.md
+++ b/docs/journal/2026/08/2026-08-07-nfr09-budget-revision.md
@@ -1,0 +1,93 @@
+# 2026-08-07 — Two budgets that could not both be met
+
+Roadmap item **10.10**, closing Milestone 10's decision backlog. Route `standard / medium (adr)`;
+session model Opus 5 — **route matched for the first time in this milestone**, after five
+consecutive items run at a lower tier than routed. The maintainer switched models deliberately
+before giving the decision, which is model authority used the way ADR-0017 intends.
+
+## The decision was the maintainer's; the derivation was mine
+
+Item 10.6 measured NFR-09 at 1.85× against a 1.5× budget and refused to decide what to do about
+it, filing item 10.10 with two paths: revise the budget, or re-open hydration optimization. That
+refusal was right — ADR-0040 says the spec owns its own numbers, and an agent quietly widening a
+budget it just failed to meet is the worst possible version of this. The maintainer chose to
+revise.
+
+That makes the derivation the thing that has to be defensible. "The maintainer said I could" is
+not a reason for 2.5× rather than 2.0× or 3.0×.
+
+## The contradiction, quantified
+
+The spec contained two budgets on the same axis — *library overhead versus a hand-written
+equivalent* — over **nested scopes**:
+
+- **NFR-01**: hydration ≤ **3×** manual construction.
+- **NFR-09**: fetch + normalize + **hydrate** ≤ **1.5×** a hand-written loop.
+
+NFR-09's scope strictly contains NFR-01's. Solving the decomposition for what 1.5× actually
+demanded of the inner step: **hydration ≤ 1.91× manual construction** — stricter than the 3× the
+spec grants it in its own right, and stricter than the **2.40×** that item 3.7 spent a
+`standard/high` effort achieving and nothing has beaten since.
+
+The two requirements could not both be satisfied. NFR-09 was the one that had to move.
+
+## What the number is, and why not a rounder one
+
+Five CI runs: **1.71 / 1.81 / 1.81 / 1.82 / 1.85×**. Worth noting on its own — the absolute times
+across those runs spread ~36% while the ratio spread **8.2%**, which is ADR-0011's whole argument
+for using a ratio, observed rather than assumed.
+
+Structural landmarks from the decomposition:
+
+```
+1.27×  floor if hydration were FREE — this is RowNormalizer's overhead alone
+1.63×  with hydration at the achieved 2.40×
+1.78×  with hydration at NFR-01's permitted 3×      <- the honest structural ceiling
+1.85×  observed maximum
+2.50×  chosen
+3.00×  NFR-01's own figure — unreachable here unless fetch cost nothing
+```
+
+2.5× sits above the structural ceiling, 35% above the observed maximum (about four times the
+ratio's own spread), and below 3× because a containing scope with shared cost must be permitted
+*less* overhead than the step it contains. **2.0× was rejected specifically**: it would sit 8%
+above the observed max — exactly the measured spread — and item 9.6 already flagged a 9% margin
+as the thinnest gated NFR here, with ADR-0045 then spending a whole item cleaning up after that
+failure mode two days later. Choosing it again would have been choosing a gate I already knew
+would flake.
+
+## Two things item 10.6 got wrong, found by re-measuring
+
+**The 884 µs that was really 416 µs.** Item 10.6's profile ran every stage in one process, in
+sequence. Re-run with each stage isolated in its own process, `gateway->all()` measures 416 µs;
+measured *last*, after ~10 000 prior iterations had churned memory, the same call reads **884 µs**.
+A GC/ordering artifact, and **the fourth benchmark-scope error on this project's record** —
+ADR-0020's wrong workload, ADR-0028's autoload inside the subject, ADR-0030's `--php-disable-ini`,
+now this. A benchmark decomposition is itself a benchmark and deserves the same suspicion.
+
+**"Hydration is the entire gap" was 72% true.** Isolated, of 204 µs of overhead: hydration
+**+147.9 µs (72%)**, `RowNormalizer`'s per-value object dispatch **+55.8 µs (27%)**, and the
+prepared-statement asymmetry item 10.6 built its fairness argument around — **+0.4 µs**, nothing
+at all. The fairness reasoning stands (a hand-written literal `SELECT` genuinely would not
+`prepare()`); its cost was simply never the point. The `RowNormalizer` share is real, fixable, and
+now filed as item **10.11** rather than left inside a paragraph.
+
+Before accepting any of it as structural, I checked the obvious escape: `GatewayRow` **does**
+compile to ADR-0013's fast path. The gap is not a missed optimization.
+
+## The row width belongs in the requirement
+
+Measured on one machine: `GatewayRow` (4 columns) hydrates at **3.17×** its own manual
+construction; `TenScalarPropsDto` (10 properties) manages **2.98×**. Fewer columns means less work
+to amortize the hydrator's fixed per-call dispatch over — **narrow rows are the harder case**.
+NFR-01 has always named its shape ("10 scalar props"); NFR-09 named a row count but not a width,
+so its subject sat at a harder point of the curve than its budget's sibling, invisibly. r13 writes
+the shape in.
+
+## Lesson
+
+When two requirements constrain nested scopes on the same axis, check that the outer one is
+satisfiable *given* the inner one's own allowance — before either is written, ideally, but
+certainly before spending an item trying to meet the outer one. NFR-09 was unmeetable from the day
+it was drafted, and three items (10.6, 10.10, and part of 10.9's CI ordering trouble) went into
+discovering arithmetic that a single division would have shown at spec time.

--- a/docs/specs/01_spec_utils.md
+++ b/docs/specs/01_spec_utils.md
@@ -3,7 +3,7 @@
 > Rendered from the intake interview (Phase 5). Frozen contract: diverging implementation
 > updates this spec in the same PR or adds an ADR superseding the relevant section.
 
-**Revision r12** — 2026-08-06. See [Revision history](#revision-history).
+**Revision r13** — 2026-08-07. See [Revision history](#revision-history).
 
 ## 1. Objective & Business Context
 
@@ -81,7 +81,7 @@ MailException).
 
 **r3 addendum (RFC-0002)** — advisory until first measured under the NFR-06/ADR-0030 harness:
 
-- NFR-09 Repository/TableGateway: fetch + normalize + hydrate 100 rows <= 1.5x a hand-written PDO loop doing the same work
+- NFR-09 Repository/TableGateway: fetch + normalize + hydrate 100 rows of a 4-column row DTO <= 2.5x a hand-written PDO loop doing the same work. **Revised from 1.5x at r13 (item 10.10, ADR-0046): the original figure was unsatisfiable without violating NFR-01.** It demanded hydration cost <= 1.91x manual construction, where NFR-01 permits 3x and the measured, already-optimized figure is 2.40x (item 7.1, ADR-0013). The row width is now part of the requirement because the ratio depends on it — a narrower row amortizes the hydrator's fixed per-call dispatch over less work, so a 4-column row sits at a harder point of the curve than NFR-01's own 10-property subject
 - NFR-10 FileSequence::next() <= 200 us on local disk, lock included
 - NFR-11 Router dispatch <= 5 us against a 50-route table; ApiEnvelope construction <= 2 us
 - NFR-12 Csv: 10 000 x 10 write <= 150 ms, memory O(row) (streaming, never a full-table buffer)
@@ -178,6 +178,7 @@ non-functional requirement above maps to a CI gate (see [`.github/workflows/ci.y
 |-----|------|--------|
 | r1 | 2026-08-03 | Frozen from the imported `.specs/d4np-php.md` v2.0 via RFC-0001 (naming mapping A-7). |
 | r2 | 2026-08-05 | §6/T-03: the `hash_equals` **timing test** is replaced by a **mechanism assertion**. Rationale below; see [ADR-0027](../adr/0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md). |
+| r13 | 2026-08-07 | §3: **NFR-09's budget revised, 1.5x → 2.5x**, and its row shape made explicit (item 10.10, maintainer's decision between this and re-opening hydration optimization). The original figure contradicted NFR-01 on the same axis: NFR-09's scope *contains* hydration, yet 1.5x demanded hydration at <= **1.91x** manual construction while NFR-01 permits **3x** and item 7.1 measured **2.40x** after item 3.7 spent a `standard/high` effort reaching it. Measured five times on CI at **1.71–1.85x**. Derivation, alternatives (2.0x rejected as reproducing the thin-margin mistake item 9.6 named; 3.0x rejected as only reachable if fetch were free) and the accepted cost are in [ADR-0046](../adr/0046-nfr09s-budget-contradicted-nfr01-on-the-same-axis.md). |
 | r12 | 2026-08-06 | §6: **T-13 stated as delivered** (item 10.5) — the suite has an identifier leg the one-line description did not mention, asserting that a hostile column name is refused **before anything is prepared**, and consequence assertions the boundary check cannot make (round-trip through hydration, a tautology that matches nothing, and `SET`-before-`WHERE` parameter order). No requirement changed; the spec now describes what exists. No new ADR: the boundary decision is [ADR-0017](../adr/0017-prove-binding-at-the-pdo-boundary-and-defer-t02s-like-leg.md)'s and this applies it. |
 | r11 | 2026-08-06 | §2/§5: **FR-35 corrected** — its "composed exclusively through QueryBuilder" (carried from RFC-0002) was not implementable, because `QueryBuilder` builds `SELECT` and only `SELECT`. Reads keep it; writes get **FR-33b** `MutationBuilder`, and the FR-07 allowlist is extracted into a shared `Identifier` so one rule serves both. Adds `SqlStatement::fromMutation()` as a fourth named door, leaving `composed()` at zero in-library uses. FR-35's normative behaviours recorded: empty criteria refused, the DTO projected rather than `SELECT *`, the table allowlisted at construction. Honest limit recorded in the ADR: on SQLite a DTO/table mismatch is caught by strict hydration rather than the driver, and is invisible against an empty table. See [ADR-0044](../adr/0044-the-write-builder-querybuilder-never-had-and-one-allowlist-for-both.md). |
 | r10 | 2026-08-06 | §2/§3: FR-34 stated to the precision item 10.3 implemented (no catch anywhere — the requirement met by omission and asserted against the source; strict hydration kept with a protected seam; opt-in normalization, settling ADR-0042's deferral; a row count rather than a boolean). §3's dependency rule gains its **first two named cross-group edges**, `Persistence→Database` and `Persistence→Dto` — granted, not a general relaxation, and proved in three directions (both grants live, a non-granted edge refused, the inversion refused). See [ADR-0043](../adr/0043-two-named-edges-out-of-persistence-and-no-catch-at-all.md). |

--- a/src/bench/php/d4np/utils/GatewayBench.php
+++ b/src/bench/php/d4np/utils/GatewayBench.php
@@ -14,8 +14,19 @@ use PDO;
 use PhpBench\Attributes as Bench;
 
 /**
- * NFR-09: `Repository`/`TableGateway` fetch + normalize + hydrate 100 rows ≤ 1.5× a hand-written
- * PDO loop doing the same work.
+ * NFR-09: `Repository`/`TableGateway` fetch + normalize + hydrate 100 rows of a **4-column row
+ * DTO** ≤ 2.5× a hand-written PDO loop doing the same work.
+ *
+ * **The row width is part of the requirement** (spec r13, ADR-0046), not incidental to this
+ * fixture: a narrower row gives the hydrator's fixed per-call dispatch less work to amortize
+ * over, so it is a *harder* ratio than a wide one. Measured on one machine, `GatewayRow`
+ * (4 columns) hydrates at 3.17× its own manual construction where `TenScalarPropsDto`
+ * (10 properties) manages 2.98×. Changing {@see GatewayRow}'s shape therefore changes what this
+ * benchmark is measuring against the budget — which is why the shape is now written into the NFR.
+ *
+ * The budget was **1.5× until item 10.10**, and was unsatisfiable: it demanded hydration cost
+ * ≤ 1.91× manual construction while NFR-01 permits 3× and item 7.1 measured 2.40×. ADR-0046 has
+ * the derivation.
  *
  * **Same shape as NFR-01's ratio half** (roadmap 3.5), for the same reason: PHPBench's own
  * `@Assert` compares a subject against a previous *tagged* run, never against a sibling subject


### PR DESCRIPTION
## Summary

Roadmap item **10.10** — you chose *revise the budget*, so: **NFR-09 goes ≤ 1.5× → ≤ 2.5×**, with
its row shape written into the requirement. Spec **r13**, **ADR-0046**. Closes Milestone 10's
decision backlog; `master`'s permanently-red benchmark check goes green.

## Why the old number could never have been met

The spec contained two budgets on the same axis — *library overhead vs a hand-written
equivalent* — over **nested scopes**:

| | scope | budget |
|---|---|---|
| **NFR-01** | hydration alone | ≤ **3×** manual construction |
| **NFR-09** | fetch + normalize + **hydrate** | ≤ **1.5×** a hand-written loop |

NFR-09's scope strictly *contains* NFR-01's. Solving the decomposition for what 1.5× demanded of
the inner step: **hydration ≤ 1.91× manual construction** — stricter than the 3× the spec grants
it outright, and stricter than the **2.40×** item 3.7 spent a `standard/high` effort reaching
(ADR-0013's compiled closure), which nothing has beaten since. **Both requirements could not
hold.** NFR-09 was the one that had to move.

## Why 2.5× specifically

Five CI runs measured **1.71 / 1.81 / 1.81 / 1.82 / 1.85×**. Worth noting on its own: the absolute
times spread ~36% across those runs while the ratio spread only **8.2%** — ADR-0011's argument for
using a ratio, confirmed rather than assumed.

```
1.27×  floor if hydration were FREE — RowNormalizer's overhead alone
1.63×  with hydration at the achieved 2.40×
1.78×  with hydration at NFR-01's permitted 3×   ← the structural ceiling
1.85×  observed maximum
2.50×  chosen
3.00×  NFR-01's figure — unreachable unless fetch cost nothing
```

2.5× is above the structural ceiling, **35% above the observed max** (≈4× the ratio's own spread),
and below 3× because a containing scope with shared cost must be permitted *less* overhead than
the step inside it.

**2.0× was rejected specifically**: 8% above the observed max is exactly the measured spread, and
item 9.6 already flagged a 9% margin as "the thinnest of any gated NFR in this project" — with
ADR-0045 then spending a whole item cleaning up after precisely that failure mode. Choosing it
again would have been choosing a gate I already knew would flake.

## Two corrections to item 10.6, found by re-measuring

**The 884 µs that was really 416 µs.** Item 10.6's profile ran every stage in one process. Isolated
per-process, `gateway->all()` measures 416 µs — but measured *last*, after ~10 000 prior
iterations, the same call reads 884 µs. A GC/ordering artifact, and **the fourth benchmark-scope
error on this project's record** (ADR-0020, ADR-0028, ADR-0030, now this).

**"Hydration is the entire gap" was 72% true.** Of 204 µs overhead: hydration **+147.9 µs (72%)**,
`RowNormalizer`'s per-value dispatch **+55.8 µs (27%)**, and ADR-0014's pinned real prepares — the
asymmetry item 10.6 built its fairness argument on — **+0.4 µs**, essentially nothing. The fairness
reasoning stands; its cost attribution didn't. The `RowNormalizer` share is real and fixable, filed
as **item 10.11** rather than folded in here.

Before accepting the gap as structural I checked the obvious escape: `GatewayRow` **does** compile
to ADR-0013's fast path. This is not a missed optimization.

## Row width is now part of the requirement

`GatewayRow` (4 columns) hydrates at **3.17×** its own manual construction; `TenScalarPropsDto`
(10 properties) manages **2.98×** — fewer columns means less work to amortize the hydrator's fixed
per-call dispatch over, so **narrow rows are the harder case**. NFR-01 has always named its shape;
NFR-09 named a row count but not a width, so its subject sat at a harder point of the curve than
its sibling budget, invisibly. r13 writes the shape in.

## Changes

- **`docs/specs/01_spec_utils.md`** → **r13**: NFR-09's figure and row shape, with the
  contradiction stated in the requirement itself and in the revision history.
- **`docs/adr/0046-*.md`** — the full derivation, five rejected alternatives, and the accepted
  cost.
- **`.github/workflows/ci.yml`** — `--max-ratio 1.5` → `2.5`.
- **`.github/workflows/nightly.yml`** — NFR-09's ratio added; item 10.6 wired it into `ci.yml`
  only, leaving it the one ratio budget with no nightly watch. Same NFR, so fixed here rather than
  filed.
- **`GatewayBench`** docblock — the row-width dependency and the budget's history.
- ROADMAP item 10.10 checked with the derivation; **item 10.11 filed**; CHANGELOG `Changed`;
  journal checkpoint.

## What this gives up, and what still covers it

A real 35% regression in gateway overhead now passes the *ratio* gate. The mitigation is
structural, not hopeful: the **>10% same-runner regression gate** (ADR-0030) covers both
`GatewayBench` subjects on every PR — they are **not** in ADR-0045's exclusion list — so drift is
caught there. The ratio gate's remaining job is the design-level claim, and 2.5× is the number
that claim can honestly make.

## Verification

- [x] **Gate proved both ways** (lesson L-0008): the worst observed CI pair (160.591 / 86.767 =
      1.85×) **passes** at 2.5×; a genuine doubling (3.69×) **still fails**
- [x] PHPStan max clean · PHP-CS-Fixer clean · full suite green (2400 tests, unchanged)
- [x] `python tools/consistency_lint.py` OK · `python tools/action_pin_lint.py` OK
- [x] Leak-gate over the staged diff: zero matches
- [ ] This PR's own `benchmark / reproducible perf` — **expected green for the first time since
      item 10.6**; that is itself the verification that the revision works

## Documentation Impact

- [x] Spec r13 (NFR-09 revised, row shape added)
- [x] ADR-0046 added and indexed
- [x] ROADMAP item 10.10 checked; item 10.11 filed; journal checkpoint added
- [x] CHANGELOG `Changed`
- [ ] README / patterns — unchanged

## Lesson

When two requirements constrain nested scopes on the same axis, check the outer one is satisfiable
*given* the inner one's own allowance. NFR-09 was unmeetable from the day it was drafted, and three
items went into discovering arithmetic that one division would have shown at spec time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
