### PR TITLE
perf(http): NFR-11 benchmarks -- router dispatch and envelope construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
         if: steps.cfg.outputs.present == 'true'
         shell: bash
         run: |
-          python3 tools/bench_budget_gate.py build/logs/head.xml             --budget benchHydrateWarm=5             --budget benchBuildFiveConditionSelect=10             --budget benchWarmSingletonResolve=2             --budget benchFirstAutowiredResolve=30             --budget benchSequenceNext=200             --budget benchWriteTenThousandByTen=150000
+          python3 tools/bench_budget_gate.py build/logs/head.xml             --budget benchHydrateWarm=5             --budget benchBuildFiveConditionSelect=10             --budget benchWarmSingletonResolve=2             --budget benchFirstAutowiredResolve=30             --budget benchSequenceNext=200             --budget benchWriteTenThousandByTen=150000             --budget benchDispatchLastOfFiftyRoutes=5             --budget benchEnvelopeBuild=2
       - name: NFR-01 ratio — hydration vs manual construction
         if: steps.cfg.outputs.present == 'true'
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,7 +64,9 @@ jobs:
             --budget benchWarmSingletonResolve=2 \
             --budget benchFirstAutowiredResolve=30 \
             --budget benchSequenceNext=200 \
-            --budget benchWriteTenThousandByTen=150000
+            --budget benchWriteTenThousandByTen=150000 \
+            --budget benchDispatchLastOfFiftyRoutes=5 \
+            --budget benchEnvelopeBuild=2
 
       - name: NFR-01 ratio — hydration vs manual construction
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **phpbench benchmarks for NFR-11** (spec §4, RFC-0002; roadmap item **11.5**): `HttpBench`
+  under `src/bench/php/d4np/utils/`, wired into `bench_budget_gate.py` in both `ci.yml` and
+  `nightly.yml`. Two decisions, both **ADR-0053**: `Router` dispatch is measured against the
+  *last* of 50 registered routes — the worst case its uncached, unindexed linear scan produces
+  (ADR-0050) — with the first-of-50 best case kept visible, unbudgeted; `ApiEnvelope` construction
+  is measured through `ok()` alone, never `jsonSerialize()`, since NFR-11 budgets building the
+  object, not the serialization `Response` performs later. **CI's measured envelope figure is
+  0.366–0.395 µs against the ≤ 2 µs budget — met, with headroom.** **CI's measured router figure
+  is 6.874–7.145 µs against the ≤ 5 µs budget — not met, profiled honestly rather than massaged**:
+  the gap traces to the 49 failed pattern attempts a worst-case dispatch pays in a router with no
+  index, a cost ADR-0050 assumed away without a number behind it. Filed as roadmap item **11.7**
+  rather than decided unilaterally (raising the budget or adding an index are both out of this
+  item's `fast/medium` route, and ADR-0040 reserves spec numbers for the maintainer). Milestone
+  11 stays open on this and item 11.6 until both resolve.
+
 - **`D4np\Utils\Http\ApiEnvelope` + `Http\Outcome`** — one JSON shape for every answer an API
   gives (spec r3 FR-39, RFC-0002; roadmap item **11.3**; **ADR-0051**). `{"status", "code",
   "messages", "data"}`, **all four keys on every outcome** — `data: null` is serialized as `null`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-07 — The first real origin, and what it said about the client](docs/journal/2026/08/2026-08-07-t07-live-origin.md).
+  [2026-08-07 — Two subjects, one honest miss](docs/journal/2026/08/2026-08-07-nfr11-benchmarks.md).
 
 ## Model & effort routing (advisory)
 
@@ -1204,8 +1204,33 @@ The console-side trio: client, router, envelope (RFC-0002 FR-37…FR-39).
       retried away: closing a socket that still holds unread inbound bytes resets the connection
       and destroys the response, so the origin now drains the request before answering (6/6 green
       after, 3/5 before).*
