### PR TITLE
perf(persistence): hoist the policy decision out of the per-value loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   [benchmark record](docs/benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md)). The
   policy decision is now computed once in the constructor instead of per value, and the default
   policy — trim, and nothing else, which is what `TableGateway` and `Repository` configure unless a
-  consumer says otherwise — runs through one guarded fast path. Measured: **95.2 → 65.2 µs per 100
-  four-column rows**, the overhead over an inline trim loop **+52.3 → +22.3 µs (58% removed)**;
-  NFR-09's gateway ratio improves accordingly. **No behaviour changes**: ADR-0042's four switches,
+  consumer says otherwise — runs through one guarded fast path. Measured on the development machine:
+  **95.2 → 65.2 µs per 100 four-column rows**, the overhead over an inline trim loop **+52.3 →
+  +22.3 µs (58% removed)**. On CI, the environment NFR-06 defines, the remaining overhead is
+  **+2.760 µs** and **NFR-09's ratio is unchanged at 1.73×** — the component is 4.6% of the gateway
+  overhead there, not the 27% a local decomposition had attributed, and the ratio's own noise band
+  (1.71–1.85×, ADR-0046) is wider than the change. **No behaviour changes**: ADR-0042's four switches,
   their defaults, the step ordering and the strict-failure stance are untouched, and the two
   execution paths are held to identical output by T-15's differential matrix across all sixteen
   policy combinations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Changed
 
