### PR TITLE
feat(mail): refuse the terminator at construction, and hand mail() an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`D4np\Utils\Mail\` — the `Mail` group**: `EmailAddress`, `MailMessage`, the `Mailer` interface
+  and `NativeMailer` over PHP's `mail()`, with `D4np\Utils\Support\MailException` joining the
+  exception hierarchy (spec FR-43/FR-44, RFC-0002; roadmap item **12.4**; **ADR-0056**). It replaces
+  the surveyed estate's mailer, which called `ini_set('SMTP', …)` immediately before `mail()` and
+  interpolated the recipient and subject from request data unchecked.
+
+  **`CR`, `LF` and NUL are refused at construction** — in an address and in a subject — rather than
+  stripped at send time. Probed against a real SMTP transport, PHP does three different things with
+  the same bytes: it **flattens** them to spaces in `mail()`'s `$subject` (so
+  `Subject: a subject  Bcc: victim@example.com` reaches the wire, safe and silently not what the
+  caller wrote), it throws a `ValueError` for an **array** header value, and it **honours** them in a
+  **string** header block — issuing a second `RCPT TO`. A refusal at construction is the only answer
+  that does not depend on which of those a given call and platform get.
+
+  Consequences worth knowing before wiring it up:
+  - Addresses are validated by `filter_var()`, which is **stricter than RFC 5321 in one visible
+    way**: a bare hostname with no dot (`user@example`) is refused.
+  - `NativeMailer` **mutates nothing global**. Where the MTA lives stays deployment configuration;
+    the only thing the constructor configures is the envelope sender, which is passed as a `sendmail`
+    option and is therefore **a no-op on the Windows SMTP transport**.
+  - Non-ASCII subjects become RFC 2047 encoded-words (folded at 75 characters, no `mbstring`
+    dependency), bodies are base64-encoded, and a message with both a text and an HTML body becomes
+    `multipart/alternative`.
+  - Declared non-goals: no SMTP client, no attachments, no custom headers, no display names.
+    `Mailer` is the seam a fuller mail library plugs into without touching calling code.
+
 - **`D4np\Utils\Errors\Level`, `LevelFilteredLogger`, `MultiLogger`, `LoggerFactory`** — PSR-3
   logging channels: a level vocabulary with the ordering PSR-3 omits, a floor decorator that wraps
   *any* `LoggerInterface`, a fan-out composite, and a factory that turns one configuration array

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1263,7 +1263,16 @@ The console-side trio: client, router, envelope (RFC-0002 FR-37…FR-39).
       (**0.901–0.929 µs**) confirms the cost scales with the 49 failed `preg_match()` attempts a
       worst-case dispatch pays, which is exactly the shape a linear, uncached scan produces
       (ADR-0050's stated non-goal — no index, no cache). Unlike 11.6, this is not a noisy-runner
-      question; it is a real cost with a known cause. Options, none taken unilaterally
+      question; it is a real cost with a known cause. **Evidence added at item 12.4** (2026-08-08),
+      which qualifies the "40% over" figure without changing the diagnosis: across five CI runs on
+      **unmodified** `Router` code the subject has measured **6.874–7.145 · 5.188 · 5.673 · 4.735 ·
+      7.021 µs** — once *inside* the ceiling. The two runs of the *same commit* that bracket that
+      range came from runners differing by 27–103% on **every** subject (`benchWriteTenThousandByTen`
+      9 691 → 19 660 µs), so the spread is the runner's, not the router's. What this changes for the
+      decision: the mean sits clearly over budget and the cause is understood, so option (a) or (b)
+      is still the question — but a ceiling this close to the runner's own variance makes the gate
+      **flap** rather than fail, and whichever option is chosen should leave headroom against that
+      variance rather than against the measured mean. Options, none taken unilaterally
       ([ADR-0040](docs/adr/0040-run-infection-outside-the-dependency-graph-and-hold-the-floor-at-the-specs-70.md)
       reserves spec numbers for the maintainer): **(a)** raise NFR-11's router budget to a value
       the current linear scan clears (the measured number, with headroom, e.g. ≤ 10 µs); **(b)**
@@ -1410,6 +1419,29 @@ AEAD crypto, PSR-3 channel composition, and the Mail group (RFC-0002 FR-40…FR-
       slicing then lower-casing.*
 - [ ] 12.5 phpbench: NFR-13 (crypto 1 KiB round-trip) (RFC-0002) (step:optimize) — size: XS ·
       route: fast / medium
+- [ ] 12.6 Decide how the **relative** benchmark gate should treat a run-wide slowdown. Filed from
+      item 12.4's CI, where the *same commit* failed **two different gates on two runs** and neither
+      failure was attributable to the diff (a new `Mail` group nothing else imports). Run 1: the
+      relative gate failed with five subjects at **+11.19% … +19.44%**, among them
+      `RowNormalizerBench::benchInlineTrimHundredRows` — **the control**, a hand-written inline
+      `trim()` loop that calls no library code and therefore cannot regress. Run 2: the relative gate
+      passed (both halves measured on the same slow runner) and the **absolute** ceiling tripped
+      instead, on item 11.7's router. Every subject in run 2 was **27–103% slower** than in run 1.
+      So ADR-0030's same-runner A/B is sound and has an unhandled failure mode: base and head are
+      measured **sequentially**, so a runner that changes speed *between the halves* moves every
+      subject in one direction, and the gate reports it as a regression in whichever half came second.
+      ADR-0045's exclusions do not cover it — those name three subjects for *cross-run* noise, while
+      this hits everything, control included. The instrument that detects it already exists: **a
+      control subject moving beyond the threshold is proof the run is invalid**, not proof the code
+      regressed (the method item 10.12 introduced). Options, none taken unilaterally: **(a)** name
+      the control subjects in `bench_regression_gate.py` and have the gate **invalidate the run**
+      (exit distinctly, ask for a re-run) when one of them moves past the threshold; **(b)** compare
+      each subject against the control's own delta rather than against zero, so a run-wide shift
+      cancels; **(c)** interleave the base and head measurements instead of running them in
+      sequence; **(d)** accept the flapping and re-run by hand, as this item's own PR did. (b) is
+      the most precise and the easiest to get subtly wrong; (a) is the smallest change that stops a
+      false failure being indistinguishable from a real one — size: S · route: standard / medium ·
+      ADR (it revises ADR-0030/ADR-0045's gate design)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,9 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-08 — The idiomatic enum was too slow, and one of my own arguments was dead](docs/journal/2026/08/2026-08-08-logging-channels.md).
+  [2026-08-08 — Three answers to the same bytes, and a corpus that could not fail](docs/journal/2026/08/2026-08-08-mail-group.md).
   Previous:
+  [2026-08-08 — The idiomatic enum was too slow, and one of my own arguments was dead](docs/journal/2026/08/2026-08-08-logging-channels.md),
   [2026-08-07 — A tag that shrinks, a key nobody checks, and a guard that never fired](docs/journal/2026/08/2026-08-07-crypto.md).
 
 ## Model & effort routing (advisory)
@@ -1373,12 +1374,40 @@ AEAD crypto, PSR-3 channel composition, and the Mail group (RFC-0002 FR-40…FR-
       read as "the dispatch or the runner moved" first. The benchmark job is red on
       `benchDispatchLastOfFiftyRoutes` (5.188 vs 5) — **item 11.7, pre-existing on master**, not
       this item's code.*
-- [ ] 12.4 `Mail` group: `EmailAddress` (validated), `MailMessage` (**CR/LF/NUL in
+- [x] 12.4 `Mail` group: `EmailAddress` (validated), `MailMessage` (**CR/LF/NUL in
       header-bound values refused at construction**), `Mailer` + `NativeMailer` (explicit
       constructor config, no global `ini_set`), `MailException`, the Mail deptrac layer
       (Support-only edge) + T-10 header-injection corpus (RFC-0002 FR-43/FR-44; T-10)
-      (security) — size: M · route: frontier-reasoning / extra · ADR (header-injection
-      refusal + transport non-goals)
+      (security) — size: M · route: frontier-reasoning / extra *(run at standard tier / Opus 5;
+      mismatch accepted by the maintainer and recorded)* · **ADR-0056**. *2831 tests (+119 under
+      `--group T-10`). **No spec amendment — the second item in a row**, after four of the
+      previous six needed one. **The probe that shaped everything:** `mail()` returning `false` on
+      a host with no MTA says nothing about whether a payload was accepted, so the item was probed
+      against a **real SMTP sink** on `127.0.0.1`. PHP does three different things with the same
+      bytes: `CRLF` in `$subject` is **flattened to spaces** (`Subject: a subject  Bcc: victim@…`
+      reached the wire), `CRLF` in an **array** header value throws `ValueError`, and `CRLF` in a
+      **string** header block is **honoured** — a second `RCPT TO:<victim@…>` was issued, a working
+      Bcc injection. So the refusal is at construction (ADR-0025's stance on the other protocol),
+      the transport hands `mail()` an **array** as defence in depth, and the array form is asserted
+      as a **mechanism** through a `MailApi` seam because both shapes send a working email and no
+      behavioural test can tell them apart (ADR-0027, ADR-0026's seam). Also probed: PHP issues a
+      `RCPT TO` for an array `Bcc` **and omits the header** from what it sends, which is why that is
+      not done by hand. Subjects become hand-rolled RFC 2047 encoded-words (no `mbstring`, ADR-0019)
+      folded at 75 characters; bodies are base64 with `chunk_split(…, 76)`; two bodies become
+      `multipart/alternative` with a 128-bit boundary. **A boundary-collision check was written and
+      then removed as unreachable** — the boundary is drawn after the bodies exist, so placing it in
+      one means guessing 128 unborn bits (ADR-0022 / item 12.1's precedent for inert defences). New
+      `Mail` deptrac layer, **Support-only and deliberately not reaching `Errors`** (a transport that
+      logged its own failures would invert ADR-0029); proved by planting a `Mail → Errors` type
+      dependency (2 violations → 0). ***15 defects planted, 14 caught — and the one real miss is
+      worth the item's weight:*** splitting the subject on **bytes** instead of characters passed the
+      suite, because the multi-byte test used only three-byte characters and an encoded-word's
+      payload here is **45 bytes, a multiple of three**, so every split landed on a character
+      boundary by arithmetic. Test widened to two-byte, four-byte and mixed subjects; plant now
+      caught. **A corpus whose members all share one width cannot test a boundary computed in that
+      width** — the same failure class as a benchmark measuring the wrong shape (ADR-0018/0020). The
+      15th "miss" was not a defect: lower-casing before slicing the domain is byte-equivalent to
+      slicing then lower-casing.*
 - [ ] 12.5 phpbench: NFR-13 (crypto 1 KiB round-trip) (RFC-0002) (step:optimize) — size: XS ·
       route: fast / medium
 
@@ -1397,7 +1426,7 @@ Legend: ⏳ not started · 🚧 in progress · ✅ done · ❎ N/A.
 | §3 | Architecture & layering (deptrac); r3 adds Persistence/Mail + named edges | 1.1, 1.6, 2.1, 2.5, 10.2–10.3, 12.4 | 🚧 |
 | §4 | NFR budgets & benchmark methodology; r3 adds NFR-09–14 | 3.5, 4.5, 5.5, 6.4, 7.1, 9.6, 10.6, 10.11–10.12, 11.5, 12.3, 12.5 | 🚧 |
 | §5 | Security test criteria; r3 adds T-08/09/10/13 | 4.4, 5.4, 5.5, 6.3, 9.4, 10.5, 11.4, 12.2, 12.4 | 🚧 |
-| §6 | API example / public interface | 1.6, 3.1, 10.3–10.4, 11.3 | 🚧 |
-| §7 | Verification & test strategy (r3) | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3, 8.2, 9.5, 10.2, 10.5, 10.11, 11.2, 11.4, 12.2–12.3 | 🚧 |
+| §6 | API example / public interface | 1.6, 3.1, 10.3–10.4, 11.3, 12.4 | 🚧 |
+| §7 | Verification & test strategy (r3) | 1.2, 2.6, 3.1, 3.4, 4.4, 6.3, 8.2, 9.5, 10.2, 10.5, 10.11, 11.2, 11.4, 12.2–12.4 | 🚧 |
 | §8 | CI/CD & release engineering | 1.4, 1.7, 7.1–7.3, 8.3 | 🚧 |
 | §9 | Decision log (imported + seeded ADRs); r3 items carrying ADRs | 2.1, 5.3, 7.4, 9.3–9.4, 10.1, 10.3–10.4, 10.11–10.12, 11.1–11.2, 12.1, 12.3–12.4 | 🚧 |

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -60,6 +60,17 @@ deptrac:
         - type: directory
           value: src/main/php/d4np/utils/Persistence/.*
 
+    # RFC-0002's eighth group (roadmap Milestone 12, item 12.4). Support-only, like every group
+    # except `Persistence`: `EmailAddress` and `MailMessage` consume the exception hierarchy and
+    # nothing else, and the transport reaches PHP's `mail()` rather than another group. In
+    # particular it does NOT reach `Errors` — a mailer that logged its own failures would be the
+    # inversion ADR-0029 keeps out, and a caller who wants the failure logged catches
+    # `MailException` and logs it where the decision belongs.
+    - name: Mail
+      collectors:
+        - type: directory
+          value: src/main/php/d4np/utils/Mail/.*
+
     # The layer every group is allowed to depend on, and which may depend on none of them.
     - name: Support
       collectors:
@@ -163,6 +174,10 @@ deptrac:
       - Support
       # `Logger` implements PSR-3 and `ExceptionHandler` accepts one (spec FR-17, FR-18).
       - Psr
+
+    # Support and nothing else — deliberately including no `Errors`: see the layer's comment above.
+    Mail:
+      - Support
 
     # Support is the bottom of the library: it depends on no group. An empty list here is the
     # load-bearing half of the rule — it is what makes a Support -> Dto import (the inversion

--- a/docs/adr/0056-refuse-the-terminator-at-construction-and-hand-mail-an-array.md
+++ b/docs/adr/0056-refuse-the-terminator-at-construction-and-hand-mail-an-array.md
@@ -1,0 +1,219 @@
+# ADR-0056: Refuse the terminator at construction, and hand `mail()` an array
+
+- **Status:** Accepted
+- **Date:** 2026-08-08
+- **Deciders:** tech-lead (agent-drafted), maintainer (merge)
+- **Related:** ROADMAP item **12.4** (security) · spec **FR-43**, **FR-44**, **T-10** ·
+  [ADR-0025](0025-typed-http-wrappers-that-refuse-rather-than-coerce.md) (CR/LF refused in a
+  response header **at set time, not send time** — the stance this applies to SMTP) ·
+  [ADR-0026](0026-session-hardening-as-a-value-and-csrf-through-a-seam.md) (the `SessionApi` seam
+  that makes a call sequence assertable) ·
+  [ADR-0027](0027-constant-time-comparison-is-asserted-by-mechanism-not-by-timing.md) (a property
+  no behaviour can distinguish is asserted as a mechanism) ·
+  [ADR-0019](0019-four-escaping-contexts-and-the-unquoted-attribute-assumption.md) (no undeclared
+  `mbstring`; PCRE instead) ·
+  [ADR-0022](0022-argon2id-by-default-with-a-fallback-decided-at-construction.md) and item 12.1
+  (defensive code a probe proves inert is removed) ·
+  [ADR-0029](0029-result-carries-a-throwable-and-production-withholds-the-message-too.md) (a
+  logger does not escalate — why `Mail` does not reach `Errors`) ·
+  [ADR-0043](0043-two-named-edges-out-of-persistence-and-no-catch-at-all.md) (the layering-edge
+  precedent this group deliberately does not need)
+
+## Context
+
+Spec FR-43 and FR-44: a validated `EmailAddress`, a readonly `MailMessage` refusing `CR`, `LF` and
+NUL in any header-bound value at construction, a `Mailer` interface, and a `NativeMailer` over PHP's
+`mail()` configured through its constructor rather than by mutating globals — with an SMTP client
+declared a non-goal.
+
+The estate this replaces sent mail by calling `ini_set()` for `SMTP` and `sendmail_from` immediately
+before `mail()`, with the recipient and subject interpolated from request data and no check on
+either. Two questions had to be answered before any of it could be designed, and both were settled
+by probing rather than by reading the manual.
+
+**Does PHP already defend this?** It does, partially, inconsistently, and differently depending on
+which argument carries the bytes. Probed on PHP 8.3 against a real SMTP transport — a sink on
+`127.0.0.1` speaking enough of RFC 5321 to receive a message, because `mail()` returning `false` on
+a host with no MTA says nothing about whether the payload was accepted:
+
+| payload | what actually happened |
+|---|---|
+| `CRLF` in `$subject` | **flattened to spaces** — `Subject: a subject  Bcc: victim@…` reached the wire |
+| `CRLF` in `$to` | flattened — and the envelope carried `RCPT TO:<to@…  Bcc: victim@…>` |
+| `CRLF` in an **array** header value | `ValueError`, nothing sent |
+| `CRLF` in a header **name** (array form) | `ValueError` |
+| NUL in `$subject` or in a header | `ValueError` |
+| `CRLF` in a **string** header block | **honoured** — a second `RCPT TO:<victim@…>` was issued |
+
+So the same bytes are silently rewritten, refused with an exception, or obeyed, according to where
+they were put. The last row is a working Bcc injection, and it is not a PHP defect: passing a string
+header block *is* the documented way to add a `Bcc`, so PHP parsed exactly what it was given.
+
+**Where does encoding come in?** A header is 7-bit by RFC 5322, so a non-ASCII subject cannot be
+sent literally. `mb_encode_mimeheader()` would do it, and `mbstring` is not a declared dependency of
+this library — ADR-0019 already refused to acquire one for a job PCRE could do.
+
+## Decision
+
+### D1 — Every header-bound value is refused at construction, never cleaned
+
+`EmailAddress::of()` and `MailMessage::create()` refuse `CR`, `LF` and NUL outright. This is
+ADR-0025's response-splitting stance — *refuse at set time, not at send time* — applied to the other
+protocol, and the probe above is why it is a refusal rather than a strip:
+
+- **Stripping is what PHP does to `$subject`, and it is a silent data change.** A subject arriving as
+  `a subject  Bcc: victim@example.com` is safe and is not the subject anyone wrote. Every other
+  component in this library refuses that trade (ADR-0037's CSV formula guard is opt-in for the same
+  reason; ADR-0019's escaper substitutes rather than deletes).
+- **Waiting for PHP would inherit three behaviours.** A library that relied on `mail()`'s checks
+  would be safe on the array path, silently lossy on `$subject`, and injectable on the string path.
+
+The consequence is a type-level guarantee: an `EmailAddress` cannot hold a terminator, so every
+address-shaped header value in `MailMessage` and `NativeMailer` is already clean without any of them
+re-checking. The subject is the only free-text header value a caller supplies, and it is checked in
+exactly one place.
+
+The explicit `CR`/`LF`/NUL loop in `EmailAddress::of()` is **redundant against `filter_var()`**,
+which rejects all three today. It is kept deliberately, and not as belt-and-braces: it is the
+statement of the one property this class must never lose, expressed as a check against *this
+library's* rule rather than against PHP's current filter definition. The planted-defect campaign
+confirms it is observable — removing it changes the refusal message, and a test reads that message.
+
+### D2 — Bodies are not header values, and are not checked
+
+A body may contain anything, including `CRLF`; it is not a header. Stated because the natural
+next edit after D1 is to copy the check onto the body, where it would refuse ordinary multi-line
+text — and a test pins that a body with newlines is accepted.
+
+### D3 — `NativeMailer` hands `mail()` an **array**, never a string block
+
+The array form is the one PHP validates. This library refuses the same bytes upstream, so the array
+form is defence in depth rather than the defence — and defence in depth is exactly what one wants
+against the failure mode where a *future* edit loosens D1.
+
+Both shapes send a working email, so no behavioural test can see which one is used. It is asserted
+as a **mechanism** (ADR-0027's rule) against a `MailApi` seam (ADR-0026's `SessionApi` pattern):
+the recorded call's headers must be an array, no header name may contain a colon, no value may
+contain a terminator, and the seam's own fourth parameter must be typed `array` so a future edit
+cannot quietly build a block by hand.
+
+`Bcc` goes through as an array header on purpose. Probed: PHP issues a `RCPT TO` for it **and omits
+the header from the message it sends** — which is what RFC 5322 asks for, and which is why this is
+not done by hand.
+
+### D4 — Nothing global is mutated; the only configuration is the envelope sender
+
+Where the MTA lives is deployment configuration. `NativeMailer` reads none of it and sets none of it:
+the estate's `ini_set('SMTP', …)` changed the behaviour of every other `mail()` call in the process,
+including calls made by code that never asked.
+
+That leaves the **envelope sender**, a constructor argument passed as `mail()`'s fifth parameter. Two
+honest limits are documented rather than discovered: it reaches the `sendmail` command line, so it is
+**a no-op on the Windows SMTP transport**; and it is safe to put on a command line for a reason worth
+naming — it is an `EmailAddress`, which cannot contain a space, a quote, a semicolon or a newline, so
+the type is the argument-injection defence.
+
+### D5 — Subjects are RFC 2047 encoded-words, hand-rolled and folded
+
+A non-ASCII subject becomes `=?UTF-8?B?…?=`, built with `base64_encode()` and PCRE — no `mbstring`
+(ADR-0019). RFC 2047 caps one encoded-word at 75 characters including delimiters, and a 30-character
+accented subject already produces 92, so long subjects fold into several words joined by `CRLF` and a
+space — the one place this class emits `CRLF`, and it is RFC 5322's folding sequence rather than a
+caller's value.
+
+The split walks **characters, not bytes**, because a multi-byte character cut across two words
+decodes to a replacement glyph in every client. That the test for it was initially *vacuous* is
+recorded in the Consequences: it deserves more attention than the decision.
+
+### D6 — Bodies are base64-encoded, and two bodies become `multipart/alternative`
+
+Base64 rather than raw 8-bit: an RFC 5322 body line is capped at 998 octets, and a long UTF-8
+paragraph sent raw is a message a relay may fold, mangle or reject. `chunk_split(…, 76)` is RFC
+2045's line limit. The MIME boundary is 128 bits of CSPRNG per message.
+
+**There is deliberately no check that the boundary does not occur in a body.** It is the obvious
+defensive move — a body is attacker-controlled in any application that mails user-supplied text — and
+it would be unreachable code: the boundary is drawn *after* the bodies exist, so placing it in one
+means guessing 128 unborn bits. Being unreachable it could never be tested, only asserted about. It
+was written, then removed, on ADR-0022's and item 12.1's precedent.
+
+### D7 — `Mail` is a Support-only layer, and deliberately does not reach `Errors`
+
+A new deptrac layer with one allowed edge. In particular a mailer that logged its own failures would
+invert ADR-0029's stance: the decision to log belongs to the caller who catches `MailException`, not
+to the transport. `Persistence`'s two named cross-group edges (ADR-0043) remain the only exception in
+the file. Proved by planting a `Mail → Errors` type dependency: 2 violations, restored to 0.
+
+## Alternatives
+
+1. **Strip `CR`/`LF` from the subject instead of refusing** — rejected (D1): it is what PHP does on
+   one path, and it silently sends a message the caller did not write.
+2. **Rely on `mail()`'s own checks** — rejected: three different behaviours across three arguments,
+   one of which honours the injection.
+3. **A string header block**, the shape almost all legacy code passes — rejected (D3): it is the one
+   PHP does not validate, and the probe shows an injected `Bcc` delivered.
+4. **`mb_encode_mimeheader()`** for D5 — rejected: `mbstring` is undeclared here, and ADR-0019
+   already made this call for the escaper. The hand-rolled encoded-word is ~10 lines and testable.
+5. **Refuse non-ASCII subjects** instead of encoding them — rejected: it would push every consumer
+   into building encoded-words themselves, which is where header injection gets reinvented.
+6. **Accept a display name** (`Name <a@b>`) in `EmailAddress` — rejected: a name is free text that
+   must be quoted *and* RFC 2047-encoded, and mixing it into the address value is precisely how
+   `From: "Foo\r\nBcc: x" <a@b>` gets built. If display names are wanted later they arrive as a
+   separate, separately-validated field.
+7. **An SMTP client** — rejected at RFC-0002 level and restated here: authenticated submission,
+   TLS, queueing and retries are a project, and `Mailer` is the seam that lets one be plugged in
+   without touching calling code.
+8. **Attachments / custom headers** — rejected as non-goals. Both are where a MIME builder becomes a
+   library; a consumer who needs them has outgrown this class and wants theirs behind `Mailer`.
+9. **A boundary-collision check** — written, then removed as unreachable (D6).
+10. **Validating the address with a hand-rolled RFC 5322 parser** — rejected: `filter_var()` is
+    stricter than the RFC in one visible way (it refuses `user@example`, a bare hostname), and that
+    is a smaller cost than owning an address grammar. Documented on the class rather than left for a
+    consumer to discover.
+
+## Consequences
+
+**Easier:** a `MailMessage` that exists is sendable — no transport re-validates anything; a consumer
+swapping in a real mail library implements one method; the `Bcc`-injection class of bug is
+unreachable through this API even if PHP's own behaviour changes again.
+
+**Harder / accepted costs:** `filter_var()`'s strictness will refuse some RFC-legal intranet
+addresses (`user@example`); the envelope sender is a documented no-op on one platform; no
+attachments; and the group carries a seam (`MailApi`) whose only purpose is to make a mechanism
+assertable — a cost ADR-0026 already accepted for the same reason.
+
+**The campaign found a vacuous test of mine, and the arithmetic is worth carrying.** 15 defects
+planted, 14 caught. Of the two that were not:
+
+- One was **not a defect**: lower-casing the address before slicing the domain is byte-for-byte
+  equivalent to slicing then lower-casing, because `strtolower()` preserves length. A bad plant, not
+  a test gap — the same shape as item 12.3's first-round plant that reordered two `if`s and changed
+  nothing.
+- One was **a real hole**. Splitting the subject on **bytes** instead of characters passed the suite,
+  because the multi-byte test used only three-byte characters (`日本語の件名`) and an encoded-word's
+  payload here is 45 bytes — a multiple of three. Every split landed on a character boundary *by
+  arithmetic*. The test now covers two-byte, four-byte and mixed-width subjects, and the plant is
+  caught. Reassembly assertions could never have caught it either: concatenating byte chunks returns
+  the same bytes.
+
+  **The transferable rule: a corpus whose members all share one width cannot test a boundary
+  computed in that width.** It is the same failure as a benchmark whose subject is the wrong shape
+  (ADR-0018, ADR-0020) — the instrument agreed with the code because both were measuring the easy
+  case.
+
+**No spec amendment.** FR-43, FR-44 and T-10 were implementable exactly as written — the second item
+in a row, after four of the previous six needed the spec corrected in the same PR.
+
+**No patterns-catalogue entry.** `Mailer` is an interface over a transport and `MailApi` is a seam;
+neither is a deliberate pattern adoption, and ADR-0026's `SessionApi` set the precedent of not
+claiming one. Recorded here so the absence is a decision rather than an omission (§8).
+
+## References
+
+- RFC 5322 §2.2 (header fields are 7-bit; folding), §2.1.1 (line limits: 78 SHOULD, 998 MUST)
+- RFC 5321 §4.1.2 (envelope), §2.4 (the local part is case-sensitive; the domain is not)
+- RFC 2045 §6.8 (base64 line length), RFC 2047 §2 (encoded-word, 75-character limit)
+- OWASP Cheat Sheet Series: *Email Header Injection*
+- PHP manual: `mail()` (the array header form, PHP ≥ 7.2), `filter_var()` / `FILTER_VALIDATE_EMAIL`
+- Item 12.4's probes (the SMTP-sink capture table above) — recorded in the journal entry for
+  2026-08-08

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,3 +71,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0053](0053-benchmark-the-last-route-and-construction-not-serialization.md) | Benchmark the last route, and construction, not serialization | Accepted |
 | [0054](0054-authenticated-encryption-with-fixed-lengths-and-a-key-only-secretkey-can-produce.md) | Authenticated encryption, with fixed lengths and a key only `SecretKey` can produce | Accepted |
 | [0055](0055-one-ordering-validation-before-filtering-and-a-swallow-only-at-the-leaf.md) | One ordering, validation before filtering, and a swallow only at the leaf | Accepted |
+| [0056](0056-refuse-the-terminator-at-construction-and-hand-mail-an-array.md) | Refuse the terminator at construction, and hand `mail()` an array | Accepted |

--- a/docs/journal/2026/08/2026-08-08-mail-group.md
+++ b/docs/journal/2026/08/2026-08-08-mail-group.md
@@ -93,9 +93,44 @@ a stated limit. It is safe on that command line for a reason worth naming: it is
 one cannot contain a space, a quote, a semicolon or a newline — the type *is* the argument-injection
 defence.
 
+## Postscript — the same commit failed two different gates
+
+CI's benchmark job went red, and my first read of it was wrong in a way worth recording.
+
+**Run 1:** the *relative* gate failed — five subjects between +11.19% and +19.44%, none of them
+touching `Mail`. Among them `RowNormalizerBench::benchInlineTrimHundredRows`, which is **the
+control**: a hand-written inline `trim()` loop that calls no library code and therefore cannot
+regress. I concluded runner noise and re-ran the same commit, saying a re-run would clear it.
+
+**Run 2:** it did not. The relative gate passed and the **absolute** ceiling tripped instead, on item
+11.7's router (7.021 µs against 5). Every subject in run 2 was **27–103% slower** than in run 1 on
+identical code — `benchWriteTenThousandByTen` went 9 691 → 19 660 µs.
+
+So both failures were the runner, and the re-run did not fix it; it moved which gate noticed. The
+mechanism, once the two runs are put side by side, is specific: ADR-0030's same-runner A/B measures
+base and head **sequentially**, so a runner that changes speed *between the halves* shifts every
+subject in one direction and the gate reads it as a regression in whichever half ran second. On a
+uniformly slow runner the halves agree with each other and the absolute ceiling is what gives way.
+ADR-0045's exclusions do not cover this — they name three subjects for *cross-run* noise, while this
+moves everything, control included.
+
+Filed as item **12.6** with four options and no decision taken, and the router evidence appended to
+item 11.7, where it qualifies the "40% over" figure without changing the diagnosis: five runs on
+unmodified code now read 6.874–7.145 · 5.188 · 5.673 · 4.735 · 7.021 µs, once *inside* the ceiling.
+
+The control subject earned its keep twice here. In run 1 it was the proof the code was innocent —
+without it I would have had only "my diff doesn't touch hydration", which is an argument rather than
+evidence. And it is the instrument item 12.6 proposes to use: **a control moving past the threshold
+means the run is invalid, not that the code regressed.**
+
 ## Lesson
 
 An oracle that cannot fail is worse than no oracle. `mail()` returning `false` for every input made
 the first two probe rounds unable to answer their own question, and a corpus of uniformly-3-byte
 characters made a test unable to fail. Both looked like evidence. The fix in both cases was to remove
 the thing that made every answer identical — the missing MTA, and the shared character width.
+
+The postscript is the same lesson pointed at a gate: one that can fail for a reason unrelated to the
+change is an oracle whose *green* is worth less than it looks, and whose red costs an investigation
+each time. The control subject is what tells the two apart — which is why it belongs inside the
+benchmark rather than in the reasoning about it afterwards.

--- a/docs/journal/2026/08/2026-08-08-mail-group.md
+++ b/docs/journal/2026/08/2026-08-08-mail-group.md
@@ -1,0 +1,101 @@
+# 2026-08-08 — Three answers to the same bytes, and a corpus that could not fail
+
+Roadmap item **12.4**, the `Mail` group. Route `frontier-reasoning / extra`; run at standard tier
+(Opus 5, the session model) with the maintainer's go-ahead — mismatch recorded, not glossed.
+
+## The probe that decided the whole item
+
+`mail()` on this machine cannot reach an MTA, so it returns `false` for everything. That makes it
+useless as an oracle: "PHP rejected my payload" and "PHP accepted my payload and the transport
+failed" are the same observation. Round two of the probes hit exactly that wall, and round three
+removed the variable — a **socket server on `127.0.0.1` speaking enough of RFC 5321** to receive a
+message, with `ini_set('SMTP', …)` in the probe process only, and the raw session written to a file.
+
+What arrived on the wire:
+
+| payload | result |
+|---|---|
+| `CRLF` in `$subject` | **flattened to spaces** — `Subject: a subject  Bcc: victim@example.com` |
+| `CRLF` in `$to` | flattened — envelope carried `RCPT TO:<to@example.com  Bcc: victim@…>` |
+| `CRLF` in an **array** header value | `ValueError`, nothing sent |
+| `CRLF` in a header **name** | `ValueError` |
+| NUL anywhere in a header or the subject | `ValueError` |
+| `CRLF` in a **string** header block | **honoured** — a second `RCPT TO:<victim@…>` was issued |
+
+Three behaviours for the same three bytes, chosen by which argument carries them. The last row is a
+working Bcc injection and is not a PHP defect: a string header block *is* the documented way to add a
+`Bcc`, so PHP parsed what it was handed.
+
+Two decisions fall straight out of the table. **Refuse at construction**, because a library relying on
+PHP's checks would be safe on one path, silently lossy on another and injectable on the third — and
+because flattening is a silent data change, which is the trade this library refuses everywhere else
+(ADR-0037's CSV guard, ADR-0019's escaper). And **hand `mail()` an array**, because that is the shape
+PHP validates; with our own refusal upstream it is defence in depth, which is what one wants for the
+day someone loosens a validation.
+
+The array form had one more gift: PHP issues a `RCPT TO` for an array `Bcc` **and omits the header
+from the message it sends**. That is what RFC 5322 asks for, and it is why the group does not
+hand-roll bcc handling.
+
+## Assert the shape, because behaviour cannot see it
+
+Both header shapes send a working email. No behavioural test distinguishes them — the same situation
+as `hash_equals` versus `===` (ADR-0027) and the session cookie ordering (ADR-0026). So the array form
+is asserted as a mechanism through a `MailApi` seam: the recorded call's headers must be an array, no
+name may carry a colon, no value a terminator, and **the seam's fourth parameter must be typed
+`array`**, so a future edit cannot quietly build a block by hand.
+
+## A defence I wrote, then deleted
+
+`multipart/alternative` needs a boundary, and a body is attacker-controlled in any application that
+mails user-supplied text — so the obvious move is to search both bodies for the boundary and refuse a
+collision. I wrote it. Then I noticed it can never run: the boundary is drawn from a CSPRNG *after*
+the bodies exist, so placing it in one means guessing 128 bits that do not exist yet. Unreachable code
+cannot be tested, only asserted about, and it reads as though the surrounding code needed it.
+
+Removed, with the reasoning in ADR-0056 §D6. Item 12.1 deleted a guard for the same reason a day
+earlier; yesterday, item 12.3 kept a piece of code and deleted its *justification* instead. Three
+variants of one question in three days: **what is this line actually able to prevent?**
+
+## The corpus that could not fail
+
+Fifteen defects planted, fourteen caught. The interesting one:
+
+Splitting the encoded subject on **bytes** rather than characters — the exact bug that renders a
+subject as replacement glyphs — **passed the suite**. My multi-byte test used `日本語の件名`, and an
+encoded-word's payload here is 45 bytes: 75 minus 12 of delimiters, rounded down to a multiple of 3 so
+base64 does not pad mid-word. 45 is divisible by 3. Every character in the corpus is three bytes wide.
+So every split landed on a character boundary **by arithmetic**, and a byte-wise implementation was
+indistinguishable from a correct one.
+
+Worse, the reassembly assertion could never have caught it either: concatenating byte chunks returns
+the same bytes. Only per-word UTF-8 validity can see it, and only with characters whose width does not
+divide the chunk size.
+
+The test now runs two-byte, four-byte and mixed-width subjects, and the plant is caught. The rule is
+general enough to write down: **a corpus whose members all share one width cannot test a boundary
+computed in that width.** It is the same failure as a benchmark whose subject is the wrong shape
+(ADR-0018, ADR-0020) — the instrument agreed with the code because both were measuring the easy case.
+
+The fifteenth plant was not a defect at all: lower-casing an address before slicing off the domain is
+byte-for-byte equivalent to slicing then lower-casing, since `strtolower()` preserves length. A bad
+plant, like item 12.3's `if`-reordering — and the campaign's own check (verify the plant *applied*)
+is what keeps those from being read as passes.
+
+## Two small honest limits
+
+`filter_var()` refuses `user@example` — a bare hostname, legal per RFC 5321 and used by real intranet
+addresses. Owning an RFC 5322 grammar is the alternative, and it is worse. Documented on the class.
+
+The envelope sender reaches a `sendmail` command line, so it is **a no-op on the Windows SMTP
+transport**. Also documented, because a silent no-op that only manifests on one platform is worse than
+a stated limit. It is safe on that command line for a reason worth naming: it is an `EmailAddress`, and
+one cannot contain a space, a quote, a semicolon or a newline — the type *is* the argument-injection
+defence.
+
+## Lesson
+
+An oracle that cannot fail is worse than no oracle. `mail()` returning `false` for every input made
+the first two probe rounds unable to answer their own question, and a corpus of uniformly-3-byte
+characters made a test unable to fail. Both looked like evidence. The fix in both cases was to remove
+the thing that made every answer identical — the missing MTA, and the shared character width.

--- a/src/main/php/d4np/utils/Mail/EmailAddress.php
+++ b/src/main/php/d4np/utils/Mail/EmailAddress.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Mail;
+
+use D4np\Utils\Support\MailException;
+
+/**
+ * A validated email address (spec FR-43, RFC-0002; ADR-0056).
+ *
+ * The type exists so that "this string is an address" is established **once**, at a boundary, rather
+ * than re-asserted by every function that accepts one. Everything downstream — {@see MailMessage},
+ * {@see NativeMailer} — takes this type and therefore never validates an address again.
+ *
+ * **The rules are `filter_var()`'s, and they are stricter than RFC 5321 in one visible way.**
+ * Probed: `FILTER_VALIDATE_EMAIL` rejects `user@example` — a bare hostname with no dot, which the
+ * RFC permits and which real intranet addresses use. It also rejects quoted local parts
+ * (`"user name"@example.com`), non-ASCII local parts, and the display-name form
+ * (`User <user@example.com>`), while accepting IP literals (`user@[127.0.0.1]`). Those are the
+ * accepted trade-offs of not hand-rolling an RFC 5322 parser, and they are written here rather than
+ * discovered by a consumer whose address is refused.
+ *
+ * **CR, LF and NUL are refused explicitly, before `filter_var()` is asked.** `filter_var()` happens
+ * to reject all three today (probed), so this check is redundant *as validation* — and it is kept
+ * because it is not redundant as a **statement**: the one property this class must never lose is
+ * that no instance can carry a header terminator, and a test that asserts it against this class,
+ * rather than against `filter_var()`'s current rule set, is a test about this library.
+ *
+ * The display name is deliberately **not** part of this type: a name is free text that has to be
+ * RFC 2047-encoded and quoted, and mixing it into the address value is how
+ * `From: "Foo\r\nBcc: x" <a@b>` gets built. {@see MailMessage} carries no display names for the same
+ * reason — an address is an address.
+ */
+final class EmailAddress implements \Stringable
+{
+    /**
+     * Characters that terminate or split a header. The whole `Mail` group's safety rests on none of
+     * these reaching a header value, and this is the one place the set is written down.
+     */
+    public const FORBIDDEN = ["\r", "\n", "\0"];
+
+    private function __construct(public readonly string $value)
+    {
+    }
+
+    /**
+     * @throws MailException if `$address` is not a usable address
+     */
+    public static function of(string $address): self
+    {
+        foreach (self::FORBIDDEN as $character) {
+            if (\str_contains($address, $character)) {
+                throw new MailException(\sprintf(
+                    'An email address may not contain %s. Refused here rather than at send time: '
+                    . 'what PHP does with a header terminator depends on which argument carries it '
+                    . 'and which transport is configured (ADR-0056), so the only reliable answer is '
+                    . 'that an address carrying one never becomes an address at all.',
+                    self::describe($character),
+                ));
+            }
+        }
+
+        // Trimming first would accept " user@example.com" by silently changing it, and an address
+        // the caller did not write is worse than a refusal they can read.
+        if (\filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
+            throw new MailException(\sprintf(
+                '"%s" is not a valid email address. Note that the check is filter_var()\'s, which is '
+                . 'stricter than RFC 5321 in one respect worth knowing: a bare hostname with no dot '
+                . '(user@example) is refused.',
+                $address,
+            ));
+        }
+
+        return new self($address);
+    }
+
+    /**
+     * The same address, or `null` where a caller has a legitimate reason to treat an invalid one as
+     * absent — reading an optional configuration value, filtering a user-supplied list.
+     *
+     * Named so the tolerant path is visible at the call site: the surveyed estate's helpers returned
+     * `false` from everything, so no reader could tell which calls had decided to be tolerant.
+     */
+    public static function tryOf(string $address): ?self
+    {
+        try {
+            return self::of($address);
+        } catch (MailException) {
+            return null;
+        }
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * The domain part, lower-cased — the half that is case-insensitive per RFC 5321. The local part
+     * is deliberately not normalised: it is case-**sensitive** by the same RFC, and lower-casing it
+     * is a widespread habit that quietly rewrites addresses on hosts which honour the distinction.
+     */
+    public function domain(): string
+    {
+        return \strtolower(\substr($this->value, \strrpos($this->value, '@') + 1));
+    }
+
+    private static function describe(string $character): string
+    {
+        return match ($character) {
+            "\r" => 'a carriage return',
+            "\n" => 'a line feed',
+            default => 'a NUL byte',
+        };
+    }
+}

--- a/src/main/php/d4np/utils/Mail/MailApi.php
+++ b/src/main/php/d4np/utils/Mail/MailApi.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Mail;
+
+/**
+ * The seam over PHP's `mail()` (ADR-0056, following ADR-0026's `SessionApi`).
+ *
+ * It exists for one reason: the central decision in {@see NativeMailer} is *which shape of headers
+ * it hands to `mail()`*, and that decision is invisible to every behavioural test. Both shapes send
+ * a working email; only one of them refuses an injected `Bcc:` (probed — the array form throws a
+ * `ValueError`, the string form issues a second `RCPT TO`). A property no observable behaviour
+ * distinguishes has to be asserted as a mechanism, which needs a seam to assert against
+ * (ADR-0027's rule).
+ *
+ * It also keeps the unit suite off the network: `mail()` with no MTA blocks on a connection attempt
+ * and then fails, which would make every test slow and its failure mode indistinguishable from a
+ * real defect.
+ */
+interface MailApi
+{
+    /**
+     * @param array<string, string> $headers the array form, deliberately — see the interface docblock
+     */
+    public function send(string $to, string $subject, string $message, array $headers, string $parameters): bool;
+}

--- a/src/main/php/d4np/utils/Mail/MailMessage.php
+++ b/src/main/php/d4np/utils/Mail/MailMessage.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Mail;
+
+use D4np\Utils\Support\MailException;
+
+/**
+ * A message that is sendable by construction (spec FR-43, RFC-0002; ADR-0056).
+ *
+ * Every value that will land in a header is validated here, so a `MailMessage` which exists is one a
+ * transport can hand over without re-checking anything. Addresses arrive as {@see EmailAddress} and
+ * are therefore already free of header terminators; the subject is checked here, because it is the
+ * one header value a caller supplies as free text.
+ *
+ * **Why the subject is refused rather than cleaned, and why waiting for PHP would not do.** Probed
+ * against a real SMTP transport, PHP's own handling of `CR`/`LF` depends on *which argument* carries
+ * them:
+ *
+ * | payload | what reached the wire |
+ * |---|---|
+ * | `CRLF` in `mail()`'s `$subject` | flattened to spaces — `Subject: a subject  Bcc: victim@…` |
+ * | `CRLF` in `mail()`'s `$to` | flattened — and the envelope got `RCPT TO:<to@…  Bcc: victim@…>` |
+ * | `CRLF` in an **array** header value | `ValueError`, nothing sent |
+ * | `CRLF` in a **string** header block | **honoured** — a second `RCPT TO:<victim@…>` was issued |
+ *
+ * So PHP does three different things with the same bytes, and the third is a working Bcc injection.
+ * Flattening is the interesting case: it is *safe* and it silently changes the caller's value, which
+ * is the shape spec §1 rejects everywhere else in this library (ADR-0037's CSV guard, ADR-0019's
+ * escaper). A message with a corrupted subject is not a message anyone asked to send.
+ *
+ * **Non-goals, stated so nobody looks for them:** no attachments, no arbitrary custom headers, no
+ * display names (see {@see EmailAddress}), no priority or read-receipt flags. Attachments and
+ * custom headers are where a MIME builder becomes a project; a consumer who needs them has outgrown
+ * this class and wants a mailer library behind {@see Mailer}.
+ */
+final class MailMessage
+{
+    /** RFC 2047 allows an encoded-word of at most 75 characters, delimiters included. */
+    private const ENCODED_WORD_LIMIT = 75;
+
+    /**
+     * @param list<EmailAddress> $to
+     * @param list<EmailAddress> $cc
+     * @param list<EmailAddress> $bcc
+     */
+    private function __construct(
+        public readonly EmailAddress $from,
+        public readonly array $to,
+        public readonly string $subject,
+        public readonly ?string $text,
+        public readonly ?string $html,
+        public readonly array $cc,
+        public readonly array $bcc,
+        public readonly ?EmailAddress $replyTo,
+    ) {
+    }
+
+    /**
+     * @param EmailAddress|list<EmailAddress> $to
+     * @param list<EmailAddress>              $cc
+     * @param list<EmailAddress>              $bcc
+     *
+     * @throws MailException if the subject carries a header terminator, if there is no recipient, or
+     *                       if the message has no body at all
+     */
+    public static function create(
+        EmailAddress $from,
+        EmailAddress|array $to,
+        string $subject,
+        ?string $text = null,
+        ?string $html = null,
+        array $cc = [],
+        array $bcc = [],
+        ?EmailAddress $replyTo = null,
+    ): self {
+        $recipients = $to instanceof EmailAddress ? [$to] : \array_values($to);
+
+        if ($recipients === []) {
+            throw new MailException(
+                'A message needs at least one recipient. An empty list would be handed to a '
+                . 'transport that reports success for delivering nothing to nobody.',
+            );
+        }
+
+        foreach (EmailAddress::FORBIDDEN as $character) {
+            if (\str_contains($subject, $character)) {
+                throw new MailException(\sprintf(
+                    'A subject may not contain %s. This is refused rather than stripped: PHP would '
+                    . 'flatten it to spaces on one transport path, throw on another and honour the '
+                    . 'injected header on a third (ADR-0056), and none of those is the message the '
+                    . 'caller wrote.',
+                    match ($character) {
+                        "\r" => 'a carriage return',
+                        "\n" => 'a line feed',
+                        default => 'a NUL byte',
+                    },
+                ));
+            }
+        }
+
+        if (($text === null || $text === '') && ($html === null || $html === '')) {
+            throw new MailException(
+                'A message needs a text body, an HTML body, or both. A message with neither is a '
+                . 'header set, and a transport would deliver it as an empty email rather than fail.',
+            );
+        }
+
+        return new self($from, $recipients, $subject, $text, $html, \array_values($cc), \array_values($bcc), $replyTo);
+    }
+
+    /**
+     * Every address that must receive the message — `to`, `cc` and `bcc` together.
+     *
+     * A transport needs this list for the envelope, and it is derived here so no transport has to
+     * remember that `bcc` is a delivery instruction rather than a header.
+     *
+     * @return non-empty-list<EmailAddress>
+     */
+    public function recipients(): array
+    {
+        /** @var non-empty-list<EmailAddress> $all */
+        $all = [...$this->to, ...$this->cc, ...$this->bcc];
+
+        return $all;
+    }
+
+    /**
+     * The subject as a header value: unchanged when it is 7-bit ASCII, RFC 2047 encoded-words when
+     * it is not.
+     *
+     * A header is 7-bit by RFC 5322, so a non-ASCII subject cannot be sent literally — it arrives as
+     * mojibake or is mangled by a relay. The encoding is hand-rolled base64 encoded-words rather
+     * than `mb_encode_mimeheader()`, because `mbstring` is not a declared dependency of this library
+     * and ADR-0019 already refused to acquire one for a job PCRE could do.
+     *
+     * Long subjects are split across several encoded-words: RFC 2047 caps one at 75 characters
+     * including its delimiters, and a 30-character accented subject already produces 92. The split
+     * is on **byte boundaries of the decoded text**, chosen so no multi-byte character is cut in
+     * half — a cut character is the classic way an encoded subject renders as a replacement glyph.
+     */
+    public function encodedSubject(): string
+    {
+        if (\preg_match('/^[\x20-\x7E]*$/', $this->subject) === 1) {
+            return $this->subject;
+        }
+
+        // 'B' encoding, so the payload is base64: 4 output characters per 3 input bytes, and the
+        // wrapper '=?UTF-8?B?' + '?=' costs 12. Solve for the largest multiple of 3 that fits.
+        $budget = self::ENCODED_WORD_LIMIT - 12;
+        $chunk = (int) (\intdiv($budget, 4) * 3);
+
+        $words = [];
+        foreach (self::splitOnCharacterBoundaries($this->subject, $chunk) as $part) {
+            $words[] = '=?UTF-8?B?' . \base64_encode($part) . '?=';
+        }
+
+        // Folded with CRLF + a space: the one place this class emits CRLF, and it is the RFC 5322
+        // folding sequence rather than a value a caller supplied.
+        return \implode("\r\n ", $words);
+    }
+
+    /**
+     * @return non-empty-list<string>
+     */
+    private static function splitOnCharacterBoundaries(string $text, int $limit): array
+    {
+        $parts = [];
+        $current = '';
+
+        // Walks UTF-8 sequences rather than bytes: a continuation byte (10xxxxxx) never starts a
+        // part, so no character is split across two encoded-words.
+        foreach (\preg_split('//u', $text, -1, PREG_SPLIT_NO_EMPTY) ?: [] as $character) {
+            if ($current !== '' && \strlen($current) + \strlen($character) > $limit) {
+                $parts[] = $current;
+                $current = '';
+            }
+
+            $current .= $character;
+        }
+
+        $parts[] = $current;
+
+        /** @var non-empty-list<string> $parts */
+        return $parts;
+    }
+}

--- a/src/main/php/d4np/utils/Mail/Mailer.php
+++ b/src/main/php/d4np/utils/Mail/Mailer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Mail;
+
+use D4np\Utils\Support\MailException;
+
+/**
+ * The transport contract (spec FR-44, RFC-0002; ADR-0056).
+ *
+ * One method, no return value: a message was handed over or an exception says why not. There is no
+ * boolean, because the surveyed estate's mailer returned `false` for a malformed address and for an
+ * unreachable MTA alike, and a caller could act on neither.
+ *
+ * **This interface, not {@see NativeMailer}, is what application code should depend on.** It is the
+ * seam that makes the group's stated non-goal survivable: this library ships no SMTP client, so a
+ * consumer who needs authenticated submission, attachments or a queue implements `Mailer` over the
+ * library of their choice and changes no calling code. The seam is also what lets a test assert what
+ * *would* have been sent without a mail server — see `Fixture\RecordingMailer`.
+ *
+ * **"Handed over" is the whole promise.** A transport that returns without throwing has passed the
+ * message to something that accepted responsibility for it; whether it is ultimately delivered is
+ * not knowable at this boundary, by anyone, and an interface that implied otherwise would be lying.
+ */
+interface Mailer
+{
+    /**
+     * @throws MailException if the message could not be handed to the transport
+     */
+    public function send(MailMessage $message): void;
+}

--- a/src/main/php/d4np/utils/Mail/NativeMailApi.php
+++ b/src/main/php/d4np/utils/Mail/NativeMailApi.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Mail;
+
+/**
+ * {@see MailApi} over PHP's own `mail()` — the only place in this library that calls it.
+ *
+ * `mail()` reports a refusal two ways, and both are turned into `false` here so that
+ * {@see NativeMailer} has one thing to check: it returns `false` when the transport declines, and it
+ * **throws `ValueError`** when it considers an argument malformed (probed: a `CR`/`LF` or NUL in an
+ * array header value, a NUL in the subject, an invalid header name). The `ValueError` should be
+ * unreachable — {@see MailMessage} and {@see EmailAddress} refuse those bytes long before this point
+ * — and it is caught rather than left to escape, because "unreachable" is a claim about today's
+ * validation, while a `ValueError` from a logging or notification path is a fatal error in
+ * production.
+ */
+final class NativeMailApi implements MailApi
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function send(string $to, string $subject, string $message, array $headers, string $parameters): bool
+    {
+        try {
+            // @ suppresses the warning `mail()` emits when it cannot reach the MTA; the boolean is
+            // the signal, and NativeMailer turns it into an exception that names the recipients.
+            return $parameters === ''
+                ? @\mail($to, $subject, $message, $headers)
+                : @\mail($to, $subject, $message, $headers, $parameters);
+        } catch (\ValueError) {
+            return false;
+        }
+    }
+}

--- a/src/main/php/d4np/utils/Mail/NativeMailer.php
+++ b/src/main/php/d4np/utils/Mail/NativeMailer.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Mail;
+
+use D4np\Utils\Support\MailException;
+
+/**
+ * A {@see Mailer} over PHP's `mail()` (spec FR-44, RFC-0002; ADR-0056).
+ *
+ * **Headers are handed over as an array, never as a string block, and that is the security decision
+ * in this class.** Probed against a real SMTP transport: with the array form, PHP throws a
+ * `ValueError` on a `CR`/`LF` in a header value; with the string form it *parses* the injected header
+ * and issues a second `RCPT TO`, so a `Bcc:` smuggled into a `From:` value is delivered. This
+ * library validates before it ever gets there ({@see MailMessage}, {@see EmailAddress}), which makes
+ * the array form defence in depth rather than the defence — and defence in depth is exactly what one
+ * wants for the failure mode where a *future* edit loosens a validation.
+ *
+ * **Nothing global is mutated.** The surveyed estate configured its mailer with `ini_set()` calls at
+ * send time — `SMTP`, `sendmail_from` — which change the behaviour of every other `mail()` call in
+ * the process, including ones made by code that never asked. Where the MTA lives is deployment
+ * configuration (`php.ini`), and this class reads none of it: the only thing it configures is the
+ * **envelope sender**, and that is a constructor argument.
+ *
+ * **The envelope sender is a `sendmail` option and a no-op on some platforms.** It is passed as
+ * `mail()`'s fifth argument, which reaches the `sendmail` command line — so it applies where PHP is
+ * configured with `sendmail_path` and is ignored by the Windows SMTP transport. Stated because a
+ * silent no-op that only manifests on one platform is worse than a documented limit. It is safe to
+ * put on a command line for the reason it is typed: an {@see EmailAddress} cannot contain a space,
+ * a quote, a semicolon or a newline.
+ *
+ * **Bodies are base64-encoded**, and both bodies together become `multipart/alternative`. Base64
+ * rather than raw 8-bit because a header is 7-bit by RFC 5322 and a *body* line is capped at 998
+ * octets: a long UTF-8 paragraph sent raw is a message a relay may fold, mangle or reject, and the
+ * encoding removes the question rather than hoping about it.
+ */
+final class NativeMailer implements Mailer
+{
+    private readonly MailApi $api;
+
+    public function __construct(
+        private readonly ?EmailAddress $envelopeSender = null,
+        ?MailApi $api = null,
+    ) {
+        $this->api = $api ?? new NativeMailApi();
+    }
+
+    /**
+     * @throws MailException if the transport declined the message
+     */
+    public function send(MailMessage $message): void
+    {
+        [$body, $contentType] = $this->render($message);
+
+        $headers = [
+            'From' => $message->from->value,
+            'MIME-Version' => '1.0',
+            'Content-Type' => $contentType,
+            'Content-Transfer-Encoding' => 'base64',
+        ];
+
+        if ($message->replyTo !== null) {
+            $headers['Reply-To'] = $message->replyTo->value;
+        }
+
+        if ($message->cc !== []) {
+            $headers['Cc'] = self::join($message->cc);
+        }
+
+        // Bcc as a header of the array form is a *delivery instruction*: probed, PHP issues a
+        // `RCPT TO` for it and omits the header from the message it sends, which is the behaviour
+        // RFC 5322 asks for and the reason this is not done by hand.
+        if ($message->bcc !== []) {
+            $headers['Bcc'] = self::join($message->bcc);
+        }
+
+        $sent = $this->api->send(
+            self::join($message->to),
+            $message->encodedSubject(),
+            $body,
+            $headers,
+            $this->envelopeSender === null ? '' : '-f' . $this->envelopeSender->value,
+        );
+
+        if (!$sent) {
+            throw new MailException(\sprintf(
+                'The transport declined the message to %s. PHP\'s mail() reports a refused message '
+                . 'and an unreachable MTA identically, so this covers both: check the mail '
+                . 'configuration (sendmail_path, or SMTP and smtp_port) before the message.',
+                self::join($message->recipients()),
+            ));
+        }
+    }
+
+    /**
+     * @return array{string, string} the encoded body and the `Content-Type` that describes it
+     *
+     * @throws MailException
+     */
+    private function render(MailMessage $message): array
+    {
+        $text = $message->text;
+        $html = $message->html;
+
+        if ($text !== null && $text !== '' && $html !== null && $html !== '') {
+            $boundary = self::boundary();
+
+            $body = "--{$boundary}\r\n"
+                . "Content-Type: text/plain; charset=UTF-8\r\n"
+                . "Content-Transfer-Encoding: base64\r\n\r\n"
+                . self::encode($text) . "\r\n"
+                . "--{$boundary}\r\n"
+                . "Content-Type: text/html; charset=UTF-8\r\n"
+                . "Content-Transfer-Encoding: base64\r\n\r\n"
+                . self::encode($html) . "\r\n"
+                . "--{$boundary}--\r\n";
+
+            // The outer part is the multipart container, which is not itself base64 — so the
+            // envelope's Content-Transfer-Encoding is overridden here rather than left to describe
+            // a body it does not describe.
+            return [$body, \sprintf('multipart/alternative; boundary="%s"', $boundary)];
+        }
+
+        if ($html !== null && $html !== '') {
+            return [self::encode($html), 'text/html; charset=UTF-8'];
+        }
+
+        // MailMessage::create() refuses a message with neither body, so this branch has one.
+        return [self::encode((string) $text), 'text/plain; charset=UTF-8'];
+    }
+
+    /**
+     * A part separator that cannot occur in either body.
+     *
+     * **There is deliberately no check that it does not.** A body is attacker-controlled in any
+     * application that mails user-supplied text, so the obvious defensive move is to search both
+     * bodies for the boundary and refuse a collision — and that check would be unreachable code.
+     * The boundary is drawn from a CSPRNG *after* the bodies exist, so placing it in one requires
+     * guessing 128 bits that have not been generated yet; and being unreachable, the check could
+     * never be tested, only asserted about. ADR-0022 and item 12.1 removed guards a probe proved
+     * inert for the same reason: a defence nothing can trigger is documentation with a runtime cost,
+     * and it reads as though the surrounding code needed it.
+     */
+    private static function boundary(): string
+    {
+        return '=_' . \bin2hex(\random_bytes(16));
+    }
+
+    private static function encode(string $body): string
+    {
+        // RFC 2045 caps an encoded line at 76 characters; chunk_split() is exactly that rule.
+        return \rtrim(\chunk_split(\base64_encode($body), 76, "\r\n"), "\r\n");
+    }
+
+    /**
+     * @param list<EmailAddress> $addresses
+     */
+    private static function join(array $addresses): string
+    {
+        return \implode(', ', \array_map(static fn (EmailAddress $a): string => $a->value, $addresses));
+    }
+}

--- a/src/main/php/d4np/utils/Support/MailException.php
+++ b/src/main/php/d4np/utils/Support/MailException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Support;
+
+/**
+ * A message could not be built or could not be handed to a transport (spec FR-43/FR-44, RFC-0002;
+ * ADR-0056).
+ *
+ * Covers both halves of the `Mail` group, which are failures of different kinds on purpose:
+ *
+ * - **Construction** — an address that is not an address, a subject carrying CR, LF or NUL, a
+ *   message with no recipient and no body. These are *caller* errors, refused where the message is
+ *   assembled so that a `MailMessage` which exists is one a transport can send.
+ * - **Delivery** — `mail()` returned `false`, or refused the message itself. These are
+ *   *environment* failures, and they are the reason the group has an exception at all rather than a
+ *   boolean: the surveyed estate's mailer returned `false` for both a bad address and an
+ *   unreachable MTA, so no caller could tell a typo from an outage.
+ *
+ * A plain leaf on {@see UtilsException}, like {@see CryptoException}: nothing in this group needed
+ * a second failure kind to unify with, and the two above are distinguished by their message rather
+ * than by their class — a caller retries an outage and fixes a typo, and both decisions are made by
+ * a human reading the message, not by a `catch` block choosing between two types.
+ */
+final class MailException extends UtilsException
+{
+}

--- a/src/test/php/d4np/utils/Mail/EmailAddressTest.php
+++ b/src/test/php/d4np/utils/Mail/EmailAddressTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Mail;
+
+use D4np\Utils\Mail\EmailAddress;
+use D4np\Utils\Support\MailException;
+use D4np\Utils\Support\UtilsException;
+use D4np\Utils\Tests\Mail\Fixture\HeaderInjectionPayloads;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The address boundary (spec FR-43), and the first leg of suite T-10.
+ */
+#[CoversClass(EmailAddress::class)]
+#[Group('T-10')]
+final class EmailAddressTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function valid(): iterable
+    {
+        yield 'plain' => ['user@example.com'];
+        yield 'plus tag' => ['user+tag@example.com'];
+        yield 'dotted local' => ['first.last@example.com'];
+        yield 'subdomain' => ['user@mail.example.com'];
+        yield 'digits' => ['user123@example.com'];
+        yield 'dashed domain' => ['user@my-example.com'];
+        yield 'IP literal' => ['user@[127.0.0.1]'];
+        yield 'uppercase local' => ['User@example.com'];
+    }
+
+    #[DataProvider('valid')]
+    public function testAValidAddressIsCarriedUnchanged(string $address): void
+    {
+        self::assertSame($address, EmailAddress::of($address)->value);
+        self::assertSame($address, (string) EmailAddress::of($address));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalid(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'no at' => ['userexample.com'];
+        yield 'two ats' => ['user@@example.com'];
+        yield 'no local part' => ['@example.com'];
+        yield 'no domain' => ['user@'];
+        yield 'leading space' => [' user@example.com'];
+        yield 'trailing space' => ['user@example.com '];
+        yield 'inner space' => ['user name@example.com'];
+        yield 'quoted local part' => ['"user name"@example.com'];
+        yield 'display-name form' => ['User <user@example.com>'];
+        yield 'comma-separated pair' => ['a@example.com, b@example.com'];
+        yield 'non-ASCII local part' => ['utènte@example.com'];
+        yield 'bare hostname (stricter than RFC 5321)' => ['user@example'];
+    }
+
+    #[DataProvider('invalid')]
+    public function testAnInvalidAddressIsRefused(string $address): void
+    {
+        $this->expectException(MailException::class);
+
+        EmailAddress::of($address);
+    }
+
+    /**
+     * T-10's first surface. Every payload in the corpus, applied to a legitimate address.
+     */
+    #[DataProvider('injectionPayloads')]
+    public function testNoInjectionPayloadCanBecomeAnAddress(string $payload): void
+    {
+        $this->expectException(MailException::class);
+
+        EmailAddress::of($payload);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function injectionPayloads(): iterable
+    {
+        yield from HeaderInjectionPayloads::appliedTo('user@example.com');
+    }
+
+    /**
+     * The property that must survive every future change to the validation rules: **no instance can
+     * carry a header terminator.** Asserted against this class rather than against `filter_var()`'s
+     * current rule set, because the rule set is PHP's to change and this promise is the library's.
+     */
+    public function testTheForbiddenSetIsTheThreeHeaderTerminators(): void
+    {
+        self::assertSame(["\r", "\n", "\0"], EmailAddress::FORBIDDEN);
+    }
+
+    public function testTheRefusalMessageNamesTheOffendingCharacter(): void
+    {
+        foreach (["\r" => 'carriage return', "\n" => 'line feed', "\0" => 'NUL byte'] as $character => $name) {
+            try {
+                EmailAddress::of('user@example.com' . $character);
+                self::fail("a {$name} must be refused");
+            } catch (MailException $e) {
+                self::assertStringContainsString($name, $e->getMessage());
+            }
+        }
+    }
+
+    public function testTryOfReturnsNullInsteadOfThrowing(): void
+    {
+        self::assertNull(EmailAddress::tryOf('not an address'));
+        self::assertNull(EmailAddress::tryOf("user@example.com\r\nBcc: victim@example.com"));
+        self::assertSame('user@example.com', EmailAddress::tryOf('user@example.com')?->value);
+    }
+
+    public function testTheDomainIsLowerCasedAndTheLocalPartIsNot(): void
+    {
+        $address = EmailAddress::of('User.Name@Example.COM');
+
+        // RFC 5321: the domain is case-insensitive, the local part is not. Lower-casing the local
+        // part is a common habit that rewrites the address on hosts which honour the distinction.
+        self::assertSame('example.com', $address->domain());
+        self::assertSame('User.Name@Example.COM', $address->value);
+    }
+
+    public function testTheDomainOfAnAddressWithAnAtInTheLocalPartIsTheLastOne(): void
+    {
+        // filter_var() refuses an unquoted second '@', so the only way to hold one is an IP literal
+        // domain; strrpos() is what makes the last '@' the separator either way.
+        self::assertSame('[127.0.0.1]', EmailAddress::of('user@[127.0.0.1]')->domain());
+    }
+
+    public function testTheExceptionIsCatchableAsTheLibrarysRoot(): void
+    {
+        $this->expectException(UtilsException::class);
+
+        EmailAddress::of('nope');
+    }
+}

--- a/src/test/php/d4np/utils/Mail/Fixture/HeaderInjectionPayloads.php
+++ b/src/test/php/d4np/utils/Mail/Fixture/HeaderInjectionPayloads.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Mail\Fixture;
+
+/**
+ * The T-10 corpus: the ways a header terminator is smuggled into a mail field.
+ *
+ * Shared by every leg of the suite so that a payload added here is exercised against **all** the
+ * surfaces at once — item 10.5's lesson, where two suites carried two corpora and the newer one was
+ * weaker (`MutationBuilderTest`'s ten identifier payloads against `QueryBuilderTest`'s nineteen).
+ *
+ * The list is not a fuzzer: every entry is a shape published in an injection cheat sheet or observed
+ * in the wild, and each is named so a failure says which shape got through.
+ */
+final class HeaderInjectionPayloads
+{
+    /**
+     * Payloads that must never be accepted anywhere a header value is built. `%s` marks where a
+     * legitimate value goes, so one payload can be applied to an address, a subject or a name.
+     *
+     * @return array<string, string>
+     */
+    public static function all(): array
+    {
+        return [
+            'CRLF then Bcc' => "%s\r\nBcc: victim@example.com",
+            'CRLF then To' => "%s\r\nTo: victim@example.com",
+            'CRLF then Cc' => "%s\r\nCc: victim@example.com",
+            'bare LF then Bcc' => "%s\nBcc: victim@example.com",
+            'bare CR then Bcc' => "%s\rBcc: victim@example.com",
+            'double CRLF then a body' => "%s\r\n\r\nan injected body",
+            'CRLF then Content-Type' => "%s\r\nContent-Type: text/html",
+            'CRLF then MIME-Version' => "%s\r\nMIME-Version: 1.0",
+            'CRLF with folding whitespace' => "%s\r\n Bcc: victim@example.com",
+            'CRLF with a tab' => "%s\r\n\tBcc: victim@example.com",
+            'leading CRLF' => "\r\nBcc: victim@example.com%s",
+            'NUL then Bcc' => "%s\0Bcc: victim@example.com",
+            'NUL alone' => "%s\0",
+            'CR alone' => "%s\r",
+            'LF alone' => "%s\n",
+            'CRLF alone' => "%s\r\n",
+            'many CRLFs' => "%s\r\n\r\n\r\nBcc: victim@example.com",
+            'CRLF then a From override' => "%s\r\nFrom: spoofed@example.com",
+            'CRLF then Return-Path' => "%s\r\nReturn-Path: bounce@example.com",
+        ];
+    }
+
+    /**
+     * The corpus applied to one legitimate value.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function appliedTo(string $legitimate): iterable
+    {
+        foreach (self::all() as $label => $template) {
+            yield $label => [\str_replace('%s', $legitimate, $template)];
+        }
+    }
+
+    /**
+     * The strings a smuggled header would produce, for asserting absence at the transport boundary.
+     *
+     * @return list<string>
+     */
+    public static function forbiddenAtTheBoundary(): array
+    {
+        return ['victim@example.com', 'spoofed@example.com', 'bounce@example.com', 'an injected body'];
+    }
+}

--- a/src/test/php/d4np/utils/Mail/Fixture/RecordingMailApi.php
+++ b/src/test/php/d4np/utils/Mail/Fixture/RecordingMailApi.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Mail\Fixture;
+
+use D4np\Utils\Mail\MailApi;
+
+/**
+ * A {@see MailApi} that records what would have reached PHP's `mail()`.
+ *
+ * The suite's whole view of the transport boundary: it is what lets T-10 assert *which shape of
+ * headers* is handed over — the array form, which PHP validates — rather than only that an email
+ * appeared to send.
+ */
+final class RecordingMailApi implements MailApi
+{
+    /** @var list<array{to: string, subject: string, message: string, headers: array<string, string>, parameters: string}> */
+    public array $calls = [];
+
+    public function __construct(public bool $succeeds = true)
+    {
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function send(string $to, string $subject, string $message, array $headers, string $parameters): bool
+    {
+        $this->calls[] = [
+            'to' => $to,
+            'subject' => $subject,
+            'message' => $message,
+            'headers' => $headers,
+            'parameters' => $parameters,
+        ];
+
+        return $this->succeeds;
+    }
+
+    /**
+     * Everything a transport would put on the wire, flattened — the string an injection test wants to
+     * search. Header *names* are included, because a smuggled `Bcc` is a name, not a value.
+     *
+     * @return array{to: string, subject: string, message: string, headers: array<string, string>, parameters: string}
+     */
+    public function lastCall(): array
+    {
+        return $this->calls[\count($this->calls) - 1];
+    }
+
+    public function lastAsText(): string
+    {
+        $call = $this->lastCall();
+        $text = 'To: ' . $call['to'] . "\n" . 'Subject: ' . $call['subject'] . "\n";
+
+        foreach ($call['headers'] as $name => $value) {
+            $text .= $name . ': ' . $value . "\n";
+        }
+
+        return $text . "\n" . $call['message'] . "\n" . $call['parameters'];
+    }
+}

--- a/src/test/php/d4np/utils/Mail/MailMessageTest.php
+++ b/src/test/php/d4np/utils/Mail/MailMessageTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Mail;
+
+use D4np\Utils\Mail\EmailAddress;
+use D4np\Utils\Mail\MailMessage;
+use D4np\Utils\Support\MailException;
+use D4np\Utils\Tests\Mail\Fixture\HeaderInjectionPayloads;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Message construction (spec FR-43), and T-10's second leg — the subject, which is the one header
+ * value a caller supplies as free text.
+ */
+#[CoversClass(MailMessage::class)]
+#[Group('T-10')]
+final class MailMessageTest extends TestCase
+{
+    private function address(string $value = 'to@example.com'): EmailAddress
+    {
+        return EmailAddress::of($value);
+    }
+
+    private function message(string $subject = 'a subject', ?string $text = 'a body', ?string $html = null): MailMessage
+    {
+        return MailMessage::create($this->address('from@example.com'), $this->address(), $subject, $text, $html);
+    }
+
+    public function testAMessageCarriesWhatItWasGiven(): void
+    {
+        $message = MailMessage::create(
+            $this->address('from@example.com'),
+            [$this->address('one@example.com'), $this->address('two@example.com')],
+            'a subject',
+            'a text body',
+            '<p>an html body</p>',
+            [$this->address('cc@example.com')],
+            [$this->address('bcc@example.com')],
+            $this->address('reply@example.com'),
+        );
+
+        self::assertSame('from@example.com', $message->from->value);
+        self::assertSame(['one@example.com', 'two@example.com'], \array_map(
+            static fn (EmailAddress $a): string => $a->value,
+            $message->to,
+        ));
+        self::assertSame('a subject', $message->subject);
+        self::assertSame('a text body', $message->text);
+        self::assertSame('<p>an html body</p>', $message->html);
+        self::assertSame('cc@example.com', $message->cc[0]->value);
+        self::assertSame('bcc@example.com', $message->bcc[0]->value);
+        self::assertSame('reply@example.com', $message->replyTo?->value);
+    }
+
+    public function testASingleRecipientNeedsNoArray(): void
+    {
+        self::assertCount(1, $this->message()->to);
+    }
+
+    public function testRecipientsAreToPlusCcPlusBcc(): void
+    {
+        $message = MailMessage::create(
+            $this->address('from@example.com'),
+            $this->address('to@example.com'),
+            's',
+            'b',
+            null,
+            [$this->address('cc@example.com')],
+            [$this->address('bcc@example.com')],
+        );
+
+        // The envelope needs all three; that bcc is a delivery instruction rather than a header is
+        // the transport's business, and deriving the list here means no transport has to remember it.
+        self::assertSame(
+            ['to@example.com', 'cc@example.com', 'bcc@example.com'],
+            \array_map(static fn (EmailAddress $a): string => $a->value, $message->recipients()),
+        );
+    }
+
+    public function testAMessageWithNoRecipientIsRefused(): void
+    {
+        $this->expectException(MailException::class);
+        $this->expectExceptionMessage('at least one recipient');
+
+        MailMessage::create($this->address('from@example.com'), [], 's', 'b');
+    }
+
+    /**
+     * @return iterable<string, array{?string, ?string}>
+     */
+    public static function bodylessMessages(): iterable
+    {
+        yield 'both null' => [null, null];
+        yield 'both empty' => ['', ''];
+        yield 'text empty, html null' => ['', null];
+        yield 'text null, html empty' => [null, ''];
+    }
+
+    #[DataProvider('bodylessMessages')]
+    public function testAMessageWithNoBodyIsRefused(?string $text, ?string $html): void
+    {
+        $this->expectException(MailException::class);
+        $this->expectExceptionMessage('needs a text body, an HTML body, or both');
+
+        MailMessage::create($this->address('from@example.com'), $this->address(), 's', $text, $html);
+    }
+
+    public function testEitherBodyAloneIsEnough(): void
+    {
+        self::assertSame('only text', $this->message('s', 'only text')->text);
+        self::assertSame('<p>only html</p>', $this->message('s', null, '<p>only html</p>')->html);
+    }
+
+    /**
+     * **T-10's second surface.** Every payload in the corpus, applied to the subject — the field PHP
+     * would silently flatten to spaces rather than refuse (probed against a real SMTP transport).
+     */
+    #[DataProvider('injectionPayloads')]
+    public function testNoInjectionPayloadCanBecomeASubject(string $payload): void
+    {
+        $this->expectException(MailException::class);
+
+        $this->message($payload);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function injectionPayloads(): iterable
+    {
+        yield from HeaderInjectionPayloads::appliedTo('a subject');
+    }
+
+    public function testTheSubjectRefusalExplainsWhyItIsNotStripped(): void
+    {
+        try {
+            $this->message("a subject\r\nBcc: victim@example.com");
+            self::fail('a subject with CRLF must be refused');
+        } catch (MailException $e) {
+            // The message is the documentation a caller actually reads.
+            self::assertStringContainsString('refused rather than stripped', $e->getMessage());
+        }
+    }
+
+    /**
+     * A body may contain anything at all: it is not a header, and the transport encodes it. Asserted
+     * so that a future tightening of the subject rule is not copy-pasted onto the body, where it
+     * would refuse ordinary multi-line text.
+     */
+    public function testABodyMayContainNewlines(): void
+    {
+        $message = $this->message('s', "line one\r\nline two\n\nline four");
+
+        self::assertStringContainsString('line two', (string) $message->text);
+    }
+
+    public function testAnAsciiSubjectIsNotEncoded(): void
+    {
+        self::assertSame('a plain subject', $this->message('a plain subject')->encodedSubject());
+    }
+
+    public function testANonAsciiSubjectBecomesRfc2047EncodedWords(): void
+    {
+        $subject = 'Résumé';
+        $encoded = $this->message($subject)->encodedSubject();
+
+        self::assertStringStartsWith('=?UTF-8?B?', $encoded);
+        self::assertStringEndsWith('?=', $encoded);
+        // A header must be 7-bit per RFC 5322; that is the whole reason for the encoding.
+        self::assertMatchesRegularExpression('/^[\x20-\x7E\r\n]*$/', $encoded);
+        self::assertSame($subject, \base64_decode(\substr($encoded, 10, -2), true));
+    }
+
+    public function testALongNonAsciiSubjectIsSplitIntoSeveralEncodedWords(): void
+    {
+        // 60 accented characters: one encoded-word would be 92 characters against RFC 2047's 75.
+        $subject = \str_repeat('è', 60);
+        $encoded = $this->message($subject)->encodedSubject();
+
+        $words = \explode("\r\n ", $encoded);
+        self::assertGreaterThan(1, \count($words), 'a long subject must fold into several words');
+
+        $decoded = '';
+        foreach ($words as $word) {
+            self::assertLessThanOrEqual(75, \strlen($word), "encoded-word over RFC 2047's limit: {$word}");
+            self::assertStringStartsWith('=?UTF-8?B?', $word);
+            $decoded .= (string) \base64_decode(\substr($word, 10, -2), true);
+        }
+
+        self::assertSame($subject, $decoded, 'the folded words must reassemble to the subject');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function multiByteSubjects(): iterable
+    {
+        // The widths matter, and getting this wrong is how the test was vacuous on its first run.
+        // An encoded-word's payload is 45 bytes here (75 minus 12 of delimiters, rounded down to a
+        // multiple of 3 so base64 does not pad mid-word). 45 is divisible by 3, so a subject made
+        // only of 3-byte characters lands on a character boundary *by arithmetic* — and a byte-wise
+        // split passes. Two-byte and four-byte characters are what actually exercise the boundary.
+        yield 'two-byte (Latin-1 supplement)' => [\str_repeat('è', 60)];
+        yield 'four-byte (emoji)' => [\str_repeat('😀', 30)];
+        yield 'three-byte (aligns with the chunk size — kept as the easy case)' => [\str_repeat('日本語の件名', 12)];
+        yield 'mixed widths' => [\str_repeat('aè日😀', 20)];
+    }
+
+    /**
+     * The failure this split exists to avoid: a multi-byte character cut across two encoded-words
+     * decodes to a replacement glyph in every client.
+     */
+    #[DataProvider('multiByteSubjects')]
+    public function testNoMultiByteCharacterIsSplitAcrossWords(string $subject): void
+    {
+        $words = \explode("\r\n ", $this->message($subject)->encodedSubject());
+        $decoded = '';
+
+        foreach ($words as $word) {
+            $part = (string) \base64_decode(\substr($word, 10, -2), true);
+            // `//u` fails to compile against invalid UTF-8, which is the check — and it needs no
+            // mbstring, an extension this library has never declared (ADR-0019).
+            self::assertSame(1, \preg_match('//u', $part), 'a word decoded to invalid UTF-8');
+            $decoded .= $part;
+        }
+
+        // Reassembly alone would NOT catch a byte-wise split — concatenating byte chunks returns the
+        // same bytes — so it is asserted here as a companion to the per-word check, not instead of it.
+        self::assertSame($subject, $decoded);
+    }
+
+    public function testAnEmptySubjectIsAllowed(): void
+    {
+        // Unusual but legal, and not this class's business to police: a subject-less notification is
+        // a real thing, while a *corrupted* subject is not.
+        self::assertSame('', $this->message('')->encodedSubject());
+    }
+}