-- [ ] 11.5 phpbench: NFR-11 (router dispatch at 50 routes; envelope build) (RFC-0002)
-      (step:optimize) — size: XS · route: fast / medium
+- [x] 11.5 phpbench: NFR-11 (router dispatch at 50 routes; envelope build) (RFC-0002)
+      (step:optimize) — size: XS · route: fast / medium · **ADR-0053**. *`HttpBench.php`
+      (`ContainerBench`'s/`QueryBuilderBench`'s shape) measures both halves. **Which route to
+      dispatch was the scoping question** (`Router` has no cache and no index, ADR-0050's stated
+      non-goal, so dispatch is a linear scan with a real best/worst case): the **last** of 50
+      registered routes is the worst case that scan produces, and is the budgeted subject; the
+      **first** is kept alongside it, unbudgeted, so the best case is not silently dropped. The
+      same question on the envelope side: `ok()` construction alone is budgeted, never
+      `jsonSerialize()` — NFR-11 budgets building the object, not the serialization
+      `Response` performs later — with the multi-message `invalid()` path kept visible,
+      unbudgeted, beside it.
+      **NFR-11 CI measurement (reference: `ubuntu-24.04`, this PR's own run — not spec NFR-06's
+      named machine): envelope half MET comfortably** — `benchEnvelopeBuild` **0.366–0.395 µs**
+      (mean 0.381) against ≤ 2 µs, more than 5× headroom; `benchEnvelopeBuildWithMessages`
+      **0.354–0.368 µs**, no measurable cost for the extra messages.
+      **Router half NOT met: `benchDispatchLastOfFiftyRoutes` measured 6.874–7.145 µs
+      (mean 6.984) against the ≤ 5 µs budget — about 40% over.** `benchDispatchFirstOfFiftyRoutes`
+      measured **0.901–0.929 µs**, confirming the gap is the scan itself and not fixed per-call
+      overhead: dispatching the 50th route costs roughly 7.6× dispatching the 1st, in line with
+      49 extra failed `preg_match()` attempts. Shipped **as measured, not tuned to pass** — the
+      spec's own gate, `bench_budget_gate.py --budget benchDispatchLastOfFiftyRoutes=5`, is wired
+      into CI red-and-honest, following items 3.5/3.7's and 10.6/10.10's precedent rather than
+      softening the gate or narrowing the workload until it clears. The gap is filed as item
+      **11.7**, not decided here — the budget is a spec number and ADR-0040 reserves those for
+      the maintainer. **Milestone 11 stays open on two decision items (11.6, 11.7); README's row
+      stays "planned" until both resolve** — `consistency_lint`'s `milestones` check enforces
+      exactly this (a milestone marked done in README needs every ROADMAP item checked).*
 - [ ] 11.6 Decide what NFR-10's **absolute** budget should be, now that the subject it guards
       has crossed it on unmodified code. Filed from item 11.4's CI, whose `src/main` diff is a
       single file in the `Http` group — `benchSequenceNext` exercises `Support\FileSequence` and
@@ -1226,6 +1251,25 @@ The console-side trio: client, router, envelope (RFC-0002 FR-37…FR-39).
       unenforced), or keep it and accept a job that fails a few runs in twenty. **A gate that
       fails on unchanged code teaches people to re-run it**, which is the failure mode worth
       pricing here — size: S · route: frontier-reasoning / extra (adr, decision-heavy)
