### PR TITLE
feat(http): one envelope shape, and a reference instead of the exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`D4np\Utils\Http\ApiEnvelope` + `Http\Outcome`** — one JSON shape for every answer an API
+  gives (spec r3 FR-39, RFC-0002; roadmap item **11.3**; **ADR-0051**). `{"status", "code",
+  "messages", "data"}`, **all four keys on every outcome** — `data: null` is serialized as `null`
+  rather than omitted, so a client may read `payload.data` without a guard, and `messages` encodes
+  as `[]` rather than `{}`. The nine outcomes are an enum, each case owning its HTTP status, so
+  the mapping exists once. Message strings are caller-supplied; the library ships no catalogue and
+  writes exactly one English string (the fallback for a `caught()` with no wording).
+  **`caught()` takes a correlation reference, not a `Throwable`** — an envelope built from an
+  exception would put `getMessage()` on the wire, and a message names schemas and paths as readily
+  as a stack trace does (ADR-0029's stance, applied at the payload boundary). Two status choices
+  worth knowing: `invalid` is **422** (well-formed but rejected), `empty` is **200** (a search with
+  no results is a successful search). Mapping an `Errors\Result` to an envelope stays in the
+  application — an `Http`→`Errors` import would breach the layering rule — and is written out in
+  [`docs/patterns/endpoint-kernel.md`](docs/patterns/endpoint-kernel.md).
+
 - **`D4np\Utils\Http\Router`** — a minimal front-controller router (spec r3 FR-38, RFC-0002;
   roadmap item **11.2**; **ADR-0050**), with `MatchedRoute` and two new failures,
   `Support\RouteNotFoundException` (404) and `Support\MethodNotAllowedException` (405). **The two

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-07 — Two answers where the estate had one](docs/journal/2026/08/2026-08-07-router.md).
+  [2026-08-07 — Three envelopes become one, and the exception stays home](docs/journal/2026/08/2026-08-07-api-envelope.md).
 
 ## Model & effort routing (advisory)
 
@@ -1154,11 +1154,27 @@ The console-side trio: client, router, envelope (RFC-0002 FR-37…FR-39).
       session:** *a `sed` plant silently failed to match and my guard did not catch it because it
       checked that the* **replacement** *was present — and `$value` already occurred elsewhere.
       The check has to be that the* **original is gone**.