--- a/src/test/php/d4np/utils/Mail/NativeMailerTest.php
+++ b/src/test/php/d4np/utils/Mail/NativeMailerTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Tests\Mail;
+
+use D4np\Utils\Mail\EmailAddress;
+use D4np\Utils\Mail\Mailer;
+use D4np\Utils\Mail\MailMessage;
+use D4np\Utils\Mail\NativeMailer;
+use D4np\Utils\Support\MailException;
+use D4np\Utils\Tests\Mail\Fixture\HeaderInjectionPayloads;
+use D4np\Utils\Tests\Mail\Fixture\RecordingMailApi;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * The transport boundary (spec FR-44), and T-10's third leg — what reaches PHP's `mail()`.
+ */
+#[CoversClass(NativeMailer::class)]
+#[Group('T-10')]
+final class NativeMailerTest extends TestCase
+{
+    private RecordingMailApi $api;
+
+    protected function setUp(): void
+    {
+        $this->api = new RecordingMailApi();
+    }
+
+    private function address(string $value): EmailAddress
+    {
+        return EmailAddress::of($value);
+    }
+
+    /**
+     * @param list<EmailAddress> $cc
+     * @param list<EmailAddress> $bcc
+     */
+    private function message(
+        string $subject = 'a subject',
+        ?string $text = 'a text body',
+        ?string $html = null,
+        array $cc = [],
+        array $bcc = [],
+        ?EmailAddress $replyTo = null,
+    ): MailMessage {
+        return MailMessage::create(
+            $this->address('from@example.com'),
+            $this->address('to@example.com'),
+            $subject,
+            $text,
+            $html,
+            $cc,
+            $bcc,
+            $replyTo,
+        );
+    }
+
+    public function testIsAMailer(): void
+    {
+        self::assertInstanceOf(Mailer::class, new NativeMailer());
+    }
+
+    public function testTheEnvelopeCarriesTheRecipientsAndTheHeadersTheSender(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message());
+
+        $call = $this->api->lastCall();
+        self::assertSame('to@example.com', $call['to']);
+        self::assertSame('a subject', $call['subject']);
+        self::assertSame('from@example.com', $call['headers']['From']);
+    }
+
+    public function testCcAndBccBecomeHeadersAndReplyToIsOptional(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message(
+            cc: [$this->address('cc@example.com')],
+            bcc: [$this->address('bcc@example.com')],
+            replyTo: $this->address('reply@example.com'),
+        ));
+
+        $headers = $this->api->lastCall()['headers'];
+        // Bcc goes through as a header of the ARRAY form on purpose: probed, PHP issues a `RCPT TO`
+        // for it and omits it from the message it sends, which is what RFC 5322 asks for.
+        self::assertSame('cc@example.com', $headers['Cc']);
+        self::assertSame('bcc@example.com', $headers['Bcc']);
+        self::assertSame('reply@example.com', $headers['Reply-To']);
+    }
+
+    public function testNoReplyToHeaderWhenNoneWasGiven(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message());
+
+        self::assertArrayNotHasKey('Reply-To', $this->api->lastCall()['headers']);
+        self::assertArrayNotHasKey('Cc', $this->api->lastCall()['headers']);
+        self::assertArrayNotHasKey('Bcc', $this->api->lastCall()['headers']);
+    }
+
+    /**
+     * **The mechanism assertion this class exists for.** Both header shapes send a working email, and
+     * only the array form makes PHP validate: probed, an injected `CR`/`LF` in an array value throws
+     * a `ValueError`, while the same bytes in a string header block are *parsed* and a second
+     * `RCPT TO` is issued. No behavioural test can see the difference, so the shape is asserted
+     * directly (ADR-0027's rule).
+     */
+    public function testHeadersAreHandedOverAsAnArrayNeverAsAStringBlock(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message());
+
+        $headers = $this->api->lastCall()['headers'];
+        self::assertIsArray($headers);
+        self::assertNotSame([], $headers);
+
+        foreach ($headers as $name => $value) {
+            self::assertIsString($name, 'an array header must be keyed by its name');
+            self::assertStringNotContainsString(':', $name, "header name {$name} carries a colon");
+            self::assertDoesNotMatchRegularExpression('/[\r\n]/', $value, "header {$name} carries a terminator");
+        }
+
+        // And the seam's own signature keeps it that way: a `string` here would let a future edit
+        // build a header block by hand without any test noticing.
+        $parameter = (new ReflectionMethod($this->api, 'send'))->getParameters()[3];
+        self::assertSame('array', (string) $parameter->getType());
+    }
+
+    /**
+     * T-10's third surface: the corpus reaching the transport. Every payload is refused upstream, so
+     * the assertion is that **no call happens at all** — the strongest form, since a refusal after
+     * the transport was invoked would already have sent something.
+     */
+    #[DataProvider('injectionPayloads')]
+    public function testNoInjectionPayloadEverReachesTheTransport(string $payload): void
+    {
+        $mailer = new NativeMailer(null, $this->api);
+
+        // Through the subject...
+        try {
+            $mailer->send($this->message($payload));
+        } catch (MailException) {
+            // expected
+        }
+
+        // ...and through every address field.
+        foreach (['from', 'to', 'cc', 'bcc', 'replyTo'] as $field) {
+            try {
+                $address = EmailAddress::of(\str_replace('a subject', 'user@example.com', $payload));
+                $mailer->send(match ($field) {
+                    'from' => MailMessage::create($address, $this->address('to@example.com'), 's', 'b'),
+                    'to' => MailMessage::create($this->address('from@example.com'), $address, 's', 'b'),
+                    'cc' => MailMessage::create($this->address('from@example.com'), $this->address('to@example.com'), 's', 'b', null, [$address]),
+                    'bcc' => MailMessage::create($this->address('from@example.com'), $this->address('to@example.com'), 's', 'b', null, [], [$address]),
+                    default => MailMessage::create($this->address('from@example.com'), $this->address('to@example.com'), 's', 'b', null, [], [], $address),
+                });
+            } catch (MailException) {
+                // expected
+            }
+        }
+
+        self::assertSame([], $this->api->calls, 'a payload reached the transport');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function injectionPayloads(): iterable
+    {
+        yield from HeaderInjectionPayloads::appliedTo('a subject');
+    }
+
+    /**
+     * The vacuity guard for the test above: with a legitimate message the transport *is* called, so
+     * "no call happened" means something.
+     */
+    public function testALegitimateMessageDoesReachTheTransport(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message());
+
+        self::assertCount(1, $this->api->calls);
+        foreach (HeaderInjectionPayloads::forbiddenAtTheBoundary() as $forbidden) {
+            self::assertStringNotContainsString($forbidden, $this->api->lastAsText());
+        }
+    }
+
+    public function testATextOnlyMessageIsBase64EncodedAndDeclaredAsSuch(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message('s', 'a text body'));
+
+        $call = $this->api->lastCall();
+        self::assertSame('text/plain; charset=UTF-8', $call['headers']['Content-Type']);
+        self::assertSame('base64', $call['headers']['Content-Transfer-Encoding']);
+        self::assertSame('1.0', $call['headers']['MIME-Version']);
+        self::assertSame('a text body', \base64_decode(\str_replace("\r\n", '', $call['message']), true));
+    }
+
+    public function testAnHtmlOnlyMessageDeclaresTextHtml(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message('s', null, '<p>hello</p>'));
+
+        $call = $this->api->lastCall();
+        self::assertSame('text/html; charset=UTF-8', $call['headers']['Content-Type']);
+        self::assertSame('<p>hello</p>', \base64_decode(\str_replace("\r\n", '', $call['message']), true));
+    }
+
+    public function testBothBodiesBecomeMultipartAlternativeWithBothPartsIntact(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message('s', 'the text', '<p>the html</p>'));
+
+        $call = $this->api->lastCall();
+        self::assertMatchesRegularExpression(
+            '#^multipart/alternative; boundary="=_[0-9a-f]{32}"$#',
+            $call['headers']['Content-Type'],
+        );
+
+        // Sliced rather than captured: the assertion above already pinned the header's exact shape,
+        // and a `preg_match()` capture would leave PHPStan unable to prove the offset exists.
+        $boundary = \substr($call['headers']['Content-Type'], \strlen('multipart/alternative; boundary="'), -1);
+
+        self::assertStringContainsString("--{$boundary}\r\n", $call['message']);
+        self::assertStringContainsString("--{$boundary}--", $call['message']);
+        self::assertStringContainsString('text/plain; charset=UTF-8', $call['message']);
+        self::assertStringContainsString('text/html; charset=UTF-8', $call['message']);
+
+        // Both parts must survive the encoding, or the alternative is one body and a mystery.
+        self::assertStringContainsString(\base64_encode('the text'), $call['message']);
+        self::assertStringContainsString(\base64_encode('<p>the html</p>'), $call['message']);
+    }
+
+    public function testTheBoundaryIsFreshEveryTime(): void
+    {
+        $mailer = new NativeMailer(null, $this->api);
+        $mailer->send($this->message('s', 'a', '<p>b</p>'));
+        $mailer->send($this->message('s', 'a', '<p>b</p>'));
+
+        self::assertNotSame(
+            $this->api->calls[0]['headers']['Content-Type'],
+            $this->api->calls[1]['headers']['Content-Type'],
+        );
+    }
+
+    public function testEncodedBodyLinesRespectRfc2045sSeventySixCharacterLimit(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message('s', \str_repeat('a body that is long. ', 40)));
+
+        foreach (\explode("\r\n", $this->api->lastCall()['message']) as $line) {
+            self::assertLessThanOrEqual(76, \strlen($line));
+        }
+    }
+
+    public function testTheEnvelopeSenderIsPassedAsASendmailOptionOnlyWhenConfigured(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message());
+        self::assertSame('', $this->api->lastCall()['parameters']);
+
+        (new NativeMailer($this->address('bounce@example.com'), $this->api))->send($this->message());
+        self::assertSame('-fbounce@example.com', $this->api->lastCall()['parameters']);
+    }
+
+    /**
+     * The envelope sender reaches a command line on a sendmail host, so it is worth asserting that
+     * nothing shell-significant can appear in it. It cannot, because it is an `EmailAddress` — this
+     * pins the reason rather than the mechanism.
+     */
+    public function testTheEnvelopeSenderCannotCarryShellSignificantCharacters(): void
+    {
+        foreach (['a@b.com; rm -rf /', 'a@b.com`id`', 'a@b.com $(id)', "a@b.com\nX: y", 'a@b.com|tee'] as $hostile) {
+            self::assertNull(EmailAddress::tryOf($hostile), "an EmailAddress must refuse: {$hostile}");
+        }
+    }
+
+    public function testADeclinedMessageThrowsAndNamesEveryRecipient(): void
+    {
+        $api = new RecordingMailApi(succeeds: false);
+
+        try {
+            (new NativeMailer(null, $api))->send($this->message(
+                cc: [$this->address('cc@example.com')],
+                bcc: [$this->address('bcc@example.com')],
+            ));
+            self::fail('a declined message must throw');
+        } catch (MailException $e) {
+            self::assertStringContainsString('to@example.com', $e->getMessage());
+            self::assertStringContainsString('cc@example.com', $e->getMessage());
+            self::assertStringContainsString('bcc@example.com', $e->getMessage());
+            // The two indistinguishable causes are named, since mail() cannot tell them apart.
+            self::assertStringContainsString('sendmail_path', $e->getMessage());
+        }
+    }
+
+    public function testANonAsciiSubjectIsHandedOverEncoded(): void
+    {
+        (new NativeMailer(null, $this->api))->send($this->message('Résumé'));
+
+        $subject = $this->api->lastCall()['subject'];
+        self::assertStringStartsWith('=?UTF-8?B?', $subject);
+        self::assertSame('Résumé', \base64_decode(\substr($subject, 10, -2), true));
+    }
+
+    public function testMultipleRecipientsAreCommaSeparated(): void
+    {
+        (new NativeMailer(null, $this->api))->send(MailMessage::create(
+            $this->address('from@example.com'),
+            [$this->address('one@example.com'), $this->address('two@example.com')],
+            's',
+            'b',
+        ));
+
+        self::assertSame('one@example.com, two@example.com', $this->api->lastCall()['to']);
+    }
+}