+- [ ] 11.7 Decide what to do about NFR-11's **router dispatch** budget, measured **not met** on
+      unmodified `Router` code. Filed from item 11.5's own CI run
+      ([ADR-0053](docs/adr/0053-benchmark-the-last-route-and-construction-not-serialization.md)):
+      `benchDispatchLastOfFiftyRoutes` measured **6.874–7.145 µs (mean 6.984)** on
+      `ubuntu-24.04` against the ≤ 5 µs ceiling — roughly 40% over, and (unlike item 11.6's
+      subject) with no history of noisy runs to suggest measurement error; the first-of-50 figure
+      (**0.901–0.929 µs**) confirms the cost scales with the 49 failed `preg_match()` attempts a
+      worst-case dispatch pays, which is exactly the shape a linear, uncached scan produces
+      (ADR-0050's stated non-goal — no index, no cache). Unlike 11.6, this is not a noisy-runner
+      question; it is a real cost with a known cause. Options, none taken unilaterally
+      ([ADR-0040](docs/adr/0040-run-infection-outside-the-dependency-graph-and-hold-the-floor-at-the-specs-70.md)
+      reserves spec numbers for the maintainer): **(a)** raise NFR-11's router budget to a value
+      the current linear scan clears (the measured number, with headroom, e.g. ≤ 10 µs); **(b)**
+      add a cache or an index to `Router` — reversing ADR-0050's stated non-goal, which named "a
+      50-route table matches in microseconds" as the reason no cache was needed, a claim this
+      measurement corrects; **(c)** accept the gap and ship the benchmark job red until (a) or
+      (b) is chosen, per items 3.5/3.7's precedent (measure honestly, file the gap, do not tune
+      the benchmark to pass) — size: S · route: standard / medium (a benchmark-methodology
+      decision with a known, bounded cause, unlike 11.6's open-ended noise question)
 
 ---
 

--- a/docs/adr/0053-benchmark-the-last-route-and-construction-not-serialization.md
+++ b/docs/adr/0053-benchmark-the-last-route-and-construction-not-serialization.md
@@ -1,0 +1,78 @@
+# ADR-0053: Benchmark the last route, and construction, not serialization
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Deciders:** tech-lead (agent-drafted), maintainer (merge)
+- **Related:** ROADMAP item **11.5** (step:optimize) · spec **NFR-11** ·
+  [ADR-0011](0011-benchmark-scope-and-the-measured-hydration-ratio.md),
+  [ADR-0018](0018-querybuilder-benchmark-scope-and-the-measured-build-time-gap.md) (the same
+  workload-scoping question, asked twice before) · [ADR-0050](0050-classify-the-miss-and-keep-the-router-a-table.md)
+  (`Router`), [ADR-0051](0051-one-envelope-shape-and-a-reference-instead-of-the-exception.md)
+  (`ApiEnvelope`)
+
+## Context
+
+NFR-11 sets two ceilings: `Router` dispatch against a 50-route table at ≤ 5 µs, and
+`ApiEnvelope` construction at ≤ 2 µs. Writing `HttpBench.php` (`ContainerBench`'s and
+`QueryBuilderBench`'s shape — a `phpbench` class under `src/bench/`, wired into
+`bench_budget_gate.py`'s absolute-ceiling CI step) meant deciding exactly what each subject
+measures, and two questions had wrong-by-default answers, the same way item 4.5's did (ADR-0018:
+a query builder subject that quietly measured three times NFR-03's named workload).
+
+**Which route, in a 50-route table?** `Router` has no cache and no index (ADR-0050's stated
+non-goal) — dispatch is a linear scan over compiled patterns, trying each until one matches.
+That shape has a best case and a worst case that differ by construction: the first route
+registered matches on the first `preg_match()`, the last route matches only after 49 failed
+attempts. A benchmark that dispatched the first route would report the cost of *one* pattern
+check, not of the table NFR-11 names.
+
+**Which envelope operation?** `ApiEnvelope::jsonSerialize()` exists and is cheap to call in the
+same benchmark as `ok()`. But NFR-11 budgets *construction* — the object a handler builds before
+a response is sent — and serialization is `Response`'s job, later and unbudgeted. Measuring
+through `jsonSerialize()` would report both costs as one, and a change to either would look like
+a change to both.
+
+## Decision
+
+**`benchDispatchLastOfFiftyRoutes` dispatches the last of the 50 registered routes** — the worst
+case a linear scan produces, and therefore the case a regression in per-pattern cost would show
+first. `benchDispatchFirstOfFiftyRoutes` is kept alongside it, unbudgeted, so the best case is
+not silently dropped; the gap between the two is itself a fact about the table, not noise.
+
+**`benchEnvelopeBuild` calls `ApiEnvelope::ok()` and nothing after it.** No `jsonSerialize()`,
+no `Response` construction. `benchEnvelopeBuildWithMessages` measures the variadic-message path
+(`invalid()` with three strings) alongside it, unbudgeted, for the same reason the second router
+subject exists: the single-outcome figure is not the only shape a handler builds, and dropping
+the other silently would be the same narrowing ADR-0018 corrected.
+
+Both ceilings carry the caveat every benchmark in this file's neighbours documents (ADR-0011,
+ADR-0018): tied to spec NFR-06's reference machine and methodology, and enforced in CI as an
+absolute budget per ADR-0030's finding that the headroom these NFRs carry dwarfs cross-runner
+noise — not asserted as a hard requirement independent of that measurement.
+
+## Alternatives
+
+1. **Dispatch a route near the middle of the table.** Rejected: it answers a question nobody
+   asked — "the typical case" is not what a linear scan's worst-case cost analysis needs, and a
+   number that is neither the floor nor the ceiling explains nothing about either.
+2. **Measure `jsonSerialize()` together with construction, as one "build a response" number.**
+   Rejected for the reason ADR-0018 already established: a benchmark that reports two costs as
+   one cannot tell a reader which one moved when the number changes.
+3. **A single-route table**, avoiding the best/worst-case question entirely. Rejected: NFR-11
+   names 50 routes specifically, and a router with no index is exactly the shape where table
+   size is the variable that matters.
+
+## Consequences
+
+**Easier:** a regression in `Router`'s per-pattern cost is caught at the point that shows it
+first; a change to `ApiEnvelope`'s allocation is never confused with a change to its
+serialization.
+
+**Harder / accepted:** four subjects instead of two — the unbudgeted best-case and
+multi-message variants exist only to keep this decision honest, per ADR-0018's precedent, and
+carry no ceiling of their own.
+
+**If NFR-11's dispatch budget is not met** on the reference measurement, the response follows
+item 3.5/3.7's and item 4.5/4.6's precedent exactly: report the real number, ship it
+non-blocking, and file the gap as its own roadmap item rather than narrow the benchmark until it
+passes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,3 +68,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0050](0050-classify-the-miss-and-keep-the-router-a-table.md) | Classify the miss, and keep the router a table | Accepted |
 | [0051](0051-one-envelope-shape-and-a-reference-instead-of-the-exception.md) | One envelope shape, and a reference instead of the exception | Accepted |
 | [0052](0052-a-followed-redirect-reports-the-last-hop-not-the-first.md) | A followed redirect reports the last hop, not the first (corrects 0049) | Accepted |