-- [ ] 11.3 `ApiEnvelope`: readonly envelope value, fixed JSON shape (`status`, `code`,
+- [x] 11.3 `ApiEnvelope`: readonly envelope value, fixed JSON shape (`status`, `code`,
       `messages`, `data`), outcome constructors (ok/created/updated/deleted/empty/invalid/
       notFound/failed/caught); message strings caller-supplied, `Result`-mapping stays a
       documented app-side pattern (RFC-0002 FR-39) (severity:medium — consumer-visible API
-      shape) — size: S · route: standard / medium
+      shape) — size: S · route: standard / medium *(session model matched the route — first time
+      this milestone)* · **ADR-0051** *(not scheduled by the item: a security-relevant decision
+      surfaced, and §7/§10 require one under the enterprise posture)*. *Three estate envelopes and
+      232+ construction sites become one shape, with the nine outcomes as an* `Outcome` *enum that
+      owns its HTTP status (ADR-0015's reasoning; the estate re-derived that mapping three times).*
+      **The security decision:** `caught()` *takes a* **correlation reference, not a** `Throwable`
+      *— an envelope built from an exception puts* `getMessage()` *on the wire, and a message names
+      schemas and paths as readily as a trace does (ADR-0029's stance at the payload boundary).
+      Asserted as a* **mechanism on the reflected signature**, *because no behavioural test can see
+      an overload that does not exist.* **Two status choices argued rather than assumed:**
+      `Invalid` *is* **422** *not 400 (well-formed but rejected — RFC 4918 §11.2), and* `Empty` *is*
+      **200** *not 404 (a search with no results is a successful search; the estate's 404 is what
+      teaches clients to retry "no rows").* **The shape is the product:** *all four keys on every
+      outcome, `data: null` present in the JSON and `messages` pinned to encode as* `[]` *not* `{}`.
+      *The* `Result`*→envelope mapping stayed* **out** *of the library (an* `Http`*→*`Errors` *edge
+      the layering rule forbids) and is now written out in the endpoint-kernel pattern doc. 2525
+      tests (+28), 5 planted defects, 5 caught.*
 - [ ] 11.4 T-07 `HttpClient` behavioural suite against a live `php -S` origin (timeout,
       refusal and error-taxonomy paths; T-03's process discipline) (RFC-0002 T-07)
       (security) — size: M · route: frontier-reasoning / extra

--- a/docs/adr/0051-one-envelope-shape-and-a-reference-instead-of-the-exception.md
+++ b/docs/adr/0051-one-envelope-shape-and-a-reference-instead-of-the-exception.md
@@ -1,0 +1,118 @@
+# ADR-0051: One envelope shape, and a reference instead of the exception
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
+- **Related:** ROADMAP item **11.3** · spec r3 **FR-39** (RFC-0002) ·
+  [ADR-0029](0029-result-carries-a-throwable-and-production-withholds-the-message-too.md)
+  (production withholds the message as well as the trace — the stance this applies) ·
+  [ADR-0015](0015-identifier-allowlist-closed-keywords-and-the-anchor-hole.md) (a closed
+  vocabulary becomes an enum) · [ADR-0050](0050-classify-the-miss-and-keep-the-router-a-table.md)
+  (the router whose misses this envelope reports) · RFC-0001 §"Decision" (the layering rule that
+  keeps the `Result` mapping out of `Http`) · pattern doc
+  [`endpoint-kernel.md`](../patterns/endpoint-kernel.md)
+
+## Context
+
+The surveyed estate carried **three** response-envelope implementations — one per application
+plus a vendored copy — with 232+ construction sites between them and no two agreeing on their
+field names. A client written against one could not read another, and the outcome vocabulary
+(`ok`, `created`, `notFound`, …) was re-spelled in each, with each having its own idea of which
+HTTP status accompanied which outcome.
+
+FR-39 asks for one envelope: a readonly value with the fixed shape `status`, `code`, `messages`,
+`data`, nine outcome constructors, and message strings supplied by the caller so localization
+stays in the application.
+
+Most of that is transcription. Two things in it are decisions, and one of them is
+security-relevant — which under the enterprise posture (`AGENTS.md` §7/§10) is what earns this
+ADR, since the roadmap item did not schedule one.
+
+## Decision
+
+**One envelope, one fixed shape, and `caught()` takes a correlation reference rather than a
+`Throwable`.**
+
+- **The shape is fixed**: all four keys are serialized on every outcome, including `data: null`
+  and `messages: []`. A client may read `payload.data` without first checking the key exists —
+  which is the entire value of an envelope, and is lost the moment nulls are omitted to save
+  bytes. Asserted per outcome, and `messages` is pinned to encode as `[]` rather than `{}`.
+- **The outcome vocabulary is an enum** (`Outcome`), each case owning **its HTTP status**, so the
+  mapping the estate had three times exists once. ADR-0015's reasoning: a closed vocabulary that
+  reaches a consumer-visible payload should be settled by the type system.
+- **`caught(string $reference)` does not accept a `Throwable`.** An envelope built from an
+  exception would put `getMessage()` on the wire by default, and a message names schemas, file
+  paths and query fragments as readily as a stack trace does — which is precisely why ADR-0029
+  has production withhold *both*. The client receives a reference; the exception belongs in the
+  log under that same reference, where `Errors\ExceptionHandler` already puts it. Asserted as a
+  **mechanism** on the method's signature, because behaviour cannot see an overload that does not
+  exist: a future `caught(Throwable $e)` would pass every other test in the suite.
+- **Two status choices, stated rather than assumed.** `Invalid` is **422**, not 400 — the request
+  was well-formed and understood, and a client can then tell a malformed request from a rejected
+  one without reading the body. `Empty` is **200**, not 404 — a search with no results is a
+  successful search, and the estate's habit of 404-ing an empty collection is what teaches
+  clients to treat "no rows" as a retryable failure.
+- **The `Result` → envelope mapping is deliberately not here.** `Errors\Result` is in another
+  group and RFC-0001's layering rule forbids `Http` importing it. The three-line adapter belongs
+  in the application, and the pattern doc shows where. This is the same call ADR-0050 made for
+  the router's status codes: the library supplies the vocabulary, the application supplies the
+  policy.
+- **The envelope is a payload, not a response.** It carries the status its outcome implies via
+  `status()`; sending it is `Response`'s job. The constructor is private, so every instance comes
+  from a named outcome rather than an arbitrary combination.
+
+## Alternatives Considered
+
+- **`caught(Throwable $e)`, formatting the message internally with an env check.** The obvious
+  API, and the one the estate used. Rejected: the env-gated variant duplicates a decision
+  `ExceptionHandler` already owns (ADR-0029), and it makes the safe behaviour conditional on
+  configuration being right in production. A signature that cannot receive the exception cannot
+  leak it.
+- **Omitting `null` fields from the JSON** (the `array_filter` reflex). Rejected: it makes the
+  shape depend on the data, which is the problem the envelope exists to solve. The bytes saved
+  are noise next to a client having to guard every access.
+- **`status` as a boolean `success` flag plus a separate error code.** Rejected: it collapses
+  nine distinct answers into two, and the caller then re-derives which of them happened from the
+  HTTP code — putting the taxonomy back in the client, where it was in the estate.
+- **`code` as an application-specific error code** rather than the HTTP status. Rejected for this
+  library: an application code space is the application's to define, and duplicating the HTTP
+  status is more useful to a client that has already got the status from the response line — it
+  makes the payload self-describing when logged or forwarded, which is where envelopes get read
+  in practice.
+- **A tenth `unauthorized`/`forbidden` outcome.** Not added: FR-39 fixes the taxonomy at nine,
+  and authentication outcomes belong to whatever authorization layer a consumer has — a library
+  that names them implies it knows what they mean. Adding one is a spec change, and the suite
+  asserts the count so it cannot happen quietly.
+- **Enum without the HTTP mapping**, leaving status choice to callers. Rejected as the default:
+  it is exactly the state the estate was in, with three implementations disagreeing. A caller
+  that needs a different status for one endpoint still sends one — the envelope does not send
+  itself.
+
+## Consequences
+
+**One shape across every application that adopts it**, and one place the outcome→status mapping
+lives. A client can be generated from the four keys.
+
+**The taxonomy is closed at nine**, and the suite asserts the count, so growing it is a
+deliberate spec change rather than an addition someone slips in. Both `match` expressions are
+exhaustive over `Outcome::cases()` — asserted by iterating the enum, because a missing arm is an
+`UnhandledMatchError` at run time rather than a compile error.
+
+**`caught()` is slightly less convenient than the version that takes the exception**, which is
+the point: the caller must obtain a reference from the logger first, which is the step that puts
+the diagnosis where it belongs. `ExceptionHandler` already produces exactly that reference.
+
+**No i18n surface.** The library writes one English string — the fallback message for a
+`caught()` with no wording — and every other message is the caller's. That one string is
+asserted, so a future addition to the library's vocabulary is visible in a diff.
+
+**Nothing in `Http` learned about `Errors`.** No new deptrac edge; the mapping the application
+wants is documented instead of imported.
+
+## References
+
+- Spec r3 **FR-39**; [RFC-0002](../rfc/0002-application-layer-groups-from-legacy-intake.md)
+- RFC 4918 §11.2 (`422 Unprocessable Content` — the well-formed-but-rejected distinction)
+- `src/main/php/d4np/utils/Http/{ApiEnvelope,Outcome}.php`
+- [ADR-0029](0029-result-carries-a-throwable-and-production-withholds-the-message-too.md) — the
+  message-withholding stance this applies at the payload boundary

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,3 +66,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0048](0048-prefix-internal-calls-by-rule-because-a-hot-loop-cannot-be-tuned-by-hand.md) | Prefix internal calls by rule, because a hot loop cannot be tuned by hand | Accepted |
 | [0049](0049-state-the-transport-policy-explicitly-and-bound-the-whole-request.md) | State the transport policy explicitly, and bound the whole request (amends 0004) | Accepted |
 | [0050](0050-classify-the-miss-and-keep-the-router-a-table.md) | Classify the miss, and keep the router a table | Accepted |
+| [0051](0051-one-envelope-shape-and-a-reference-instead-of-the-exception.md) | One envelope shape, and a reference instead of the exception | Accepted |

--- a/docs/journal/2026/08/2026-08-07-api-envelope.md
+++ b/docs/journal/2026/08/2026-08-07-api-envelope.md
@@ -1,0 +1,64 @@
+# 2026-08-07 — Three envelopes become one, and the exception stays home
+
+Roadmap item **11.3**, size S, `standard / medium` — **the first item this milestone whose route
+matches the session model**, so no mismatch to record.
+
+Mostly transcription: FR-39 fixes the shape (`status`, `code`, `messages`, `data`), the nine
+outcomes and the rule that message strings are the caller's. The estate had three implementations
+of this, 232+ construction sites, and no two agreeing on field names — so a client written against
+one could not read another.
+
+Two things in it were decisions rather than transcription.
+
+## `caught()` does not take a `Throwable`
+
+The obvious signature is `caught(Throwable $e)`, and the estate's envelope had it. It puts
+`$e->getMessage()` on the wire.
+
+ADR-0029 already settled that production withholds the **message as well as the trace**, because a
+message names schemas, file paths and query fragments as readily as a stack trace does. An
+envelope that accepts the exception either duplicates that decision — with an env check of its own,
+in a second place — or leaks by default when the configuration is wrong.
+
+So it takes a **correlation reference**: the client gets an id, the exception goes to the log under
+the same id, and `ExceptionHandler` already produces exactly that pairing. The signature cannot
+receive what it must not send.
+
+That is asserted as a **mechanism**, on the method's reflected parameters, because no behavioural
+test can see an overload that does not exist — a future `caught(Throwable $e)` would pass every
+other test in the file. Same reasoning as ADR-0027, and the third time this project has needed it.
+
+## Two status codes worth arguing about
+
+`Invalid` is **422**, not 400. The request was well-formed and understood; a client can then tell a
+malformed request from a rejected one without reading the body.
+
+`Empty` is **200**, not 404. A search with no results is a successful search. The estate 404-ed
+empty collections, which is how clients learn to treat "no rows" as a failure worth retrying.
+
+Neither is forced by the spec, so both are in the ADR with their reasons rather than sitting
+silently in a `match`.
+
+## The shape is the product
+
+Every key is serialized on every outcome, including `data: null` and `messages: []`. The test that
+matters most here is the dull one — `"data":null` present in the JSON — because the "tidy up the
+payload with `array_filter`" instinct is real, it is invisible in PHP, and it breaks every client
+that reads `payload.data` without a guard.
+
+`messages` is also pinned to encode as `[]` rather than `{}`: PHP's empty array is ambiguous until
+something asserts which one it becomes.
+
+## What stayed out
+
+`Result` → envelope. `Errors\Result` is in another group, RFC-0001's layering rule forbids `Http`
+importing it, and the adapter is three lines. It went in the endpoint-kernel pattern doc instead of
+the library — the same call ADR-0050 made for status codes: the library supplies the vocabulary,
+the application supplies the policy.
+
+## Lesson
+
+**A signature is a cheaper security control than a conditional.** `caught(Throwable)` with an
+env-gated message is one misconfiguration away from disclosure; `caught(string $reference)` is
+never one line away from it. When the safe behaviour can be made structural rather than
+conditional, the structural version does not need to be got right twice.

--- a/docs/patterns/endpoint-kernel.md
+++ b/docs/patterns/endpoint-kernel.md
@@ -85,11 +85,57 @@ test for whether something belongs here:
 | Autoloading | One path, not thirty-seven relative ones |
 | The 404 / 405 classification | The distinction is the router's; the *status codes* are the application's policy |
 | The `Allow` header on a 405 | Mandatory per RFC 9110; a per-endpoint copy is a per-endpoint omission |
-| Response encoding | One envelope shape for the whole surface (item 11.3's `ApiEnvelope`) |
+| Response encoding | One envelope shape for the whole surface — [`ApiEnvelope`](../../src/main/php/d4np/utils/Http/ApiEnvelope.php) ([ADR-0051](../adr/0051-one-envelope-shape-and-a-reference-instead-of-the-exception.md)) |
 | The error boundary | `Errors\ExceptionHandler` decides what a production build reveals (ADR-0029) |
 
 And what does **not** belong: anything specific to one endpoint. If a `catch` in the kernel
 names a domain exception, that exception is being handled in the wrong place.
+
+## Mapping a `Result` to an envelope — the three lines that stay in your application
+
+`Errors\Result` and `Http\ApiEnvelope` are in different groups, and RFC-0001's layering rule
+forbids `Http` importing `Errors` ([ADR-0051](../adr/0051-one-envelope-shape-and-a-reference-instead-of-the-exception.md)).
+That is not an omission to work around — the mapping is *policy*, and only the application knows
+which failure deserves which outcome. It belongs here:
+
+```php
+<?php // src/Http/EnvelopeMapper.php — yours, not the library's
+
+use D4np\Utils\Errors\Result;
+use D4np\Utils\Http\ApiEnvelope;
+
+final class EnvelopeMapper
+{
+    public function __construct(private readonly LoggerInterface $log) {}
+
+    /** @param Result<mixed> $result */
+    public function map(Result $result): ApiEnvelope
+    {
+        if ($result->isSuccess()) {
+            // Cannot throw on this branch — `Result` has no unguarded value reader, and
+            // `orElseThrow()` is how you say "I have already checked".
+            return ApiEnvelope::ok($result->orElseThrow());
+        }
+
+        $failure = $result->error();
+
+        // Anticipated refusals become `failed`/`invalid` with wording your locale owns …
+        if ($failure instanceof DomainRefusal) {
+            return ApiEnvelope::failed($this->translate($failure));
+        }
+
+        // … and anything else is a defect: log it, and hand the client the reference only.
+        $reference = \bin2hex(\random_bytes(8));
+        $this->log->error('unhandled failure', ['reference' => $reference, 'exception' => $failure]);
+
+        return ApiEnvelope::caught($reference);
+    }
+}
+```
+
+The last branch is why `ApiEnvelope::caught()` takes a **reference and not the throwable**: the
+exception reaches the log, the client reaches a support ticket, and no schema name or file path
+travels over HTTP (ADR-0029's stance at the payload boundary).
 
 ## Notes worth carrying
 

--- a/src/main/php/d4np/utils/Http/ApiEnvelope.php
+++ b/src/main/php/d4np/utils/Http/ApiEnvelope.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+use JsonSerializable;
+
+/**
+ * One JSON shape for every answer an API gives (spec r3 FR-39, RFC-0002; ADR-0051).
+ *
+ * The surveyed estate carried **three** envelope implementations — one per application, plus a
+ * vendored copy — with 232+ construction sites between them and no two agreeing on their field
+ * names. A client written against one could not read another. This is that envelope, once:
+ *
+ * ```json
+ * {"status": "invalid", "code": 422, "messages": ["email is required"], "data": null}
+ * ```
+ *
+ * **The shape is fixed**: all four keys are present on every response, including when `data` is
+ * `null` and `messages` is empty. A client can therefore read `payload.data` without first
+ * checking that the key exists — which is the entire value of having an envelope, and is lost
+ * the moment nulls start being omitted to save bytes.
+ *
+ * **Message strings are the caller's.** The library supplies no wording and no catalogue:
+ * localization belongs to the application, which is the only place that knows the request's
+ * locale. `Outcome` carries the machine-readable half, so a client never needs to parse prose.
+ *
+ * **Mapping a `Result` to an envelope is deliberately not here.** `Errors\Result` lives in
+ * another group and RFC-0001's layering rule forbids `Http` importing it; the three-line
+ * adapter belongs in the application, and
+ * [`docs/patterns/endpoint-kernel.md`](../../../../../../docs/patterns/endpoint-kernel.md)
+ * shows where it goes.
+ *
+ * This is a **payload, not a response**: it carries the status code its outcome implies, and
+ * sending it is {@see Response}'s job.
+ */
+final class ApiEnvelope implements JsonSerializable
+{
+    /**
+     * @param list<string> $messages human-readable, caller-supplied, possibly empty
+     * @param mixed        $data     the payload, or `null` — the key is present either way
+     */
+    private function __construct(
+        public readonly Outcome $outcome,
+        public readonly array $messages,
+        public readonly mixed $data,
+    ) {
+    }
+
+    /**
+     * A read that succeeded.
+     */
+    public static function ok(mixed $data = null, string ...$messages): self
+    {
+        return new self(Outcome::Ok, \array_values($messages), $data);
+    }
+
+    public static function created(mixed $data = null, string ...$messages): self
+    {
+        return new self(Outcome::Created, \array_values($messages), $data);
+    }
+
+    public static function updated(mixed $data = null, string ...$messages): self
+    {
+        return new self(Outcome::Updated, \array_values($messages), $data);
+    }
+
+    public static function deleted(mixed $data = null, string ...$messages): self
+    {
+        return new self(Outcome::Deleted, \array_values($messages), $data);
+    }
+
+    /**
+     * A valid request that matched nothing.
+     *
+     * `data` defaults to an empty **array** rather than `null`: the caller asked for a
+     * collection and got a collection, and a client iterating the result should not have to
+     * special-case the empty case into a type change.
+     */
+    public static function empty(mixed $data = [], string ...$messages): self
+    {
+        return new self(Outcome::Empty, \array_values($messages), $data);
+    }
+
+    /**
+     * Input that did not validate. The messages are what was wrong with it.
+     *
+     * @param list<string> $messages
+     */
+    public static function invalid(array $messages, mixed $data = null): self
+    {
+        return new self(Outcome::Invalid, \array_values($messages), $data);
+    }
+
+    public static function notFound(string ...$messages): self
+    {
+        return new self(Outcome::NotFound, \array_values($messages), null);
+    }
+
+    /**
+     * An operation the code anticipated could fail, and did.
+     */
+    public static function failed(string ...$messages): self
+    {
+        return new self(Outcome::Failed, \array_values($messages), null);
+    }
+
+    /**
+     * An unhandled throwable reached the boundary.
+     *
+     * **This takes a reference, not a `Throwable`, and that is the security decision here**
+     * (ADR-0051, applying ADR-0029's stance). An envelope built from an exception would put
+     * `$e->getMessage()` on the wire by default, and a message names schemas, file paths and
+     * query fragments as readily as a stack trace does. The correlation reference is what the
+     * client gets; the exception itself belongs in the log, where
+     * {@see \D4np\Utils\Errors\ExceptionHandler} already puts it under the same reference.
+     *
+     * @param string $reference the correlation id that also appears in the log record
+     */
+    public static function caught(string $reference, string ...$messages): self
+    {
+        return new self(
+            Outcome::Caught,
+            $messages === [] ? ['An unexpected error occurred.'] : \array_values($messages),
+            ['reference' => $reference],
+        );
+    }
+
+    /**
+     * The HTTP status this envelope's outcome implies.
+     */
+    public function status(): int
+    {
+        return $this->outcome->httpStatus();
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->outcome->isSuccessful();
+    }
+
+    /**
+     * The fixed shape — every key, every time.
+     *
+     * @return array{status: string, code: int, messages: list<string>, data: mixed}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'status' => $this->outcome->value,
+            'code' => $this->outcome->httpStatus(),
+            'messages' => $this->messages,
+            'data' => $this->data,
+        ];
+    }
+}

--- a/src/main/php/d4np/utils/Http/Outcome.php
+++ b/src/main/php/d4np/utils/Http/Outcome.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Http;
+
+/**
+ * What happened, as a closed set (spec r3 FR-39, RFC-0002; ADR-0051).
+ *
+ * The surveyed estate expressed the same nine answers three different ways, once per envelope
+ * implementation, each with its own spelling and its own idea of which HTTP status went with
+ * which outcome. An enum is the fix for the same reason {@see SameSite} and
+ * {@see \D4np\Utils\Database\Sort} are one (ADR-0015): a closed vocabulary that reaches a
+ * consumer-visible payload should be decided by the type system, not validated at run time.
+ *
+ * **Each case owns its HTTP status**, so the mapping exists once. A caller that disagrees for a
+ * given endpoint sends a different status itself — {@see ApiEnvelope} is a payload, not a
+ * response — but it will not disagree by accident.
+ */
+enum Outcome: string
+{
+    /** A read succeeded and carries data. */
+    case Ok = 'ok';
+
+    /** A resource was created. */
+    case Created = 'created';
+
+    /** An existing resource was modified. */
+    case Updated = 'updated';
+
+    /** A resource was removed. */
+    case Deleted = 'deleted';
+
+    /**
+     * The request was valid and matched nothing — an empty list, not an error.
+     *
+     * `200` rather than `404`, deliberately: a search with no results is a successful search,
+     * and the estate's habit of returning `404` for an empty collection is what makes clients
+     * treat "no rows" as a failure to retry.
+     */
+    case Empty = 'empty';
+
+    /** The input did not validate. The messages say what was wrong with it. */
+    case Invalid = 'invalid';
+
+    /** The addressed resource does not exist. */
+    case NotFound = 'notFound';
+
+    /** The operation was understood and did not succeed. */
+    case Failed = 'failed';
+
+    /**
+     * An unhandled throwable reached the boundary.
+     *
+     * Distinct from {@see self::Failed} because the two mean different things to whoever is
+     * on call: a `failed` is a refusal the code anticipated, a `caught` is a defect.
+     */
+    case Caught = 'caught';
+
+    /**
+     * The HTTP status this outcome is sent with.
+     *
+     * `422` for invalid input rather than `400`: the request itself was well-formed and
+     * understood, which is exactly the distinction RFC 4918 §11.2 draws, and it lets a client
+     * tell a malformed request from a rejected one without reading the body.
+     */
+    public function httpStatus(): int
+    {
+        return match ($this) {
+            self::Ok, self::Empty => 200,
+            self::Created => 201,
+            self::Updated, self::Deleted => 200,
+            self::Invalid => 422,
+            self::NotFound => 404,
+            self::Failed => 409,
+            self::Caught => 500,
+        };
+    }
+
+    /**
+     * Whether this outcome represents the operation having done what was asked.
+     */
+    public function isSuccessful(): bool
+    {
+        return match ($this) {
+            self::Ok, self::Created, self::Updated, self::Deleted, self::Empty => true,
+            self::Invalid, self::NotFound, self::Failed, self::Caught => false,
+        };
+    }
+}

--- a/src/test/php/d4np/utils/Http/ApiEnvelopeTest.php
+++ b/src/test/php/d4np/utils/Http/ApiEnvelopeTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Http;
+
+use D4np\Utils\Http\ApiEnvelope;
+use D4np\Utils\Http\Outcome;
+use D4np\Utils\Support\Json;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * `ApiEnvelope` — spec r3 **FR-39** (RFC-0002), ADR-0051.
+ *
+ * The envelope's value is that a client can rely on its shape, so the shape is what these tests
+ * pin: every key present on every outcome, `data` never dropped for being `null`, and the
+ * outcome→status mapping asserted case by case rather than trusted to a `match` nobody reads.
+ */
+final class ApiEnvelopeTest extends TestCase
+{
+    /**
+     * The whole point of an envelope: four keys, always, whatever happened.
+     */
+    #[DataProvider('everyOutcome')]
+    public function testTheShapeIsTheSameForEveryOutcome(ApiEnvelope $envelope): void
+    {
+        $serialized = $envelope->jsonSerialize();
+
+        self::assertSame(['status', 'code', 'messages', 'data'], \array_keys($serialized));
+        self::assertIsString($serialized['status']);
+        self::assertIsInt($serialized['code']);
+        self::assertIsArray($serialized['messages']);
+    }
+
+    /**
+     * @return iterable<string, array{ApiEnvelope}>
+     */
+    public static function everyOutcome(): iterable
+    {
+        yield 'ok' => [ApiEnvelope::ok(['id' => 1])];
+        yield 'ok with no data' => [ApiEnvelope::ok()];
+        yield 'created' => [ApiEnvelope::created(['id' => 1])];
+        yield 'updated' => [ApiEnvelope::updated(['id' => 1])];
+        yield 'deleted' => [ApiEnvelope::deleted()];
+        yield 'empty' => [ApiEnvelope::empty()];
+        yield 'invalid' => [ApiEnvelope::invalid(['email is required'])];
+        yield 'not found' => [ApiEnvelope::notFound('no such order')];
+        yield 'failed' => [ApiEnvelope::failed('the warehouse refused it')];
+        yield 'caught' => [ApiEnvelope::caught('ref-123')];
+    }
+
+    /**
+     * `null` data must survive serialization as an explicit `null`, not vanish.
+     *
+     * This is the assertion that stops someone "tidying up" the payload with a filter: the key
+     * disappearing is invisible in PHP and breaks every client that reads `payload.data`
+     * without a guard.
+     */
+    public function testNullDataStaysInTheJsonAsNull(): void
+    {
+        $json = Json::encode(ApiEnvelope::notFound('no such order'));
+
+        self::assertStringContainsString('"data":null', $json);
+        self::assertSame(
+            ['status' => 'notFound', 'code' => 404, 'messages' => ['no such order'], 'data' => null],
+            Json::decode($json),
+        );
+    }
+
+    public function testAnEmptyMessageListIsStillAList(): void
+    {
+        // [] must encode as `[]`, not `{}` — a client typed against an array of strings breaks
+        // on an object, and PHP's empty array is ambiguous until something pins it.
+        self::assertStringContainsString('"messages":[]', Json::encode(ApiEnvelope::ok()));
+    }
+
+    // ---- the outcome → status mapping, case by case ------------------------------------------
+
+    #[DataProvider('statuses')]
+    public function testEachOutcomeCarriesItsHttpStatus(Outcome $outcome, int $expected, bool $successful): void
+    {
+        self::assertSame($expected, $outcome->httpStatus());
+        self::assertSame($successful, $outcome->isSuccessful());
+    }
+
+    /**
+     * @return iterable<string, array{Outcome, int, bool}>
+     */
+    public static function statuses(): iterable
+    {
+        yield 'ok' => [Outcome::Ok, 200, true];
+        yield 'created' => [Outcome::Created, 201, true];
+        yield 'updated' => [Outcome::Updated, 200, true];
+        yield 'deleted' => [Outcome::Deleted, 200, true];
+        yield 'empty is a successful search, not a 404' => [Outcome::Empty, 200, true];
+        yield 'invalid is 422, not 400' => [Outcome::Invalid, 422, false];
+        yield 'not found' => [Outcome::NotFound, 404, false];
+        yield 'failed' => [Outcome::Failed, 409, false];
+        yield 'caught' => [Outcome::Caught, 500, false];
+    }
+
+    public function testTheEnvelopeReportsTheStatusOfItsOutcome(): void
+    {
+        self::assertSame(201, ApiEnvelope::created()->status());
+        self::assertTrue(ApiEnvelope::created()->isSuccessful());
+        self::assertSame(422, ApiEnvelope::invalid(['bad'])->status());
+        self::assertFalse(ApiEnvelope::invalid(['bad'])->isSuccessful());
+    }
+
+    /**
+     * Every case must appear in both `match` expressions, or PHP throws `UnhandledMatchError`
+     * at run time for the one that was forgotten. Iterating the enum is what makes adding a
+     * tenth outcome fail here rather than in production.
+     */
+    public function testEveryEnumCaseIsMappedByBothMatches(): void
+    {
+        // Calling each accessor for every case is the assertion: a case missing from either
+        // `match` raises `UnhandledMatchError` here. What is *asserted* is the partition, not the
+        // return type — `assertIsBool()` on a `bool` return is a tautology PHPStan can decide
+        // (and did), while the 5/4 split is a fact about the taxonomy that a wrong edit changes.
+        $successful = \array_filter(Outcome::cases(), static fn (Outcome $c): bool => $c->isSuccessful());
+        $failing = \array_filter(Outcome::cases(), static fn (Outcome $c): bool => !$c->isSuccessful());
+
+        self::assertCount(5, $successful, 'ok, created, updated, deleted, empty');
+        self::assertCount(4, $failing, 'invalid, notFound, failed, caught');
+
+        foreach (Outcome::cases() as $case) {
+            self::assertGreaterThanOrEqual(200, $case->httpStatus());
+        }
+
+        self::assertCount(9, Outcome::cases(), 'the taxonomy is FR-39\'s, and adding to it is a spec change');
+    }
+
+    // ---- what the envelope must not do -------------------------------------------------------
+
+    /**
+     * ADR-0051's security decision, asserted as a **mechanism**: `caught()` must not be able to
+     * accept a `Throwable`, because an envelope built from one would put `getMessage()` on the
+     * wire — and a message names schemas and paths as readily as a trace does (ADR-0029).
+     *
+     * Asserted on the signature rather than on behaviour, because behaviour cannot see an
+     * overload that does not exist: a future `caught(Throwable $e)` would pass every other test
+     * in this file.
+     */
+    public function testCaughtCannotBeHandedAThrowable(): void
+    {
+        $parameters = (new ReflectionMethod(ApiEnvelope::class, 'caught'))->getParameters();
+
+        self::assertSame('reference', $parameters[0]->getName());
+        self::assertSame('string', (string) $parameters[0]->getType());
+
+        foreach ($parameters as $parameter) {
+            $type = (string) $parameter->getType();
+            self::assertStringNotContainsString('Throwable', $type);
+            self::assertStringNotContainsString('Exception', $type);
+        }
+    }
+
+    public function testCaughtCarriesTheReferenceAndAGenericMessage(): void
+    {
+        $envelope = ApiEnvelope::caught('ref-abc');
+
+        self::assertSame(['reference' => 'ref-abc'], $envelope->data);
+        self::assertSame(['An unexpected error occurred.'], $envelope->messages);
+        self::assertSame(500, $envelope->status());
+    }
+
+    public function testCaughtLetsTheCallerReplaceTheWording(): void
+    {
+        // The library supplies no catalogue; a localized application overrides the default.
+        self::assertSame(['Errore imprevisto.'], ApiEnvelope::caught('ref', 'Errore imprevisto.')->messages);
+    }
+
+    /**
+     * The envelope is a value: no setters, and the constructor is private so every instance
+     * comes from a named outcome rather than an arbitrary combination.
+     */
+    public function testItIsAValueWithNoOtherWayIn(): void
+    {
+        $reflected = new ReflectionClass(ApiEnvelope::class);
+
+        self::assertTrue($reflected->getConstructor()?->isPrivate());
+        self::assertTrue($reflected->isFinal());
+
+        foreach ($reflected->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            self::assertStringStartsNotWith('set', $method->getName());
+        }
+    }
+
+    public function testTheLibrarySuppliesNoWordingOfItsOwnExceptForTheCaughtFallback(): void
+    {
+        // Localization is the application's (FR-39). The only string this library writes is the
+        // one a caught() with no message would otherwise leave empty, and it says nothing about
+        // the failure.
+        self::assertSame([], ApiEnvelope::ok()->messages);
+        self::assertSame([], ApiEnvelope::deleted()->messages);
+        self::assertSame([], ApiEnvelope::notFound()->messages);
+        self::assertSame(['An unexpected error occurred.'], ApiEnvelope::caught('r')->messages);
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item **11.3**. The surveyed estate carried **three** response-envelope implementations —
one per application plus a vendored copy — with **232+ construction sites** and no two agreeing on
their field names, so a client written against one could not read another. This is that envelope,
once:

```json
{"status": "invalid", "code": 422, "messages": ["email is required"], "data": null}
```

**Route matched the session model for the first time this milestone** — no mismatch to record.

## The security decision, and the ADR the item did not schedule

`caught()` takes a **correlation reference, not a `Throwable`.** The obvious signature is
`caught(Throwable $e)` — the estate had it — and it puts `getMessage()` on the wire.

ADR-0029 already settled that production withholds the **message as well as the trace**, because a
message names schemas, file paths and query fragments as readily as a stack trace does. An
envelope that accepts the exception either duplicates that decision in a second place, or leaks by
default when the configuration is wrong. Here the client gets an id and the exception goes to the
log under the same id — the pairing `ExceptionHandler` already produces.

Asserted as a **mechanism on the reflected signature**, because no behavioural test can see an
overload that does not exist: a future `caught(Throwable $e)` would pass every other test in the
file.

The roadmap item scheduled no ADR. A security-relevant decision requires one under the enterprise
posture (AGENTS.md §7/§10), so **ADR-0051** exists and says why.

## Two status choices argued rather than assumed

| Outcome | Status | Why not the obvious one |
|---|---|---|
| `invalid` | **422** | The request was well-formed and *understood* — a client can then tell a malformed request from a rejected one without reading the body (RFC 4918 §11.2) |
| `empty` | **200** | A search with no results is a successful search. The estate 404-ed empty collections, which is how clients learn to treat "no rows" as retryable |

## The shape is the product

All four keys on every outcome. **`data: null` is serialized, not omitted** — the "tidy the payload
with `array_filter`" instinct is real, invisible in PHP, and breaks every client that reads
`payload.data` without a guard. `messages` is pinned to encode as `[]` rather than `{}`, since
PHP's empty array is ambiguous until something asserts which it becomes.

The nine outcomes are an **enum**, each case owning its HTTP status, so the mapping the estate had
three times exists once (ADR-0015's reasoning). The taxonomy is closed at nine and the suite
asserts the count, so growing it is a spec change rather than an addition someone slips in.

## What stayed out

`Result` → envelope. `Errors\Result` is in another group and the layering rule forbids `Http`
importing it; the adapter is *policy*, and only the application knows which failure deserves which
outcome. It went into [`endpoint-kernel.md`](docs/patterns/endpoint-kernel.md) instead — where
writing it out **exposed that my first draft called two `Result` methods that do not exist**
(`value()`, `failure()`). Fixed against the real API: a doc with a non-compiling example is worse
than no example, because someone copies it.

## Verification

- [x] Full suite green — **2525 tests, 5467 assertions** (+28), 9 pre-existing local skips
- [x] PHPStan max clean · PHP-CS-Fixer clean · deptrac **0 violations / 0 uncovered / 296 allowed**
      (no new edge — the `Errors` mapping stayed out)
- [x] `consistency_lint` OK · leak-gate clean
- [x] **5 planted defects, 5 caught**: null data filtered out of the JSON, `invalid` → 400,
      `empty` → 404, `empty` counted as unsuccessful, and `caught()` echoing its messages into
      `data`. Each plant verified by **absence of the original** — item 11.2's lesson, and this
      time the guard worked on the first pass.

**PHPStan caught a third tautological assertion of mine this session** (`assertIsBool()` on a
`bool` return). Reformulated as the real property: the 5/4 successful-versus-failing partition
over `Outcome::cases()`, which also proves both `match` expressions are exhaustive — a missing arm
raises `UnhandledMatchError` when the test calls it.

## Documentation Impact

- [x] **ADR-0051** + index row
- [x] `docs/patterns/endpoint-kernel.md` — the `Result`→envelope adapter, and the response-encoding
      row now points at the real class
- [x] ROADMAP — 11.3 checked with its findings; journal pointer
- [x] Journal — `2026-08-07-api-envelope.md`
- [x] CHANGELOG — `Added`
- [ ] Spec — **unchanged**: FR-39 is implemented as written
- [ ] README — M11 stays `⏳ planned`; 11.4 and 11.5 remain
- [x] PR metadata — assignee, label, milestone `v0.10.0`

## Lesson

Lesson: **a signature is a cheaper security control than a conditional.** `caught(Throwable)` with
an env-gated message is one misconfiguration away from disclosure; `caught(string $reference)` is
never one line away from it. When the safe behaviour can be made structural rather than
conditional, the structural version does not have to be got right twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