+- **`RowNormalizer` is faster on the default policy** (roadmap item **10.11**; **ADR-0047**;
+  [benchmark record](docs/benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md)). The
+  policy decision is now computed once in the constructor instead of per value, and the default
+  policy — trim, and nothing else, which is what `TableGateway` and `Repository` configure unless a
+  consumer says otherwise — runs through one guarded fast path. Measured: **95.2 → 65.2 µs per 100
+  four-column rows**, the overhead over an inline trim loop **+52.3 → +22.3 µs (58% removed)**;
+  NFR-09's gateway ratio improves accordingly. **No behaviour changes**: ADR-0042's four switches,
+  their defaults, the step ordering and the strict-failure stance are untouched, and the two
+  execution paths are held to identical output by T-15's differential matrix across all sixteen
+  policy combinations.
+
 - **NFR-09's budget revised, ≤ 1.5× → ≤ 2.5×**, and its row shape written into the requirement
   (spec **r13**; roadmap item **10.10**; **ADR-0046**; maintainer's decision). The original figure
   contradicted NFR-01 on the same axis: NFR-09's scope *contains* hydration, yet 1.5× demanded

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1032,7 +1032,14 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       work**: 281 ns per string value (186 of the 400 values in a 100-row batch) to re-derive, per
       value, four decisions that are properties of the immutable policy. Hoisted into the
       constructor as one `trimOnly` flag with a single guarded fast path: **95.2 → 65.2 µs, the
-      overhead +52.3 → +22.3 µs, 58% removed.* **All four designs were measured before choosing,
+      overhead +52.3 → +22.3 µs, 58% removed** (development machine).* ***CI corrected the premise:***
+      *on the reference-class runner the remaining overhead is **+2.760 µs** (22.423 vs the inline
+      floor's 19.663) and **NFR-09's ratio did not move — 1.73×, `master`'s own figure**, since
+      ~2.8 µs of 141.75 sits inside the 1.71–1.85× noise band ADR-0046 recorded. **Item 10.10's "27%
+      of NFR-09's overhead" was a Windows figure**: on CI this component is **4.6%** of the gateway
+      overhead. The saving on CI hardware is **unmeasured** — the subject is new, so the same-runner
+      harness had nothing to compare against. Kept rather than reverted, on a smaller and honestly
+      stated benefit: strictly less work per value for one boolean and one guarded loop.* **All four designs were measured before choosing,
       and both rewrite-shaped candidates were slower than the simple one** *— a precomputed closure
       70.4 µs (a closure call is still a call), the general pipeline inlined behind locals 74.5 µs.
       The more readable one-loop ternary lost by 7.4 µs, recorded so the trade can be revisited
@@ -1055,8 +1062,10 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       `native_function_invocation` is absent from `.php-cs-fixer.dist.php`. The decision is whether
       to enable that rule repo-wide (risky-rule class, touches every file, and `@PSR12:risky` is
       already on) or to record the cost as accepted; a per-file prefix is explicitly **not** an
-      option — it cannot be held. Measure the aggregate effect on the bench suite before deciding,
-      since 10.11's figure is one method's hot loop and consumers running OPcache see less of it —
+      option — it cannot be held. **Measure on CI before deciding, not locally**: item 10.11's own
+      CI run showed the dev box overstating this class of per-call cost by ~8× (a component the local
+      decomposition put at 27% of NFR-09's overhead is 4.6% there), so the 13.6 µs figure is an upper
+      bound from the wrong machine; consumers running OPcache see less of it again —
       route: standard / medium (adr, step:optimize)
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-07 — Two budgets that could not both be met](docs/journal/2026/08/2026-08-07-nfr09-budget-revision.md).
+  [2026-08-07 — The simple design won, and the namespace cost more than the method call](docs/journal/2026/08/2026-08-07-rownormalizer-fast-path.md).
 
 ## Model & effort routing (advisory)
 
@@ -1018,7 +1018,7 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       hydrator's fixed dispatch over. Also fixes an item 10.6 omission: NFR-09's ratio now runs
       in `nightly.yml` too, where a dependency re-resolve can move it with no commit. Residual
       `RowNormalizer` cost filed as item 10.11.*
-- [ ] 10.11 Reduce `RowNormalizer`'s per-row dispatch cost, newly attributed at item 10.10:
+- [x] 10.11 Reduce `RowNormalizer`'s per-row dispatch cost, newly attributed at item 10.10:
       **+55.8 µs per 100 rows** against an inline trim loop — 27% of NFR-09's total gateway
       overhead, and the only part of it that is not hydration. The cost is a policy object's
       price (ADR-0042: one `normalize()` call per row, then a per-value branch through
@@ -1026,7 +1026,38 @@ First two named cross-group deptrac edges (RFC-0002 P-1).
       Options to weigh: a fast path when the configured policy is trim-only, hoisting the
       per-value branch decisions out of the loop into the constructor, or accepting it as the
       documented price of explicitness. **Not a correctness question** — the policy semantics
-      (ADR-0042's ordering and defaults) must not change — route: fast / medium (step:optimize)
+      (ADR-0042's ordering and defaults) must not change — route: fast / medium (step:optimize) ·
+      **ADR-0047**, **benchmark record**. ***M10's last planned item — but the milestone stays open
+      by one decision, because this item filed 10.12 below.*** *The cost was **dispatch, not
+      work**: 281 ns per string value (186 of the 400 values in a 100-row batch) to re-derive, per
+      value, four decisions that are properties of the immutable policy. Hoisted into the
+      constructor as one `trimOnly` flag with a single guarded fast path: **95.2 → 65.2 µs, the
+      overhead +52.3 → +22.3 µs, 58% removed.* **All four designs were measured before choosing,
+      and both rewrite-shaped candidates were slower than the simple one** *— a precomputed closure
+      70.4 µs (a closure call is still a call), the general pipeline inlined behind locals 74.5 µs.
+      The more readable one-loop ternary lost by 7.4 µs, recorded so the trade can be revisited
+      knowingly.* **Two tests, and their division of labour is proved rather than argued:** *a
+      differential matrix (corpus × all 16 policy combinations vs an oracle outside the class)
+      catches a condition that fires too widely, while planting `trimOnly = false` — the
+      optimization silently ceasing to exist — leaves that matrix* **green** *and fails only the
+      reflection truth-table assertion (ADR-0027's rule). 5 planted defects, 5 caught; 2424 tests
+      (+24).* **New finding, filed as item 10.12 rather than fixed here:** *the same code measures
+      51.5 µs in the global namespace and 65.2 µs inside one —* **13.6 µs is PHP's namespace
+      fallback** *on 372 unqualified internal calls (~36 ns each), isolated with a two-class probe,
+      in exactly the OPcache-off configuration NFR-06 pins. Not applied to one file, because a lone
+      `\trim()` reads as a style slip and the next tidy-up gives the 13.6 µs back with every test
+      green.*
+- [ ] 10.12 Decide the repo-wide policy on **unqualified internal function calls**, measured at
+      item 10.11: inside a namespace, PHP resolves `trim()` by trying the namespaced name first and
+      the global second, worth **13.6 µs per 100 rows / ~36 ns per call** in `RowNormalizer`'s hot
+      loop under NFR-06's OPcache-off benchmark environment (isolated with a two-class probe, not
+      inferred). Every file in this repository calls internal functions unqualified, and
+      `native_function_invocation` is absent from `.php-cs-fixer.dist.php`. The decision is whether
+      to enable that rule repo-wide (risky-rule class, touches every file, and `@PSR12:risky` is
+      already on) or to record the cost as accepted; a per-file prefix is explicitly **not** an
+      option — it cannot be held. Measure the aggregate effect on the bench suite before deciding,
+      since 10.11's figure is one method's hot loop and consumers running OPcache see less of it —
+      route: standard / medium (adr, step:optimize)
 
 ---
 
@@ -1095,9 +1126,9 @@ Legend: ⏳ not started · 🚧 in progress · ✅ done · ❎ N/A.
 | §1 | Objective & design philosophy | 1.1, 1.6 | ✅ |
 | §2 | Functional items 1–25 (+9b); r3 adds FR-27–44 (RFC-0002) | 2.1–2.5, 3.1–3.3, 4.1–4.3, 5.1–5.3, 6.1–6.2, 6.4–6.5; 9.1–9.5, 10.1–10.4, 11.1–11.3, 12.1, 12.3–12.4 | 🚧 |
 | §3 | Architecture & layering (deptrac); r3 adds Persistence/Mail + named edges | 1.1, 1.6, 2.1, 2.5, 10.2–10.3, 12.4 | 🚧 |
-| §4 | NFR budgets & benchmark methodology; r3 adds NFR-09–14 | 3.5, 4.5, 5.5, 6.4, 7.1, 9.6, 10.6, 11.5, 12.5 | 🚧 |
+| §4 | NFR budgets & benchmark methodology; r3 adds NFR-09–14 | 3.5, 4.5, 5.5, 6.4, 7.1, 9.6, 10.6, 10.11–10.12, 11.5, 12.5 | 🚧 |
 | §5 | Security test criteria; r3 adds T-08/09/10/13 | 4.4, 5.4, 5.5, 6.3, 9.4, 10.5, 11.4, 12.2, 12.4 | 🚧 |
 | §6 | API example / public interface | 1.6, 3.1, 10.3–10.4, 11.3 | 🚧 |
-| §7 | Verification & test strategy (r3) | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3, 8.2, 9.5, 10.2, 10.5, 11.2, 11.4, 12.2–12.3 | 🚧 |
+| §7 | Verification & test strategy (r3) | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3, 8.2, 9.5, 10.2, 10.5, 10.11, 11.2, 11.4, 12.2–12.3 | 🚧 |
 | §8 | CI/CD & release engineering | 1.4, 1.7, 7.1–7.3, 8.3 | 🚧 |
-| §9 | Decision log (imported + seeded ADRs); r3 items carrying ADRs | 2.1, 5.3, 7.4, 9.3–9.4, 10.1, 10.3–10.4, 11.1–11.2, 12.1, 12.4 | 🚧 |
+| §9 | Decision log (imported + seeded ADRs); r3 items carrying ADRs | 2.1, 5.3, 7.4, 9.3–9.4, 10.1, 10.3–10.4, 10.11–10.12, 11.1–11.2, 12.1, 12.4 | 🚧 |

--- a/docs/adr/0042-trim-is-the-only-default-and-the-transcode-runs-first.md
+++ b/docs/adr/0042-trim-is-the-only-default-and-the-transcode-runs-first.md
@@ -1,6 +1,10 @@
 # ADR-0042: Trim is the only default, and the transcode runs first
 
-- **Status:** Accepted
+- **Status:** Accepted — **amended by [ADR-0047](0047-hoist-the-policy-decision-and-keep-one-fast-path.md)** (2026-08-07, item 10.11): the
+  default policy is now executed through a hoisted trim-only fast path. **Nothing decided here
+  changes** — the four switches, their defaults, the step ordering and the strict-failure stance
+  are untouched, and the two execution paths are held to identical output by T-15's differential
+  matrix. Annotated rather than edited, per ADR-0041's precedent.
 - **Date:** 2026-08-06
 - **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
 - **Related:** ROADMAP item 10.2 · spec r3 **FR-36**, suite **T-15** (RFC-0002) ·

--- a/docs/adr/0047-hoist-the-policy-decision-and-keep-one-fast-path.md
+++ b/docs/adr/0047-hoist-the-policy-decision-and-keep-one-fast-path.md
@@ -46,8 +46,11 @@ ADR-0042's explicitness" was a legitimate outcome the item named up front.
 each string value and returns, skipping the per-value dispatch entirely. The general pipeline is
 untouched and still handles every other policy.
 
-Measured, real class, three passes: **95.7 µs → 65.2 µs per 100 rows**, overhead **+52.9 µs →
-+22.3 µs — 58% of the normalizer's overhead removed**, semantics unchanged.
+Measured, real class, three passes on the development machine: **95.2 µs → 65.2 µs per 100 rows**,
+overhead **+52.3 µs → +22.3 µs — 58% of the normalizer's overhead removed**, semantics unchanged.
+On CI, the authoritative environment, the same subject's remaining overhead is **+2.760 µs** and
+NFR-09's ratio is **unchanged at 1.73×** — see Consequences, which corrects the proportion this
+item was filed on.
 
 Four candidate designs were measured before choosing, not after:
 
@@ -110,10 +113,27 @@ dropped); all five were caught.
 
 ## Consequences
 
-**Faster on the path everyone takes.** `TableGateway` and `Repository` configure the default
-policy unless a consumer says otherwise, so every gateway read gets this. NFR-09's ratio should
-improve from 1.73× toward ~1.6× (CI is authoritative — the number in the benchmark record is the
-one CI reports, not this estimate).
+**Faster on the path everyone takes** — but by much less than the local decomposition implied, and
+that correction is part of this decision's record rather than a footnote to it. `TableGateway` and
+`Repository` configure the default policy unless a consumer says otherwise, so every gateway read
+gets the change. On CI (NFR-06's environment) the class measures **22.423 µs against the inline
+floor's 19.663** — a remaining overhead of **+2.760 µs per 100 rows**, and **NFR-09's ratio did not
+move: 1.73×, the same figure `master` reports.**
+
+Two consequences follow, both stated because they weaken the case for this change:
+
+- The ratio *cannot* see it. ADR-0046 recorded NFR-09 five times at 1.71–1.85× on CI, so ~2.8 µs
+  out of 141.75 µs is inside the gate's noise band.
+- **Item 10.10's "27% of NFR-09's overhead" was a Windows figure.** On CI the normalizer's
+  remaining overhead is 2.760 of the gateway path's 59.656 µs of overhead — **4.6%**. The
+  proportion that justified prioritizing this item does not reproduce on the reference
+  environment.
+
+The saving on CI hardware is **unmeasured**: `RowNormalizerBench` is new, so the same-runner
+harness had nothing to compare against, and NFR-09 cannot resolve a change this small. What
+remains certain is that the class does strictly less work per string value, at a complexity cost
+of one boolean and one guarded loop — which is why the change is kept rather than reverted, on a
+smaller and honestly-stated benefit than the item was filed on.
 
 **One more thing to keep true.** The class now has two paths that must agree. The cost is bounded
 by construction — the fast path is four lines and calls one function — and the differential matrix

--- a/docs/adr/0047-hoist-the-policy-decision-and-keep-one-fast-path.md
+++ b/docs/adr/0047-hoist-the-policy-decision-and-keep-one-fast-path.md
@@ -1,0 +1,167 @@
+# ADR-0047: Hoist the policy decision out of the loop, and keep exactly one fast path
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item **10.11** (`step:optimize`) · spec §3 **NFR-09** (the containing
+  budget) · [ADR-0042](0042-trim-is-the-only-default-and-the-transcode-runs-first.md) (the policy
+  this preserves — **amended by annotation, not edited**) ·
+  [ADR-0046](0046-nfr09s-budget-contradicted-nfr01-on-the-same-axis.md) (item 10.10, which
+  attributed this cost) ·
+  [ADR-0030](0030-same-runner-ab-because-a-stored-baseline-cannot-carry-a-10-percent-gate.md)
+  (the harness the new subjects join) ·
+  [ADR-0040](0040-install-the-mutation-tester-outside-the-graph-and-keep-nfr07s-own-number.md)
+  (the spec owns its own numbers — why no budget is invented here) ·
+  [ADR-0027](0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md) (the
+  mechanism-assertion rule this run needed twice over) · benchmark record
+  [`nfr09-rownormalizer-trim-only-fast-path`](../benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md)
+
+## Context
+
+Item 10.10 decomposed NFR-09's gateway overhead per stage, in isolated processes, and found that
+hydration was **72%** of it — not all of it, as item 10.6 had claimed. The remaining named cost
+was `RowNormalizer`: **+55.8 µs per 100 four-column rows** against an inline trim loop, 27% of the
+overhead, and the only part that is not hydration. Item 10.11 was filed to reduce it.
+
+That cost is paid on the **default policy**, where the only active step is `trim` (ADR-0042). The
+shape of the class is why: `normalize()` iterates the row, and every string value is dispatched
+through a private `normalizeValue()` that re-derives, per value, four decisions which are
+properties of the *policy* — immutable for the lifetime of the object. A four-column row from
+`GatewayBench`'s fixture carries 1.86 string values on average, so a 100-row batch pays that
+dispatch **186 times** for a policy that could not change between the first value and the last.
+
+Re-measured for this item on the same machine, in isolated processes (41 samples of 20 batches,
+warm): the inline loop **42.9 µs**, the class **95.7 µs** — an overhead of **+52.9 µs per 100
+rows**, or **276 ns per string value**. The 10.10 attribution reproduces.
+
+NFR-09 itself is **met** at 1.73× against its ≤ 2.5× budget (spec r13). This is therefore an
+optimization with headroom already in hand, which raises the bar for accepting complexity: the
+change has to earn its keep on measurement, and "accept the cost as the documented price of
+ADR-0042's explicitness" was a legitimate outcome the item named up front.
+
+## Decision
+
+**The policy decision is computed once, in the constructor, as a private `trimOnly` flag, and
+`normalize()` gains exactly one fast path guarded by it** — a loop that calls `trim()` directly on
+each string value and returns, skipping the per-value dispatch entirely. The general pipeline is
+untouched and still handles every other policy.
+
+Measured, real class, three passes: **95.7 µs → 65.2 µs per 100 rows**, overhead **+52.9 µs →
++22.3 µs — 58% of the normalizer's overhead removed**, semantics unchanged.
+
+Four candidate designs were measured before choosing, not after:
+
+| design | µs / 100 rows | overhead over the inline floor |
+|---|---|---|
+| inline trim loop (the floor, not a candidate) | 42.9 | — |
+| **the class as it stood** | **95.7** | +52.9 |
+| a precomputed `Closure` per policy, one call per value | 70.4 | +27.5 |
+| the general pipeline inlined behind locals, no method call | 74.5 | +31.6 |
+| one loop, hoisted flag consulted per value via a ternary | 59.0 | +16.1 |
+| **hoisted flag, fast path outside the loop** (chosen) | **51.6**¹ | **+8.7**¹ |
+
+¹ measured on an equivalent implementation in the *global* namespace; the class itself lands at
+65.2 µs, and the 13.6 µs difference is a second, separate finding — see Consequences.
+
+**Two tests hold it**, and the division of labour between them is the load-bearing part:
+
+- a **differential matrix** — the corpus × all sixteen policy combinations, compared against an
+  oracle implementing ADR-0042's ordering written outside the class. The `trim()` call cannot be
+  wrong; `trimOnly`'s *condition* can, and a condition that fires one combination too widely is
+  invisible to any test that exercises only the default policy;
+- the condition's **truth table**, asserted as a mechanism through reflection (ADR-0027's rule for
+  a property no behaviour can observe).
+
+The second is not redundant, and this was **proved rather than argued**: planting
+`trimOnly = false` — the optimization silently ceasing to exist — leaves the entire differential
+matrix **green**, because the two paths are output-identical by design, and fails exactly the two
+truth-table rows that assert the fast path is taken. A behavioural suite cannot see a performance
+mechanism disappear. Five defects were planted in total (condition too wide on `blankToNull`, too
+wide on `collapseWhitespace`, always true, always false, the fast path's `is_string()` guard
+dropped); all five were caught.
+
+## Alternatives Considered
+
+- **Accept the cost as the price of explicitness** — the item's own third option, and the correct
+  answer had the measurement come out differently. Rejected because the measurement did not: 58%
+  of a cost that is 27% of NFR-09's overhead, for one hoisted boolean and one guarded loop, is a
+  good trade at any reading — and unlike the two rewrite-shaped candidates, it leaves the general
+  pipeline exactly as ADR-0042 wrote it.
+- **One loop, the flag consulted per value via a ternary** (59.0 µs) — the more readable
+  formulation, with no duplicated loop body, and the one that would have been chosen on style
+  alone. Rejected on measurement: it keeps a per-value branch, giving back 7.4 µs of the 8.7 µs
+  win — 45% of the improvement for a cosmetic gain. Recorded because the margin is small enough
+  that a future reader may reasonably want it back.
+- **A precomputed `Closure` per policy** (70.4 µs) — elegant, and it generalizes to every policy
+  rather than one. Rejected: a closure call is still a call, so it recovers only half the
+  dispatch, and it moves the pipeline's ordering — ADR-0042's actual decision — into a
+  constructor-assembled callable that is harder to read than the `if/elseif` it replaces.
+- **Inlining the general pipeline behind hoisted locals** (74.5 µs) — the "no method call at all"
+  variant. Rejected on both axes: slowest of the three candidates *and* it duplicates the whole
+  pipeline into the loop, which is where the transcoding failure path with its column-naming
+  wrapper lives.
+- **A second fast path for the no-op policy** (nothing enabled at all) — a real shortcut, but a
+  degenerate configuration nobody sets: the class's reason to exist is the pipeline. Not added,
+  because "exactly one fast path" is the property that keeps this from becoming a collection of
+  special cases.
+- **Prefixing internal function calls with `\` in this class** (`\trim()`, `\is_string()`) —
+  measured, and it accounts for the whole 13.6 µs footnote above. Rejected **here** and filed as
+  its own item; see Consequences.
+
+## Consequences
+
+**Faster on the path everyone takes.** `TableGateway` and `Repository` configure the default
+policy unless a consumer says otherwise, so every gateway read gets this. NFR-09's ratio should
+improve from 1.73× toward ~1.6× (CI is authoritative — the number in the benchmark record is the
+one CI reports, not this estimate).
+
+**One more thing to keep true.** The class now has two paths that must agree. The cost is bounded
+by construction — the fast path is four lines and calls one function — and the differential matrix
+is what makes it safe to read quickly. The mechanism assertion is what makes it safe to *keep*:
+without it, the optimization can be deleted by a well-meaning simplification and every test stays
+green.
+
+**ADR-0042 is amended by annotation, not edited** (ADR-0041's precedent): its policy, defaults and
+ordering are unchanged and remain the contract. This ADR adds only *how* the default policy is
+executed.
+
+**No budget is invented.** `RowNormalizerBench` measures two subjects — the class and the inline
+floor — so the overhead is a difference two numbers on one runner can express, the way NFR-01 and
+NFR-09 do. Neither subject gets an entry in `bench_budget_gate.py`: the spec owns its own numbers
+(ADR-0040), and NFR-09 budgets the gateway path, not this component. The relative regression gate
+(ADR-0030) holds them, and neither is I/O-bound or memory-hard, so neither belongs in ADR-0045's
+exclusion list.
+
+**A separate finding, filed as item 10.12 rather than fixed here.** The chosen design measures
+51.6 µs when its class sits in the global namespace and **65.2 µs** as `D4np\Utils\Persistence\
+RowNormalizer` — same code, same loop. The difference is PHP's **namespace fallback lookup** for
+unqualified internal function calls: inside a namespace, `trim()` is resolved by trying
+`D4np\Utils\Persistence\trim` first and the global `trim` second, and NFR-06 pins the benchmark
+interpreter with **OPcache and JIT off**, which is precisely the configuration where that lookup
+is not optimized away. Isolated with a two-class probe — identical bodies in one namespace, one
+calling `is_string()`/`trim()` and the other `\is_string()`/`\trim()` — the unqualified version
+measures **65.0 µs** and the prefixed one **51.6 µs**: **13.6 µs per 100 rows, ~36 ns per internal
+call**, over 372 calls per batch.
+
+It is deliberately **not** applied in this PR. Two characters in this one file would take the
+number, but the repository calls internal functions unqualified everywhere, `native_function_
+invocation` is not in the PHP-CS-Fixer configuration, and a lone prefixed call site reads as a
+style slip rather than an optimization — the next tidy-up removes it and the 13.6 µs comes back
+with every test green. Holding it needs either the repo-wide CS-Fixer rule (a risky-rule decision
+touching every file, and the maintainer's call under ADR-0040's spirit) or a mechanism test
+pinning two characters, which is theatre. The measurement is recorded; the decision is filed.
+
+**Known limitation.** The 8.7 µs the fast path cannot remove is the per-*row* `normalize()` call
+itself, which is the method's own existence. Nothing short of moving normalization into the
+hydrator's compiled closure would reach it, and that would couple two groups the layering rule
+keeps apart (ADR-0043).
+
+## References
+
+- Benchmark record: [`nfr09-rownormalizer-trim-only-fast-path`](../benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md) — full environment, all four candidates, before/after
+- Spec §3 **NFR-09**, §6 **T-15**; [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md) **FR-36**
+- `src/main/php/d4np/utils/Persistence/RowNormalizer.php`,
+  `src/test/php/d4np/utils/Persistence/RowNormalizerTest.php`,
+  `src/bench/php/d4np/utils/RowNormalizerBench.php`
+- PHP manual, *Using namespaces: fallback to global function/constant* — the mechanism behind the
+  13.6 µs finding

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,3 +62,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0044](0044-the-write-builder-querybuilder-never-had-and-one-allowlist-for-both.md) | The write builder `QueryBuilder` never had, and one allowlist for both | Accepted |
 | [0045](0045-exclude-io-bound-and-memory-hard-subjects-from-the-relative-gate.md) | Exclude I/O-bound and memory-hard subjects from the relative regression gate | Accepted |
 | [0046](0046-nfr09s-budget-contradicted-nfr01-on-the-same-axis.md) | NFR-09's budget contradicted NFR-01 on the same axis | Accepted |
+| [0047](0047-hoist-the-policy-decision-and-keep-one-fast-path.md) | Hoist the policy decision out of the loop, and keep exactly one fast path (amends 0042) | Accepted |

--- a/docs/benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md
+++ b/docs/benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md
@@ -74,17 +74,24 @@ bodies, same namespace, one calling `is_string()`/`trim()` and the other `\is_st
 The PR's benchmark job ran on the reference-class Linux runner (NFR-06's environment, OPcache and
 JIT asserted off by `tools/assert_bench_env.php`). It measured:
 
-| Subject (CI, `RowNormalizerBench`) | µs / 100 rows | Spread |
-|---|---|---|
-| `benchNormalizeHundredRows` (the class, after this change) | **22.423** | ±1.69% |
-| `benchInlineTrimHundredRows` (the floor) | **19.663** | ±0.72% |
-| **remaining overhead** | **+2.760** | — |
+**Two runs**, because a single sample is exactly what this report got wrong the first time:
 
-| NFR-09 on CI | Value |
-|---|---|
-| `benchGatewayFetchNormalizeHydrate` | 141.754 µs |
-| `benchHandWrittenPdoLoop` | 82.098 µs |
-| **ratio** | **1.73× (budget 2.5×) — unchanged from `master`** |
+| Subject (CI, `RowNormalizerBench`) | run 1 | run 2 |
+|---|---|---|
+| `benchNormalizeHundredRows` (the class, after this change) | **22.423 µs** (±1.69%) | **21.654 µs** (±2.28%) |
+| `benchInlineTrimHundredRows` (the floor) | **19.663 µs** (±0.72%) | **19.094 µs** (±1.08%) |
+| **remaining overhead** | **+2.760 µs** | **+2.560 µs** |
+| class / floor | 1.14× | 1.13× |
+
+| NFR-09 on CI | run 1 | run 2 |
+|---|---|---|
+| `benchGatewayFetchNormalizeHydrate` | 141.754 µs | 151.245 µs |
+| `benchHandWrittenPdoLoop` | 82.098 µs | 86.820 µs |
+| **ratio** | **1.73×** | **1.74×** |
+
+Budget 2.5×; `master`'s own figure is 1.73×, and ADR-0046 recorded it five times at 1.71–1.85×. The
+overhead reproduces at 2.56–2.76 µs and the ratio does not move outside the band it already
+occupied.
 
 **Two claims made earlier in this report are wrong, and this section is the correction.**
 
@@ -94,12 +101,13 @@ JIT asserted off by `tools/assert_bench_env.php`). It measured:
    noise band** and cannot be resolved by it.
 2. **The component was never 27% of NFR-09's overhead on this hardware.** That proportion came from
    item 10.10's decomposition, which — checked now — was measured on the same Windows development
-   box as this report's before/after. On CI the normalizer's *remaining* overhead is 2.760 µs of the
-   gateway path's 59.656 µs of overhead: **4.6%**. Even doubling it to guess at the pre-change
-   figure leaves the component well under 10% of the overhead, not 27%.
+   box as this report's before/after. On CI the normalizer's *remaining* overhead is 2.56–2.76 µs
+   against the gateway path's ~59.7–64.4 µs of overhead: **4.0–4.6%**. Even doubling it to guess at
+   the pre-change figure leaves the component well under 10% of the overhead, not 27%.
 
 **What is therefore known, and what is not.** Known: the class does strictly less work per string
-value, the local saving is 30.0 µs per 100 rows, and the post-change overhead on CI is +2.760 µs.
+value, the local saving is 30.0 µs per 100 rows, and the post-change overhead on CI is 2.56–2.76 µs
+across two runs.
 **Not known: the saving on CI hardware.** `RowNormalizerBench` is new, so the same-runner harness
 had nothing to compare against — it printed `new` for both subjects, correctly — and NFR-09's
 ratio, the one instrument that would have shown the saving indirectly, cannot resolve a change this

--- a/docs/benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md
+++ b/docs/benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md
@@ -69,6 +69,49 @@ bodies, same namespace, one calling `is_string()`/`trim()` and the other `\is_st
 | the per-*row* `normalize()` call itself (100 calls, ~87 ns each) | **8.7** |
 | **total residual** | **22.3** |
 
+## CI's numbers — and the correction they force
+
+The PR's benchmark job ran on the reference-class Linux runner (NFR-06's environment, OPcache and
+JIT asserted off by `tools/assert_bench_env.php`). It measured:
+
+| Subject (CI, `RowNormalizerBench`) | µs / 100 rows | Spread |
+|---|---|---|
+| `benchNormalizeHundredRows` (the class, after this change) | **22.423** | ±1.69% |
+| `benchInlineTrimHundredRows` (the floor) | **19.663** | ±0.72% |
+| **remaining overhead** | **+2.760** | — |
+
+| NFR-09 on CI | Value |
+|---|---|
+| `benchGatewayFetchNormalizeHydrate` | 141.754 µs |
+| `benchHandWrittenPdoLoop` | 82.098 µs |
+| **ratio** | **1.73× (budget 2.5×) — unchanged from `master`** |
+
+**Two claims made earlier in this report are wrong, and this section is the correction.**
+
+1. **"NFR-09 should improve from 1.73× toward ~1.6×" did not happen.** The ratio is 1.73×, the same
+   figure `master` measured. It is not a rounding artifact: ADR-0046 recorded this ratio five times
+   at **1.71–1.85×** on CI, so a ~2.8 µs change in a 141.75 µs subject sits **inside the gate's own
+   noise band** and cannot be resolved by it.
+2. **The component was never 27% of NFR-09's overhead on this hardware.** That proportion came from
+   item 10.10's decomposition, which — checked now — was measured on the same Windows development
+   box as this report's before/after. On CI the normalizer's *remaining* overhead is 2.760 µs of the
+   gateway path's 59.656 µs of overhead: **4.6%**. Even doubling it to guess at the pre-change
+   figure leaves the component well under 10% of the overhead, not 27%.
+
+**What is therefore known, and what is not.** Known: the class does strictly less work per string
+value, the local saving is 30.0 µs per 100 rows, and the post-change overhead on CI is +2.760 µs.
+**Not known: the saving on CI hardware.** `RowNormalizerBench` is new, so the same-runner harness
+had nothing to compare against — it printed `new` for both subjects, correctly — and NFR-09's
+ratio, the one instrument that would have shown the saving indirectly, cannot resolve a change this
+small. Obtaining that number would take a throwaway PR carrying the benchmark against the old
+implementation; it was not done, and the gap is named here rather than filled with an estimate.
+
+The local figures below are kept exactly as measured, because they are what the decision was made
+on. They are Windows numbers: the class costs **2.22× the inline loop before / 1.52× after** on this
+box, against **1.14×** on CI. Function-call and property-read overhead is simply a larger share of
+this workload here — which is the same effect that made the local `RowNormalizer` look like 27% of a
+budget it is responsible for 4.6% of.
+
 ## Interpretation
 
 The cost item 10.10 attributed was **dispatch, not work**: 281 ns per string value for a policy
@@ -92,9 +135,9 @@ is one method's hot loop, not a project-wide extrapolation. It is filed as roadm
 rather than fixed here, because the honest fix is the repo-wide `native_function_invocation`
 CS-Fixer rule — a risky-rule decision touching every file, and the maintainer's call.
 
-**Caveats.** Absolute numbers are this machine's, not the reference CPU's; CI's Linux run is
-authoritative for NFR-09's ratio, and the expectation that it improves from 1.73× toward ~1.6× is
-an **estimate**, not a measurement — the PR's CI run is what settles it. Spread ran 7–18% between
+**Caveats.** Absolute numbers in this section are this machine's, not the reference CPU's. The
+extrapolation this report originally made from them — NFR-09 improving toward ~1.6× — was measured
+and **refuted**; *CI's numbers* above supersede it. Spread ran 7–18% between
 the fastest and slowest sample within a process, so the 7.4 µs gap between the top two candidates
 is above noise on medians-of-three but not by a wide margin.
 

--- a/docs/benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md
+++ b/docs/benchmarks/2026/08/nfr09-rownormalizer-trim-only-fast-path.md
@@ -1,0 +1,116 @@
+# Benchmark Report: `RowNormalizer`'s per-value dispatch — the trim-only fast path
+
+- **Date:** 2026-08-07
+- **Version / commit:** v0.0.0 @ `e1931f7` (base) → this PR's branch (item **10.11**)
+- **Environment:** 12th Gen Intel Core i7-12700, Windows 11, PHP **8.3.1** CLI.
+  **OPcache inactive in CLI** (`opcache.enable_cli=0`, `opcache_get_status()` reports inactive —
+  checked, not assumed), which is the configuration spec **NFR-06** pins for benchmarking and
+  `tools/assert_bench_env.php` asserts in CI. Not the NFR-06 reference machine (Ryzen 7 5800X), so
+  absolute microseconds here are **not** comparable to CI's; the *differences and ratios* are what
+  this report claims.
+- **Command:** a standalone profiler, **one variant per process** — `php normprofile.php <variant>`
+  — not `vendor/bin/phpbench`. Two reasons, both recorded rather than glossed: phpbench's own
+  environment-capture step fails on this machine before any subject runs (a known local quirk,
+  ADR-0030 already names this box unreliable), and item 10.10's fourth benchmark-scope error on
+  this project taught that **a decomposition is itself a benchmark** — measuring several variants
+  in one process let ordering and GC move a stage by 2× (416 µs → 884 µs when measured last).
+  The permanent, CI-run subjects are `RowNormalizerBench` (added by this item).
+
+## Scenario
+
+NFR-09 budgets the whole gateway path (fetch + normalize + hydrate 100 rows of a 4-column DTO
+≤ 2.5× a hand-written PDO loop, spec r13). Item 10.10 decomposed that overhead per stage and
+attributed **27%** of it — everything that is not hydration — to `RowNormalizer`: **+55.8 µs per
+100 rows** against an inline trim loop, paid on the **default policy**, where the only active step
+is `trim` (ADR-0042).
+
+The workload is `GatewayBench`'s row shape, which NFR-09 names: 4 columns, values padded so
+trimming has real work (`'  Row 7  '`, `' active '`), `id`/`age` arriving as `int` from SQLite and
+`status` `null` on every seventh row. That is **186 string values per 100-row batch** out of 400 —
+the count matters, because the cost being measured is per *value*, not per row.
+
+Method: 400 warm-up batches, then 41 samples of 20 batches each; the figure is the median sample
+divided by 20, and every run below is the median of three separate processes.
+
+## Results
+
+**Before → after, the real class:**
+
+| Subject | µs / 100 rows | Overhead over the inline floor | Spread (min–max) |
+|---|---|---|---|
+| inline trim loop (the floor) | **42.8** | — | 40.7–48.3 |
+| `RowNormalizer` **before** (`e1931f7`) | **95.2** | **+52.3** (281 ns per string value) | 90.2–99.8 |
+| `RowNormalizer` **after** (this PR) | **65.2** | **+22.3** | 61.9–70.5 |
+
+**58% of the overhead removed** (52.3 → 22.3 µs), semantics unchanged — T-15 green, and the full
+suite green at 2424 tests.
+
+**The four designs, measured before choosing** (equivalent implementations, global namespace):
+
+| Design | µs / 100 rows | Overhead |
+|---|---|---|
+| precomputed `Closure` per policy, one call per value | 70.4 | +27.6 |
+| general pipeline inlined behind locals, no method call | 74.5 | +31.7 |
+| one loop, hoisted flag consulted per value via a ternary | 59.0 | +16.2 |
+| **hoisted flag, fast path outside the loop** (chosen) | **51.5** | **+8.7** |
+
+**Where the residual 22.3 µs goes** — the chosen design measures 51.5 µs in the global namespace
+and 65.2 µs as `D4np\Utils\Persistence\RowNormalizer`. Isolated with a two-class probe (identical
+bodies, same namespace, one calling `is_string()`/`trim()` and the other `\is_string()`/`\trim()`):
+
+| Probe | µs / 100 rows |
+|---|---|
+| namespaced, unqualified internal calls | **65.0** |
+| namespaced, `\`-prefixed internal calls | **51.4** |
+
+| Residual component | µs / 100 rows |
+|---|---|
+| PHP's namespace fallback lookup on 372 unqualified internal calls (~36 ns each) | **13.6** |
+| the per-*row* `normalize()` call itself (100 calls, ~87 ns each) | **8.7** |
+| **total residual** | **22.3** |
+
+## Interpretation
+
+The cost item 10.10 attributed was **dispatch, not work**: 281 ns per string value for a policy
+that cannot change between the first value and the last. Hoisting the decision into the constructor
+and giving the default policy a direct `trim()` loop removes 58% of it, and the two rejected
+rewrite-shaped candidates were both *slower* than the simple one — the closure recovers only half
+the dispatch because a closure call is still a call, and inlining the general pipeline pays four
+branches per value.
+
+The ternary formulation (59.0 µs) is the more readable design and lost by 7.4 µs — 45% of the win
+for a cosmetic gain. That margin is small enough to record explicitly: a future reader who values
+the single loop more than 7 µs per 100 rows has the number to make that trade knowingly.
+
+**The namespace-fallback finding is the more transferable result.** Inside a namespace, PHP resolves
+an unqualified `trim()` by trying `D4np\Utils\Persistence\trim` first and the global `trim` second,
+and NFR-06 pins the benchmark interpreter with OPcache **off** — precisely the configuration where
+that second lookup is not optimized away. It is worth **13.6 µs per 100 rows in this one method**,
+and this repository calls internal functions unqualified in every file. Two caveats stated plainly:
+consumers who run OPcache (most production deployments) will see less of it, and *this* measurement
+is one method's hot loop, not a project-wide extrapolation. It is filed as roadmap item **10.12**
+rather than fixed here, because the honest fix is the repo-wide `native_function_invocation`
+CS-Fixer rule — a risky-rule decision touching every file, and the maintainer's call.
+
+**Caveats.** Absolute numbers are this machine's, not the reference CPU's; CI's Linux run is
+authoritative for NFR-09's ratio, and the expectation that it improves from 1.73× toward ~1.6× is
+an **estimate**, not a measurement — the PR's CI run is what settles it. Spread ran 7–18% between
+the fastest and slowest sample within a process, so the 7.4 µs gap between the top two candidates
+is above noise on medians-of-three but not by a wide margin.
+
+## Reproduce
+
+```bash
+composer install --optimize-autoloader
+vendor/bin/phpbench run --report=aggregate --filter=RowNormalizerBench
+```
+
+The two permanent subjects are `benchNormalizeHundredRows` (the class, default policy) and
+`benchInlineTrimHundredRows` (the floor); the overhead is their difference, comparable on any one
+runner. Neither carries an absolute budget in `bench_budget_gate.py` — the spec owns its numbers
+(ADR-0040) and NFR-09 budgets the gateway path, not this component — and neither is I/O-bound or
+memory-hard, so both stay inside the relative regression gate (ADR-0030, exclusions per ADR-0045).
+
+To reproduce the candidate comparison or the namespace probe, the profiler used here is not
+committed (it measures designs that were rejected); the table above records what it produced, and
+`RowNormalizerBench` is what a future run should regress against.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -23,6 +23,7 @@ One report per measured scenario, from [`template.md`](template.md). Keep the in
 
 | Date | Scenario | Version | Headline result | Report |
 |------|----------|---------|-----------------|--------|
+| 2026-08-07 | `RowNormalizer`'s per-value dispatch — the trim-only fast path (item 10.11) | v0.0.0 | overhead over an inline trim loop **+52.3 → +22.3 µs per 100 rows** (58% removed); of the residual, **13.6 µs is PHP's namespace fallback** on unqualified internal calls — filed as item 10.12 | [report](2026/08/nfr09-rownormalizer-trim-only-fast-path.md) |
 | 2026-08-05 | **Every NFR budget re-measured under NFR-06's own methodology** (item 7.1) | v0.0.0 | NFR-01 **0.958 µs / 2.40×**, NFR-03 **3.776 µs**, NFR-05 **148.3 ms** — all three previously recorded as over budget are **met**. The earlier runs used `--php-disable-ini` on Windows, which is not NFR-06's environment; still not the named reference CPU | [report](2026/08/nfr-budgets-under-nfr06-methodology.md) |
 | 2026-08-04 | NFR-05 password hashing cost (`Hash::make`, Argon2id defaults) | v0.0.0 | **349 ms** vs. the 50–200 ms range — over, but the *work factor* clears OWASP's floor; `verify()` costs the same and is the figure that scales | [report](2026/08/nfr05-password-hashing-cost.md) |
 | 2026-08-04 | NFR-03 QueryBuilder build time — **corrected workload** + 2 optimisations | v0.0.0 | literal 5-condition SELECT **14.43 → 12.98 µs**; still over ≤ 10 µs, but 1.3× not 2.3× | [report](2026/08/nfr03-querybuilder-build-time-corrected.md) |

--- a/docs/journal/2026/08/2026-08-07-rownormalizer-fast-path.md
+++ b/docs/journal/2026/08/2026-08-07-rownormalizer-fast-path.md
@@ -63,9 +63,38 @@ mechanism assertion guards the *existence of the optimization* (ADR-0027's rule,
 failure class as item 10.8's mutation gate that ran on nothing and item 2.7's coverage gate with no
 driver). Five defects planted, five caught.
 
+## Then CI refuted the premise
+
+All fifteen checks passed, and the benchmark job's numbers said something I had not expected:
+`benchNormalizeHundredRows` **22.423 µs** against the inline floor's **19.663** — a remaining
+overhead of **+2.760 µs**, not the +22.3 this box measures — and **NFR-09's ratio unchanged at
+1.73×**, exactly what `master` reports.
+
+My PR body had predicted 1.73× → ~1.6×. That was wrong, and it was wrong for a reason worth more
+than the item: **item 10.10's "+55.8 µs / 27% of NFR-09's overhead" was measured on this Windows
+development machine**, and on CI the same component accounts for **4.6%** of the gateway overhead.
+The proportion that made this item worth prioritizing does not reproduce in the environment the
+budget is defined in. ADR-0046 had already recorded NFR-09 five times at 1.71–1.85× on CI, so a
+2.8 µs change in a 141.75 µs subject was never resolvable by that gate — the noise band is wider
+than the whole component.
+
+I kept the change: it does strictly less work per value, it costs one boolean and one guarded loop,
+and it is on the path of every gateway read. But the justification in the record is now the small
+honest number, not the large local one. And the saving on CI hardware is **unmeasured** — the
+subject is new, so the same-runner harness had nothing to compare against; getting that number
+would need a throwaway PR carrying the benchmark against the old implementation, which I did not
+open. Named, not filled with an estimate.
+
 ## Lesson
 
-**Measure the candidate in its real home.** A variant benchmarked in a scratch file and the same
+**Measure the candidate in its real home** — twice over, and the second one is the expensive
+lesson. A variant in a scratch file and the same code inside its namespace differed by 26%. And a
+component measured on the dev box looked six times more important than it is on the runner where
+the budget lives. Item 10.10's lesson was that a decomposition is itself a benchmark; the turn
+after that is that **an attribution inherits the machine it was taken on**, so a proportion used to
+prioritize work has to be re-taken in the reference environment before it is trusted.
+
+The original lesson still stands as written: A variant benchmarked in a scratch file and the same
 code inside its namespace differed by 26%, and the gap was not noise — it was a language feature
 the scratch file did not exercise. Item 10.10's lesson was that a decomposition is itself a
 benchmark; this is the next turn of the same screw: a *candidate* is itself a benchmark, and the

--- a/docs/journal/2026/08/2026-08-07-rownormalizer-fast-path.md
+++ b/docs/journal/2026/08/2026-08-07-rownormalizer-fast-path.md
@@ -1,0 +1,72 @@
+# 2026-08-07 — The simple design won, and the namespace cost more than the method call
+
+Roadmap item **10.11**, `step:optimize`, route `fast / medium`. Run under `/eados optimize`'s
+measure-first discipline: a number before, one change, a number after, both recorded.
+
+## What the number actually was
+
+Item 10.10 attributed **+55.8 µs per 100 rows** to `RowNormalizer` — 27% of NFR-09's gateway
+overhead and the only part that is not hydration. Re-measured here in isolated processes it
+reproduces at **+52.3 µs**, and the useful reframing is per *value* rather than per row:
+**281 ns for each of the 186 string values** in a 100-row batch, spent re-deriving four decisions
+that belong to an immutable policy. Dispatch, not work.
+
+## Four designs, measured before choosing
+
+| design | µs / 100 rows |
+|---|---|
+| inline trim loop (floor) | 42.8 |
+| the class as it stood | 95.2 |
+| precomputed `Closure` per policy | 70.4 |
+| general pipeline inlined behind locals | 74.5 |
+| one loop, per-value ternary | 59.0 |
+| **hoisted flag + one fast path** | **51.5** |
+
+**Both rewrite-shaped candidates were slower than the simple one.** A closure recovers half the
+dispatch because a closure call is still a call; inlining the pipeline pays four branches per
+value. The design that won is the one the roadmap item named first, and it is also the smallest:
+one constructor-computed boolean, one guarded loop, the general pipeline untouched.
+
+The more readable formulation — a single loop with a ternary — lost by 7.4 µs. Small enough to
+write down rather than bury: someone may reasonably want the single loop back, and now they know
+the price.
+
+## The finding I did not ship
+
+The chosen design measured **51.5 µs** in my scratch profiler and **65.2 µs** as the real class.
+Same loop, same call. Fourteen microseconds unaccounted for is not something to average away, so I
+built a two-class probe: identical bodies in one namespace, one calling `is_string()`/`trim()`, the
+other `\is_string()`/`\trim()`. **65.0 vs 51.4 µs.**
+
+It is PHP's namespace fallback: inside a namespace, `trim()` is resolved by trying
+`D4np\Utils\Persistence\trim` first and the global `trim` second — and NFR-06 pins the benchmark
+interpreter with **OPcache off**, which is exactly where that second lookup is not optimized away.
+Checked rather than assumed: `opcache.enable_cli=0` on this box, `opcache_get_status()` inactive.
+**13.6 µs per 100 rows, ~36 ns per call, 372 calls per batch.**
+
+Two characters in this one file would have taken the number. I filed **item 10.12** instead. The
+reason is not caution, it is that a lone `\trim()` in a repository that calls internal functions
+unqualified everywhere reads as a style slip — the next tidy-up deletes it, the 13.6 µs comes back,
+and every test stays green. Holding it needs the repo-wide `native_function_invocation` rule (a
+risky-rule decision touching every file) or a mechanism test pinning two characters, which is
+theatre. So: measurement recorded, decision filed, one change shipped.
+
+## Why this item has two tests instead of one
+
+The fast path is output-identical to the general path — that is the whole design. Which means a
+behavioural suite **cannot see it stop working**. I proved that rather than asserting it: planting
+`trimOnly = false`, the optimization silently ceasing to exist, leaves the entire 16-combination
+differential matrix **green** and fails exactly two rows of the reflection truth-table assertion.
+
+So the matrix guards correctness (a condition that fires one combination too widely) and the
+mechanism assertion guards the *existence of the optimization* (ADR-0027's rule, and the same
+failure class as item 10.8's mutation gate that ran on nothing and item 2.7's coverage gate with no
+driver). Five defects planted, five caught.
+
+## Lesson
+
+**Measure the candidate in its real home.** A variant benchmarked in a scratch file and the same
+code inside its namespace differed by 26%, and the gap was not noise — it was a language feature
+the scratch file did not exercise. Item 10.10's lesson was that a decomposition is itself a
+benchmark; this is the next turn of the same screw: a *candidate* is itself a benchmark, and the
+environment that makes it fast has to be the one it will actually live in.

--- a/src/bench/php/d4np/utils/RowNormalizerBench.php
+++ b/src/bench/php/d4np/utils/RowNormalizerBench.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench;
+
+use D4np\Utils\Persistence\RowNormalizer;
+use PhpBench\Attributes as Bench;
+
+/**
+ * The `RowNormalizer` component of NFR-09, isolated — roadmap item 10.11, ADR-0047.
+ *
+ * NFR-09 budgets the whole gateway path (fetch + normalize + hydrate ≤ 2.5× a hand-written PDO
+ * loop) and item 10.10's decomposition attributed **27% of the remaining overhead** to this one
+ * step: +55.8 µs per 100 rows against an inline trim loop, paid on the *default* policy where the
+ * only active step is `trim` (ADR-0042). This class makes that component number a measured
+ * subject rather than a one-off profiling result, so a future change to the policy pipeline cannot
+ * quietly give the cost back.
+ *
+ * **Two subjects, because the number that matters is a difference.** The normalizer's absolute
+ * time says little on its own — a runner's clock speed moves it — while the *overhead* over the
+ * inline loop is what item 10.11 set out to reduce, and it is comparable across machines the same
+ * way NFR-01's and NFR-09's ratios are (both subjects run in one invocation on one runner, so
+ * clock and virtualization noise apply to both).
+ *
+ * **No absolute budget is declared for either subject**, deliberately: the spec owns its own
+ * numbers (ADR-0040), and NFR-09 budgets the gateway path, not this component. The subjects are
+ * measured and reported; the relative regression gate (ADR-0030) is what holds them, and neither
+ * is I/O-bound or memory-hard, so neither belongs in ADR-0045's exclusion list.
+ *
+ * The row shape is {@see GatewayBench}'s, for the same reason it is written into NFR-09: four
+ * columns, two of them strings, values padded so trimming has real work to do. 186 of the 400
+ * values in a 100-row batch are strings — the per-value dispatch this item removed was 276 ns
+ * each.
+ */
+#[Bench\BeforeMethods('setUp')]
+#[Bench\Iterations(10)]
+#[Bench\Revs(100)]
+#[Bench\RetryThreshold(5)]
+final class RowNormalizerBench
+{
+    private const ROW_COUNT = 100;
+
+    /** @var list<array<string, mixed>> */
+    private array $rows = [];
+
+    private RowNormalizer $normalizer;
+
+    public function setUp(): void
+    {
+        // Built in memory rather than fetched: this subject measures the normalizer, and a
+        // driver in the loop would put PDO's cost in both numbers and shrink the difference the
+        // benchmark exists to show. The shape and padding match what GatewayBench seeds.
+        for ($i = 1; $i <= self::ROW_COUNT; $i++) {
+            $this->rows[] = [
+                'id' => $i,
+                'name' => "  Row {$i}  ",
+                'age' => 20 + ($i % 50),
+                'status' => $i % 7 === 0 ? null : ' active ',
+            ];
+        }
+
+        $this->normalizer = new RowNormalizer(); // the default policy: trim, and nothing else
+    }
+
+    /**
+     * The library path on its default policy — the trim-only fast path since item 10.11.
+     */
+    public function benchNormalizeHundredRows(): void
+    {
+        foreach ($this->rows as $row) {
+            $this->normalizer->normalize($row);
+        }
+    }
+
+    /**
+     * The floor the overhead is measured against: the same guard and the same `trim()`, written
+     * inline with no policy object at all — the loop the surveyed estate hand-wrote seventeen
+     * times, and the one {@see GatewayBench::benchHandWrittenPdoLoop()} keeps.
+     */
+    public function benchInlineTrimHundredRows(): void
+    {
+        foreach ($this->rows as $row) {
+            foreach ($row as $column => $value) {
+                if (is_string($value)) {
+                    $row[$column] = trim($value);
+                }
+            }
+        }
+    }
+}

--- a/src/main/php/d4np/utils/Persistence/RowNormalizer.php
+++ b/src/main/php/d4np/utils/Persistence/RowNormalizer.php
@@ -46,6 +46,19 @@ use D4np\Utils\Support\UtilsThrowable;
 final class RowNormalizer
 {
     /**
+     * Whether the configured policy is *exactly* "trim, and nothing else" — the default, and
+     * the only policy `TableGateway` and `Repository` configure unless a consumer says
+     * otherwise.
+     *
+     * Hoisted here because the decision is a property of the **policy**, which is immutable,
+     * not of the row: computing it once per instance instead of re-deriving it per value is
+     * what makes {@see self::normalize()}'s fast path possible (roadmap item 10.11,
+     * ADR-0047). It is not a second policy — see that method for why the two paths cannot
+     * disagree.
+     */
+    private readonly bool $trimOnly;
+
+    /**
      * @param ?string $fromEncoding        the encoding values arrive in, or `null` to do no
      *                                     transcoding at all
      * @param bool    $trim               strip leading and trailing whitespace
@@ -66,6 +79,14 @@ final class RowNormalizer
         private readonly bool $lossy = false,
         private readonly string $toEncoding = 'UTF-8',
     ) {
+        // The general pipeline reduces to a bare `trim()` exactly when no encoding is
+        // declared, trimming is on, and neither of the two steps that could change the
+        // result — collapsing (which subsumes trimming and returns something different) and
+        // blank-to-null (which can return `null` instead of a string) — is enabled.
+        $this->trimOnly = $fromEncoding === null
+            && $trim
+            && !$collapseWhitespace
+            && !$blankToNull;
     }
 
     /**
@@ -81,6 +102,17 @@ final class RowNormalizer
      * Blank-to-`null` comes last, so it sees the value the earlier steps produced: a
      * `CHAR(20)` holding only spaces is blank after trimming and not before it.
      *
+     * **The trim-only fast path** (roadmap item 10.11, ADR-0047) is a performance shortcut and
+     * **not a second policy.** On the default policy the general pipeline below computes
+     * `trim($value)` and nothing else — no transcoding, no collapsing, and no blank-to-`null`
+     * — so the fast path runs that one call directly and skips the per-value dispatch through
+     * {@see self::normalizeValue()}. Measured, that dispatch was the cost: **276 ns per string
+     * value**, or +52.9 µs per 100 four-column rows against an inline trim loop, of which the
+     * fast path removes 84%. The two paths are held to identical output by T-15's
+     * oracle matrix, which walks every policy combination — the risk here is not the `trim()`
+     * call but {@see self::$trimOnly}'s condition being wrong, and that is what the matrix
+     * (plus its truth-table assertion) exists to catch.
+     *
      * @param array<string, mixed> $row as the driver returned it
      *
      * @return array<string, mixed> the same keys, in the same order, with string values
@@ -90,6 +122,18 @@ final class RowNormalizer
      */
     public function normalize(array $row): array
     {
+        if ($this->trimOnly) {
+            foreach ($row as $column => $value) {
+                // Same guard as the general path: only strings are touched, everything else
+                // — including a BLOB resource — passes through by identity.
+                if (is_string($value)) {
+                    $row[$column] = trim($value);
+                }
+            }
+
+            return $row;
+        }
+
         foreach ($row as $column => $value) {
             if (!is_string($value)) {
                 // int, float, bool, null and resources (BLOB streams) are returned by

--- a/src/test/php/d4np/utils/Persistence/RowNormalizerTest.php
+++ b/src/test/php/d4np/utils/Persistence/RowNormalizerTest.php
@@ -6,6 +6,7 @@ namespace D4np\Utils\Tests\Persistence;
 
 use D4np\Utils\Persistence\RowNormalizer;
 use D4np\Utils\Support\DatabaseException;
+use D4np\Utils\Support\Str;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
@@ -244,5 +245,204 @@ final class RowNormalizerTest extends TestCase
         } finally {
             fclose($handle);
         }
+    }
+
+    // ---- the trim-only fast path (item 10.11, ADR-0047) --------------------------------------
+
+    /**
+     * Every value the corpus below carries, through **every** policy combination, compared
+     * against {@see self::oracle()} — an implementation of ADR-0042's ordering written outside
+     * the class.
+     *
+     * This is the fast path's safety net, and it is aimed at the actual risk. The shortcut
+     * itself is a `trim()` call that cannot be wrong; what *can* be wrong is the condition
+     * choosing it, and a condition that fires one combination too widely is invisible to any
+     * test that only exercises the default policy. So the matrix asserts the whole truth
+     * table behaviourally: if `$trimOnly` ever fires where the general pipeline would have
+     * produced something else, exactly one of these combinations disagrees with the oracle.
+     *
+     * @param array<string, mixed> $row
+     */
+    #[DataProvider('policyCombinations')]
+    public function testEveryPolicyCombinationAgreesWithAnIndependentOracle(
+        array $row,
+        ?string $fromEncoding,
+        bool $trim,
+        bool $collapseWhitespace,
+        bool $blankToNull,
+    ): void {
+        $normalizer = new RowNormalizer(
+            fromEncoding: $fromEncoding,
+            trim: $trim,
+            collapseWhitespace: $collapseWhitespace,
+            blankToNull: $blankToNull,
+        );
+
+        $expected = [];
+
+        foreach ($row as $column => $value) {
+            $expected[$column] = self::oracle($value, $fromEncoding, $trim, $collapseWhitespace, $blankToNull);
+        }
+
+        self::assertSame($expected, $normalizer->normalize($row));
+    }
+
+    /**
+     * The same matrix with an encoding declared, so the half of the truth table where the fast
+     * path must **never** fire is covered too. Gated on `iconv` like every other transcoding
+     * test here.
+     *
+     * @param array<string, mixed> $row
+     */
+    #[DataProvider('transcodingPolicyCombinations')]
+    #[RequiresPhpExtension('iconv')]
+    public function testEveryTranscodingCombinationAgreesWithAnIndependentOracle(
+        array $row,
+        ?string $fromEncoding,
+        bool $trim,
+        bool $collapseWhitespace,
+        bool $blankToNull,
+    ): void {
+        $this->testEveryPolicyCombinationAgreesWithAnIndependentOracle(
+            $row,
+            $fromEncoding,
+            $trim,
+            $collapseWhitespace,
+            $blankToNull,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, ?string, bool, bool, bool}>
+     */
+    public static function policyCombinations(): iterable
+    {
+        yield from self::combinationsFor(null);
+    }
+
+    /**
+     * `ISO-8859-15` → `UTF-8` deliberately: every byte is valid in the source encoding, so
+     * transcoding can never throw here and the matrix stays about the *composition* of steps
+     * rather than about failure handling (which
+     * {@see self::testAnUnconvertibleValueIsRefusedAndNamesItsColumn()} owns).
+     *
+     * @return iterable<string, array{array<string, mixed>, ?string, bool, bool, bool}>
+     */
+    public static function transcodingPolicyCombinations(): iterable
+    {
+        yield from self::combinationsFor('ISO-8859-15');
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, ?string, bool, bool, bool}>
+     */
+    private static function combinationsFor(?string $fromEncoding): iterable
+    {
+        $corpus = [
+            'padded' => '  Ada  ',
+            'clean' => 'Ada',
+            'empty' => '',
+            'whitespace only' => '   ',
+            'tabs and newlines' => "\t Ada \n",
+            'zero string' => '0',
+            'padded zero' => '  0  ',
+            'internal runs' => 'two  spaces  inside',
+            'padded internal runs' => '  two  spaces  ',
+            'multibyte' => 'Grace Hopper',
+            'int' => 42,
+            'null' => null,
+            'float' => 3.14,
+            'bool' => true,
+        ];
+
+        foreach ([true, false] as $trim) {
+            foreach ([true, false] as $collapseWhitespace) {
+                foreach ([true, false] as $blankToNull) {
+                    $label = sprintf(
+                        'from=%s trim=%s collapse=%s blankToNull=%s',
+                        $fromEncoding ?? 'null',
+                        $trim ? 'y' : 'n',
+                        $collapseWhitespace ? 'y' : 'n',
+                        $blankToNull ? 'y' : 'n',
+                    );
+
+                    yield $label => [$corpus, $fromEncoding, $trim, $collapseWhitespace, $blankToNull];
+                }
+            }
+        }
+    }
+
+    /**
+     * ADR-0042's pipeline, restated independently of the class under test: transcode first,
+     * then collapse *or* trim, then blank-to-`null` last.
+     */
+    private static function oracle(
+        mixed $value,
+        ?string $fromEncoding,
+        bool $trim,
+        bool $collapseWhitespace,
+        bool $blankToNull,
+    ): mixed {
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        if ($fromEncoding !== null) {
+            $value = Str::transcode($value, $fromEncoding, 'UTF-8', false);
+        }
+
+        if ($collapseWhitespace) {
+            $value = Str::collapseWhitespace($value);
+        } elseif ($trim) {
+            $value = trim($value);
+        }
+
+        return $blankToNull ? Str::nullIfBlank($value) : $value;
+    }
+
+    /**
+     * The fast path asserted as a **mechanism**, per ADR-0027's rule for a property no
+     * behaviour can observe.
+     *
+     * The two paths are output-identical by construction — which is exactly why nothing above
+     * would notice if the condition were replaced by `false` and the optimization silently
+     * stopped happening. That failure class has a history in this project (a mutation gate
+     * that ran on nothing, item 10.8; a coverage gate with no driver, item 2.7), so the
+     * condition's truth table is pinned directly rather than inferred from a green suite.
+     */
+    #[DataProvider('fastPathTruthTable')]
+    public function testTheFastPathFiresExactlyForTheTrimOnlyPolicy(
+        bool $expected,
+        RowNormalizer $normalizer,
+    ): void {
+        $property = new \ReflectionProperty(RowNormalizer::class, 'trimOnly');
+
+        self::assertSame($expected, $property->getValue($normalizer));
+    }
+
+    /**
+     * @return iterable<string, array{bool, RowNormalizer}>
+     */
+    public static function fastPathTruthTable(): iterable
+    {
+        yield 'the default policy takes it' => [true, new RowNormalizer()];
+        yield 'trim spelled out takes it' => [true, new RowNormalizer(trim: true)];
+        yield 'an encoding excludes it' => [false, new RowNormalizer(fromEncoding: 'ISO-8859-15')];
+        yield 'trimming off excludes it' => [false, new RowNormalizer(trim: false)];
+        yield 'collapsing excludes it' => [false, new RowNormalizer(collapseWhitespace: true)];
+        yield 'blank-to-null excludes it' => [false, new RowNormalizer(blankToNull: true)];
+        yield 'collapsing with trim on still excludes it' => [
+            false,
+            new RowNormalizer(trim: true, collapseWhitespace: true),
+        ];
+        yield 'every switch on excludes it' => [
+            false,
+            new RowNormalizer(
+                fromEncoding: 'ISO-8859-15',
+                trim: true,
+                collapseWhitespace: true,
+                blankToNull: true,
+            ),
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Roadmap item **10.11** (`step:optimize`), run under `/eados optimize`'s measure-first
discipline. `RowNormalizer` computed its policy decision **per value**; it now computes it once
in the constructor and the default policy runs through one guarded fast path.

**95.2 → 65.2 µs per 100 four-column rows** on the development machine — the overhead over an
inline trim loop goes **+52.3 → +22.3 µs, 58% removed**, with no behaviour change.

**CI then refuted the premise this item was filed on, and the record now says so** (`6e42608`):
on the reference-class runner the remaining overhead is **+2.760 µs** and **NFR-09's ratio does not
move — 1.73×, `master`'s own figure.** See *What CI actually measured* below. The change is kept on
a smaller, honestly-stated benefit.

## Motivation

Item 10.10's decomposition attributed **+55.8 µs per 100 rows** to this class — 27% of NFR-09's
gateway overhead and the only part that is not hydration — paid on the *default* policy where the
only active step is `trim` (ADR-0042). Re-measured here it reproduces at +52.3 µs, and the useful
reframing is per **value**: **281 ns** for each of the 186 string values in a 100-row batch, spent
re-deriving four decisions that belong to an immutable policy. Dispatch, not work.

NFR-09 is already met (1.73× against ≤ 2.5×), so "accept the cost as the price of ADR-0042's
explicitness" was a legitimate outcome the item named. It lost on measurement, not on taste.

## Changes

- `src/main/.../Persistence/RowNormalizer.php` — a constructor-computed `trimOnly` flag and one
  fast path in `normalize()`. The general pipeline is untouched.
- `src/test/.../Persistence/RowNormalizerTest.php` — **+24 cases**: a 16-combination differential
  matrix against an oracle written outside the class, and the condition's truth table asserted by
  reflection.
- `src/bench/.../RowNormalizerBench.php` — two subjects (the class, and the inline floor) so the
  *difference* is reproducible in CI. **No absolute budget declared**: the spec owns its numbers
  (ADR-0040) and NFR-09 budgets the gateway path, not this component. Neither subject is I/O-bound
  or memory-hard, so neither belongs in ADR-0045's exclusion list.
- **ADR-0047** — the decision, all four measured candidates, and the rejected alternatives.
  ADR-0042 is **amended by annotation, not edited** (ADR-0041's precedent).
- Benchmark record + index row, journal, CHANGELOG, ROADMAP (10.11 closed, **10.12 filed**),
  Spec Coverage Map rows §4/§7/§9.

### Four designs, measured before choosing

| design | µs / 100 rows | overhead |
|---|---|---|
| inline trim loop (floor) | 42.8 | — |
| the class as it stood | 95.2 | +52.3 |
| precomputed `Closure` per policy | 70.4 | +27.6 |
| general pipeline inlined behind locals | 74.5 | +31.7 |
| one loop, per-value ternary | 59.0 | +16.2 |
| **hoisted flag + one fast path** (chosen) | **51.5**\* | **+8.7**\* |

\* in the global namespace; the class itself lands at 65.2 µs — see the finding below.

**Both rewrite-shaped candidates were slower than the simple one.** The more readable
single-loop ternary lost by 7.4 µs; recorded rather than buried, so a future reader can take the
readability back knowingly.

## Two tests, and the division of labour is proved rather than argued

The fast path is output-identical to the general path — that is the design — which means a
behavioural suite **cannot see it stop working**. Planting `trimOnly = false` (the optimization
silently ceasing to exist) leaves the entire differential matrix **green** and fails exactly two
rows of the reflection truth-table assertion. That is ADR-0027's rule, and the same failure class
as item 10.8's mutation gate running on nothing and item 2.7's coverage gate with no driver.

**5 planted defects, 5 caught:** condition too wide on `blankToNull`, too wide on
`collapseWhitespace`, always true, always false, and the fast path's `is_string()` guard dropped.

## A finding filed rather than shipped — item 10.12

The chosen design measures **51.5 µs** in the global namespace and **65.2 µs** as
`D4np\Utils\Persistence\RowNormalizer`. Same loop. Isolated with a two-class probe (identical
bodies, one namespace, `is_string()`/`trim()` vs `\is_string()`/`\trim()`): **65.0 vs 51.4 µs**.

It is PHP's **namespace fallback lookup** — `D4np\Utils\Persistence\trim` tried before the global
`trim` — worth **13.6 µs per 100 rows, ~36 ns × 372 calls**, in exactly the OPcache-off
configuration NFR-06 pins (verified locally: `opcache.enable_cli=0`, status inactive; not assumed).

Two characters in this file would take the number. **Deliberately not applied:** the repository
calls internal functions unqualified everywhere and `native_function_invocation` is absent from
`.php-cs-fixer.dist.php`, so a lone prefixed call reads as a style slip — the next tidy-up removes
it, the 13.6 µs returns, and every test stays green. Holding it needs the repo-wide CS-Fixer rule
(risky-rule class, touches every file) — **the maintainer's call**, filed as item **10.12** with
the measurement attached.

**Consequence for the milestone:** M10 stays open by that one decision rather than closing here,
and README's M10 row stays `⏳ planned` accordingly.

## What CI actually measured — and the correction it forced

**Two runs, because a single sample is what this PR just got wrong:**

| Subject (CI, NFR-06 environment) | run 1 | run 2 |
|---|---|---|
| `benchNormalizeHundredRows` (the class, after) | **22.423 µs** (±1.69%) | **21.654 µs** (±2.28%) |
| `benchInlineTrimHundredRows` (the floor) | **19.663 µs** (±0.72%) | **19.094 µs** (±1.08%) |
| **remaining overhead** | **+2.760 µs** | **+2.560 µs** |
| NFR-09 ratio (gateway / hand-written) | 141.754 / 82.098 = **1.73×** | 151.245 / 86.820 = **1.74×** |

Budget 2.5×; `master`'s own figure is 1.73×.

Two things this PR claimed are wrong, and the commit `6e42608` fixes them in the ADR, the benchmark
record, the roadmap, the journal and the changelog:

1. **NFR-09 did not improve.** 1.73× is exactly what `master` reports, and it is not rounding:
   ADR-0046 recorded this ratio five times at **1.71–1.85×**, so ~2.8 µs inside a 141.75 µs subject
   sits within the gate's own noise band.
2. **The component was never 27% of NFR-09's overhead on this hardware.** That proportion came from
   item 10.10's decomposition, taken on the same Windows box as this PR's before/after. On CI the
   normalizer's remaining overhead is 2.56–2.76 µs of the gateway path's ~59.7–64.4 µs — **4.0–4.6%**.

**The saving on CI hardware is unmeasured, and that gap is named rather than estimated:**
`RowNormalizerBench` is new, so the same-runner harness had nothing to compare against (it printed
`new` for both subjects, correctly), and NFR-09 cannot resolve a change this small. Measuring it
would take a throwaway PR carrying the benchmark against the old implementation; that was not done.

**Why the change is still worth merging** — it does strictly less work per string value, for one
boolean and one guarded loop, on the path of every gateway read, with the policy semantics pinned
by a 16-combination differential matrix. If you would rather not carry two paths for a benefit this
size on reference hardware, that is a legitimate call and the honest number to make it on is now in
the ADR. Item 10.12's text was corrected too: its 13.6 µs figure is an upper bound from the same
wrong machine, so that decision must re-measure on CI.

## Design Patterns

- None adopted. This is a measured optimization inside an existing class; the Table Data Gateway
  entry from item 10.4 is unchanged.

## Verification

- [x] Full suite green — **2424 tests, 5219 assertions** (+24), 9 pre-existing local skips
      (no `fileinfo`/coverage driver on this box; CI certifies coverage)
- [x] `phpstan analyse` — no errors (max level)
- [x] `php-cs-fixer` — clean
- [x] `deptrac analyse` — **0 violations, 0 uncovered, 254 allowed**; no new edge (the change adds
      no dependency)
- [x] `python tools/consistency_lint.py` — OK
- [x] `python tools/action_pin_lint.py` — OK (offline half; no workflow files touched)
- [x] Planted-defect campaign — 5/5 caught, files staged first so `git checkout --` could actually
      restore them (item 10.4's lesson)
- [x] Before/after measured in **isolated processes**, 41 samples × 20 batches, median of three
      runs each, spread reported (item 10.10's lesson: a decomposition is itself a benchmark)
- [x] **All 15 checks pass**, benchmark job included
- [x] NFR-09's ratio on CI — measured: **1.73×, unchanged.** The estimate this PR originally
      carried (→ ~1.6×) was **refuted**; see below. Every artifact was corrected in `6e42608`
      rather than left standing.

## Documentation Impact

- [x] ADR-0047 added; ADR-0042 annotated; ADR index row
- [x] Benchmark record + index row (newest-first)
- [x] ROADMAP — 10.11 checked with its findings, **10.12 filed**, Spec Coverage Map §4/§7/§9
- [x] Journal — `2026-08-07-rownormalizer-fast-path.md`; ROADMAP's latest-checkpoint pointer
- [x] CHANGELOG — `[Unreleased] / Changed`
- [ ] Spec — **unchanged, deliberately**: no requirement moved. NFR-09's budget, T-15's scope and
      FR-36's text all still describe what the code does.
- [x] README — M10 row deliberately left `⏳ planned` (10.12 is open)
- [x] PR metadata — assignee (owner), label, milestone `v0.9.0`

## Lesson

Lesson: **measure the candidate in its real home** — twice over. A variant in a scratch file and
the same code inside its namespace differed by 26% (a language feature the scratch file never
exercised). And a component measured on the dev box looked six times more important than it is on
the runner where the budget lives. Item 10.10's lesson was that a decomposition is itself a
benchmark; the turn after it is that **an attribution inherits the machine it was taken on**, so a
proportion used to prioritize work must be re-taken in the reference environment before it is
trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