+| [0053](0053-benchmark-the-last-route-and-construction-not-serialization.md) | Benchmark the last route, and construction, not serialization | Accepted |

--- a/docs/journal/2026/08/2026-08-07-nfr11-benchmarks.md
+++ b/docs/journal/2026/08/2026-08-07-nfr11-benchmarks.md
@@ -1,0 +1,66 @@
+# 2026-08-07 — Two subjects, one honest miss
+
+Roadmap item **11.5**, spec **NFR-11**. Route `fast / medium`; run at Sonnet 5, the routed tier.
+The item that was supposed to close Milestone 11 measured two subjects and closed neither
+budget question — one passed with room to spare, the other did not pass at all.
+
+## Two scoping questions before any number existed
+
+`Router` has no cache and no index — ADR-0050's stated non-goal — so dispatch is a linear scan
+that tries each compiled pattern until one matches. That has a real best case and a real worst
+case, and the first question was which one NFR-11's ≤5µs budgets: the **last** of 50 registered
+routes, the worst case the scan produces, is what a regression in per-pattern cost would show
+first. The first route is kept alongside it, unbudgeted, so the best case is not silently
+dropped — the same discipline item 4.5's `QueryBuilderBench` established for a heavier,
+unbudgeted shape kept beside its own budgeted one.
+
+The second question was smaller but had the same wrong-by-default answer: `ApiEnvelope::ok()`
+construction is the budgeted subject, never `jsonSerialize()`. NFR-11 budgets building the
+object a handler hands to `Response`; serialization is that class's job, later, and unbudgeted.
+Both decisions are **ADR-0053**.
+
+## What the measurement said
+
+On this PR's own CI run (`ubuntu-24.04`, not spec NFR-06's named reference machine):
+
+| Subject | Measured | Budget | |
+|---|---|---|---|
+| `benchEnvelopeBuild` | 0.366–0.395 µs (mean 0.381) | ≤ 2 µs | met, 5×+ headroom |
+| `benchEnvelopeBuildWithMessages` | 0.354–0.368 µs | unbudgeted | — |
+| `benchDispatchFirstOfFiftyRoutes` | 0.901–0.929 µs | unbudgeted | — |
+| `benchDispatchLastOfFiftyRoutes` | 6.874–7.145 µs (mean 6.984) | ≤ 5 µs | **not met, ~40% over** |
+
+The envelope half is not close to its ceiling; the router half is not close to being met. The
+gap between first-route and last-route dispatch — roughly 7.6× — is the 49 failed
+`preg_match()` attempts a worst-case lookup pays in a router with no index, which is exactly the
+mechanism ADR-0050 named when it decided a cache was not worth building. That decision assumed
+"a 50-route table matches in microseconds" without a number behind it; this item supplied the
+number, and it does not support the assumption at the worst case.
+
+## What did not happen
+
+The benchmark was not narrowed until it passed, and the CI gate was not softened to hide the
+miss. `bench_budget_gate.py --budget benchDispatchLastOfFiftyRoutes=5` is wired into both
+`ci.yml` and `nightly.yml` exactly as NFR-11 states it, and it fails, honestly, until the
+maintainer decides something. Items 3.5→3.7 and 10.6→10.10 set this precedent — a measurement
+that fails the spec's own number gets shipped as measured and filed as a decision, not quietly
+adjusted by whoever is holding the benchmark at the time.
+
+Filed as item **11.7**, not decided here: raise the budget, add the index ADR-0050 declined, or
+ship the gate red until one of those happens. ADR-0040 reserves the number itself for the
+maintainer.
+
+## Where this leaves Milestone 11
+
+Two decision items now sit open — 11.6 (a noisy subject that may not be a real regression at
+all) and 11.7 (a real, bounded cost with a known cause) — and `consistency_lint`'s own
+`milestones` check is what keeps README honest about it: a milestone cannot be marked done while
+any of its items are unchecked, so the README row stays "planned" structurally, not by a
+judgment call this session made.
+
+## Lesson
+
+A benchmark item's job is to produce the number, not to make the number acceptable. Two of this
+item's four subjects came in comfortably under budget and two did not, and shipping all four
+honestly — including the one that fails the gate — is what item 3.5 established as this
+project's answer to a benchmark that disagrees with its own spec.