--- a/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
+++ b/src/test/php/d4np/utils/Support/ExceptionHierarchyTest.php
@@ -13,6 +13,7 @@ use D4np\Utils\Support\HttpException;
 use D4np\Utils\Support\HydrationException;
 use D4np\Utils\Support\InvalidUrlException;
 use D4np\Utils\Support\JsonException;
+use D4np\Utils\Support\MailException;
 use D4np\Utils\Support\MethodNotAllowedException;
 use D4np\Utils\Support\MissingKeyException;
 use D4np\Utils\Support\RouteNotFoundException;
@@ -101,6 +102,7 @@ final class ExceptionHierarchyTest extends TestCase
                 HydrationException::class,
                 InvalidUrlException::class,
                 JsonException::class,
+                MailException::class,
                 MethodNotAllowedException::class,
                 MissingKeyException::class,
                 RouteNotFoundException::class,
@@ -181,6 +183,7 @@ final class ExceptionHierarchyTest extends TestCase
             HttpClientException::class,
             InvalidUrlException::class,
             JsonException::class,
+            MailException::class,
             MethodNotAllowedException::class,
             MissingKeyException::class,
             RouteNotFoundException::class,


### PR DESCRIPTION
## Summary

Roadmap item **12.4** — RFC-0002's eighth group: `Mail\{EmailAddress, MailMessage, Mailer,
NativeMailer, MailApi, NativeMailApi}`, `Support\MailException`, a Support-only `Mail` deptrac layer,
the **T-10** header-injection corpus, and **ADR-0056**.

Replaces the surveyed estate's mailer, which called `ini_set('SMTP', …)` immediately before `mail()`
and interpolated the recipient and subject from request data with no check on either.

## Motivation, and the probe that decided the design

`mail()` cannot reach an MTA on the development machine, so it returns `false` for every input —
which makes it useless as an oracle: *"PHP rejected the payload"* and *"PHP accepted it and the
transport failed"* are the same observation. So the item was probed against a **real SMTP sink on
`127.0.0.1`**, and PHP turns out to do three different things with the same three bytes:

| payload | what reached the wire |
|---|---|
| `CRLF` in `mail()`'s `$subject` | **flattened to spaces** — `Subject: a subject  Bcc: victim@example.com` |
| `CRLF` in `mail()`'s `$to` | flattened — envelope carried `RCPT TO:<to@example.com  Bcc: victim@…>` |
| `CRLF` in an **array** header value | `ValueError`, nothing sent |
| NUL in a header or the subject | `ValueError` |
| `CRLF` in a **string** header block | **honoured — a second `RCPT TO:<victim@…>` was issued** |

The last row is a working Bcc injection, and it is not a PHP defect: a string header block *is* the
documented way to add a `Bcc`, so PHP parsed exactly what it was handed.

Two decisions follow directly:

1. **Refuse `CR`/`LF`/NUL at construction** (ADR-0025's stance on the other protocol). A library
   relying on PHP's checks would be safe on one path, silently lossy on another, injectable on the
   third. Flattening is the interesting case — *safe* and a silent data change, which is the trade
   this library refuses everywhere else (ADR-0037's CSV guard, ADR-0019's escaper).
2. **Hand `mail()` an array, never a string block** — the shape PHP validates. With our own refusal
   upstream this is defence in depth, which is what one wants for the day someone loosens a
   validation. Both shapes send a working email, so it is asserted as a **mechanism** through a
   `MailApi` seam (ADR-0026's `SessionApi` shape, ADR-0027's rule), including that the seam's fourth
   parameter is typed `array` so a future edit cannot quietly build a block by hand.

`Bcc` goes through as an array header because — probed — PHP issues a `RCPT TO` for it **and omits
the header from the message it sends**, which is what RFC 5322 asks for.

## A defence written and then deleted

`multipart/alternative` needs a boundary, and a body is attacker-controlled in any application that
mails user-supplied text — so the obvious move is to refuse a boundary that occurs in a body. I wrote
it, then noticed it can never run: the boundary is drawn from a CSPRNG **after** the bodies exist, so
placing it in one means guessing 128 bits that do not exist yet. Unreachable code cannot be tested,
only asserted about. Removed on ADR-0022's and item 12.1's precedent, with the reasoning kept in the
ADR.

## The corpus that could not fail

**15 defects planted, 14 caught.** The miss is the part worth review attention:

Splitting the encoded subject on **bytes** rather than characters — the exact bug that renders a
subject as replacement glyphs — **passed the suite**. The multi-byte test used only three-byte
characters (`日本語の件名`), and an encoded-word's payload here is **45 bytes** (75 minus 12 of
delimiters, rounded down to a multiple of 3 so base64 does not pad mid-word). 45 is divisible by 3, so
every split landed on a character boundary *by arithmetic*. Reassembly assertions could not have
caught it either: concatenating byte chunks returns the same bytes.

The test now covers two-byte, four-byte and mixed-width subjects, and the plant is caught. Rule worth
keeping: **a corpus whose members all share one width cannot test a boundary computed in that width**
— the same failure as a benchmark measuring the wrong shape (ADR-0018/0020).

The 15th plant was **not a defect**: lower-casing an address before slicing off the domain is
byte-for-byte equivalent to slicing then lower-casing, since `strtolower()` preserves length.

## Changes

- `Mail/EmailAddress.php` — validated value object; `of()` throws, `tryOf()` returns null; `domain()`
  lower-cases only the domain (RFC 5321: the local part is case-**sensitive**).
- `Mail/MailMessage.php` — readonly message; refuses a terminator in the subject, an empty recipient
  list and a body-less message; `recipients()` derives the envelope; `encodedSubject()` does RFC 2047.
- `Mail/Mailer.php`, `Mail/NativeMailer.php` — the transport contract and the `mail()` implementation.
- `Mail/MailApi.php`, `Mail/NativeMailApi.php` — the seam and its real implementation.
- `Support/MailException.php` — added to **both** pinned lists in `ExceptionHierarchyTest`.
- `deptrac.yaml` — the `Mail` layer, Support-only and **deliberately not reaching `Errors`** (a
  transport that logged its own failures would invert ADR-0029). Proved by planting a
  `Mail → Errors` type dependency: 2 violations, restored to 0.
- Tests: `EmailAddressTest`, `MailMessageTest`, `NativeMailerTest`, `Fixture\{RecordingMailApi,
  HeaderInjectionPayloads}` — the corpus is **shared** across all three legs, item 10.5's lesson about
  two suites carrying two corpora.

**Two honest limits, documented on the classes rather than left to be discovered:** `filter_var()`
refuses `user@example` (a bare hostname, legal per RFC 5321 and used by real intranet addresses); and
the envelope sender reaches a `sendmail` command line, so it is **a no-op on the Windows SMTP
transport**. It is safe on that command line for a reason worth naming — it is an `EmailAddress`, and
one cannot contain a space, a quote, a semicolon or a newline, so the type *is* the argument-injection
defence.

## Design Patterns

- **None claimed.** `Mailer` is an interface over a transport and `MailApi` is a test seam; neither is
  a deliberate pattern adoption, and ADR-0026's `SessionApi` set the precedent of not claiming one.
  Recorded in the ADR so the absence is a decision rather than an omission (§8).

## Verification

- [x] **2831 tests / 6022 assertions**; `--group T-10` = **119 tests**. 9 pre-existing local skips
      (no fileinfo/coverage driver on this box; CI certifies both)
- [x] Planted-defect campaign — 14/15; the two anomalies analysed above rather than reported as counts
- [x] Deptrac **342 allowed / 0 uncovered / 0 violations**, and the new layer proved failable
- [x] PHPStan max clean (its two findings were fixed by narrowing and by slicing instead of a
      `preg_match` capture — no cast, no ignore) · PHP-CS-Fixer clean
- [x] `python tools/consistency_lint.py` OK
- [x] Coverage ≥ 90% green; matrix green on **8.1/8.2/8.3**; mutation green (566 mutants killed).
      Item 12.3's lesson applied: nothing here uses a version-sensitive construct, and the 8.1 cell
      is what settles that rather than my say-so.
- [ ] `benchmark / reproducible perf` — **red, and not attributable to this diff.** My first
      prediction was wrong twice over, so here is what actually happened across **two runs of the
      same commit**:

      | | run 1 | run 2 |
      |---|---|---|
      | relative gate (>10% vs base) | **FAIL** — 5 subjects +11.19%…+19.44% | passed |
      | absolute ceilings | all ok (router **4.735** ≤ 5) | **FAIL** — router **7.021** > 5 (item 11.7) |
      | `benchWriteTenThousandByTen` | 9 691 µs | 19 660 µs |

      Every subject in run 2 is **27–103% slower** on identical code, so run 2 met a slow runner. And
      run 1's five "regressions" include `RowNormalizerBench::benchInlineTrimHundredRows` — **the
      control**, a hand-written inline `trim()` loop that calls no library code and therefore cannot
      regress. Both failures are the runner; re-running did not clear it, it moved which gate noticed.

      Mechanism: ADR-0030's same-runner A/B measures base and head **sequentially**, so a runner that
      changes speed *between the halves* shifts every subject one way. ADR-0045's exclusions name
      three subjects for *cross-run* noise and do not cover this, which moves everything.

      **Filed as item 12.6** (four options, no decision taken — ADR-0040 reserves gate numbers), and
      the router evidence appended to **item 11.7**: five runs on unmodified `Router` code now read
      6.874–7.145 / 5.188 / 5.673 / 4.735 / 7.021 µs, once *inside* the ceiling. The mean is still
      over with a known cause, but a ceiling that close to the runner's variance flaps rather than
      fails, which is worth knowing before picking (a) or (b) there. **No benchmark subject is added
      by this item, and no gate or budget was touched.**

## Documentation Impact

- [ ] README.md — unchanged; M12's row stays "planned" until 12.5 lands (`consistency_lint` enforces
      this, so it cannot be faked)
- [x] ROADMAP.md — 12.4 checked with its retrospective; Spec Coverage Map §6 and §7 updated; **item
      12.6 filed** and evidence appended to **item 11.7** (see the benchmark note above)
- [x] ADR — **ADR-0056**, indexed
- [ ] docs/patterns/README.md — unchanged (see Design Patterns)
- [x] Spec — **deliberately unchanged**: FR-43, FR-44 and T-10 were implementable as written, the
      second item in a row
- [x] CHANGELOG.md — Added, with the three behaviours a consumer needs to know before wiring a channel
- [x] PR metadata — assignee (owner), label `enhancement`, milestone `v0.11.0`

## Lesson

Lesson: an oracle that cannot fail is worse than no oracle. `mail()` returning `false` for every
input made two probe rounds unable to answer their own question, and a corpus of uniformly-3-byte
characters made a test unable to fail — both looked like evidence, and the fix in both cases was to
remove the thing that made every answer identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