--- a/src/bench/php/d4np/utils/HttpBench.php
+++ b/src/bench/php/d4np/utils/HttpBench.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench;
+
+use D4np\Utils\Http\ApiEnvelope;
+use D4np\Utils\Http\Router;
+use PhpBench\Attributes as Bench;
+
+/**
+ * NFR-11: `Router` dispatch against a 50-route table in ≤ 5 µs, and `ApiEnvelope` construction
+ * in ≤ 2 µs.
+ *
+ * **The 50-route table is the workload NFR-11 names, not a guess at a realistic one.** Every
+ * route carries one placeholder (`/resourceNN/{id}`), because a router that matched only literal
+ * paths would report the cost of `preg_match()` against nothing worth capturing — the estate this
+ * class replaced always had at least one path parameter per endpoint. The dispatched path is the
+ * last route registered, which is the worst case a linear scan over a compiled table can produce:
+ * every earlier pattern is tried and fails before the match. {@see Router} has no cache and no
+ * index (ADR-0050's stated non-goal), so the *last* route is where a regression in per-pattern
+ * cost would show first.
+ *
+ * **`ApiEnvelope::ok()` is the subject, not `jsonSerialize()`.** NFR-11 budgets *construction* —
+ * the object a handler builds before a response is ever sent — and serialization is a separate,
+ * unbudgeted step `Response` performs later. Measuring through `jsonSerialize()` would report the
+ * two costs as one and make a change to either look like a change to both.
+ *
+ * Both ceilings carry the caveat every benchmark here carries (roadmap 3.5, ADR-0018): they are
+ * tied to spec NFR-06's reference machine and methodology and are **not** asserted as a hard CI
+ * gate for the same reason a slower runner should not fail a check that has nothing to do with a
+ * regression. The nightly, same-runner-tracked check is roadmap item 7.1's job.
+ */
+#[Bench\Iterations(10)]
+#[Bench\RetryThreshold(5)]
+final class HttpBench
+{
+    private const ROUTE_COUNT = 50;
+
+    private Router $router;
+
+    /**
+     * A 50-route table, one placeholder per route, none of them the one that gets dispatched
+     * until the last.
+     */
+    public function setUpRouter(): void
+    {
+        $router = new Router();
+
+        for ($i = 1; $i <= self::ROUTE_COUNT; $i++) {
+            $router->get("/resource{$i}/{id}", static fn (): string => 'handler');
+        }
+
+        $this->router = $router;
+    }
+
+    /**
+     * NFR-11's router half: ≤ 5 µs, dispatched against the last of 50 routes — the worst case a
+     * linear scan over a compiled table produces, and therefore the honest number to budget.
+     */
+    #[Bench\BeforeMethods('setUpRouter')]
+    #[Bench\Revs(1000)]
+    #[Bench\Subject]
+    public function benchDispatchLastOfFiftyRoutes(): void
+    {
+        $this->router->match('GET', '/resource' . self::ROUTE_COUNT . '/42');
+    }
+
+    /**
+     * The same table, dispatched against the first route registered — the best case, kept
+     * visible so the last-route figure above is not the only number on record. NFR-11 does not
+     * budget this shape.
+     */
+    #[Bench\BeforeMethods('setUpRouter')]
+    #[Bench\Revs(1000)]
+    #[Bench\Subject]
+    public function benchDispatchFirstOfFiftyRoutes(): void
+    {
+        $this->router->match('GET', '/resource1/42');
+    }
+
+    /**
+     * NFR-11's envelope half: ≤ 2 µs for the outcome a handler reaches for most often — a
+     * successful read carrying a small payload.
+     */
+    #[Bench\Revs(1000)]
+    #[Bench\Subject]
+    public function benchEnvelopeBuild(): void
+    {
+        ApiEnvelope::ok(['id' => 42, 'name' => 'Ada']);
+    }
+
+    /**
+     * The variadic-message path, kept visible alongside the single-outcome figure above: an
+     * envelope built with several caller-supplied messages does the same allocation plus one
+     * `array_values()` over a longer list. NFR-11 does not budget this shape separately.
+     */
+    #[Bench\Revs(1000)]
+    #[Bench\Subject]
+    public function benchEnvelopeBuildWithMessages(): void
+    {
+        ApiEnvelope::invalid(['email is required', 'name must not be blank', 'age must be a number']);
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item **11.5** — the phpbench suite for NFR-11 (`Router` dispatch ≤ 5 µs at 50 routes;
`ApiEnvelope` construction ≤ 2 µs), meant to close Milestone 11. **It measures two subjects and
closes neither budget question outright**: the envelope half is comfortably met, the router half
is measured and honestly does not meet its budget.

## What NFR-11 needed decided before it had a number

`Router` has no cache and no index (ADR-0050's stated non-goal), so dispatch is a linear scan
with a real best case and a real worst case. **`benchDispatchLastOfFiftyRoutes` dispatches the
last of 50 registered routes** — the worst case that scan produces, and the case a regression in
per-pattern cost would show first — with the first-route best case kept alongside it, unbudgeted.
**`benchEnvelopeBuild` measures `ApiEnvelope::ok()` construction alone**, never
`jsonSerialize()`: NFR-11 budgets building the object, not the serialization `Response` performs
later. Both decisions are **ADR-0053**, following the same scoping discipline ADR-0011 and
ADR-0018 already established for other subjects.

## The measurement (this PR's own CI, `ubuntu-24.04` — not spec NFR-06's named machine)

| Subject | Measured | Budget | |
|---|---|---|---|
| `benchEnvelopeBuild` | 0.366–0.395 µs (mean 0.381) | ≤ 2 µs | **met**, 5×+ headroom |
| `benchEnvelopeBuildWithMessages` | 0.354–0.368 µs | unbudgeted | — |
| `benchDispatchFirstOfFiftyRoutes` | 0.901–0.929 µs | unbudgeted | — |
| `benchDispatchLastOfFiftyRoutes` | 6.874–7.145 µs (mean 6.984) | ≤ 5 µs | **not met, ~40% over** |

The 7.6× gap between first- and last-route dispatch is the 49 failed `preg_match()` attempts a
worst-case lookup pays in an unindexed router — exactly the mechanism ADR-0050 assumed away when
it decided a cache was not worth building ("a 50-route table matches in microseconds," stated
without a number behind it). This measurement corrects that assumption.

**Shipped as measured, not tuned to pass.** `bench_budget_gate.py --budget
benchDispatchLastOfFiftyRoutes=5` is wired into both `ci.yml` and `nightly.yml` at the number
NFR-11 actually states, and the `benchmark` job on this PR **fails honestly** on that one line —
following items 3.5→3.7's and 10.6→10.10's precedent: report the real number, ship it, file the
decision, never narrow the benchmark or soften the gate to make it pass.

## Filed, not decided: item 11.7

Raising the budget or adding an index to `Router` (reversing ADR-0050) are both bigger than this
item's `fast/medium` route, and ADR-0040 reserves spec numbers for the maintainer. Item 11.7
lays out three options: raise NFR-11's router ceiling to the measured number with headroom, add
the index/cache ADR-0050 declined, or accept the gap and ship the gate red until one of the
first two is chosen.

**Milestone 11 now has two open decision items (11.6, 11.7)** — one about a possibly-noisy
subject with no clear cause, one about a real, bounded cost with a known cause.
`consistency_lint`'s `milestones` check is what keeps README honest about this structurally: it
refuses to let a milestone read "done" while any of its items are unchecked, so the README row
stays "planned" without this being a judgment call.

## Design Patterns

- None adopted (benchmark + CI wiring only).

## Verification

- [x] `python tools/consistency_lint.py` — OK (all invariants, including `milestones`)
- [x] `vendor/bin/deptrac analyse` — 0 violations, 0 uncovered, 296 allowed (no new namespace or
      edge; `HttpBench` sits in the existing `D4np\Utils\Bench` namespace)
- [x] PHPStan max / CS-Fixer — N/A by established policy: `src/bench` is outside both the
      `phpstan.neon` paths and the CS-Fixer finder (item 10.12's documented fact), same as every
      other `*Bench.php` class in this repo
- [x] Leak-gate grep over the staged diff: zero matches
- **CI, this run:** 15/16 checks pass. **The one red check is the `benchmark` job's `Absolute
  NFR budgets` step — expected, and the subject of this PR**, not a defect to fix before merge.

## Documentation Impact

- [x] ADR — **ADR-0053** (new): the two scoping decisions
- [x] Spec — unchanged; NFR-11's number is not revised here (that decision is item 11.7's)
- [x] ROADMAP.md — item **11.5** checked with the full measurement; item **11.7** filed
- [x] CHANGELOG.md — entry under `Added`, both figures stated plainly
- [x] Journal — `docs/journal/2026/08/2026-08-07-nfr11-benchmarks.md`
- [ ] README.md — **deliberately unchanged**: Milestone 11's row stays "planned" (see above)
- [x] PR metadata — assignee (owner), label `enhancement`, milestone `v0.10.0`

## Lesson

Lesson: a benchmark item's job is to produce the number, not to make the number acceptable. Two
of four subjects here came in under budget and two did not; shipping all four honestly —
including the one that fails its own gate — is what this project asked of item 3.5, and asking
anything less of this one would be inconsistent with that record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
