### PR TITLE
perf(security): NFR-13 benchmark, and a control that doesn't need a sibling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
         if: steps.cfg.outputs.present == 'true'
         shell: bash
         run: |
-          python3 tools/bench_budget_gate.py build/logs/head.xml             --budget benchHydrateWarm=5             --budget benchBuildFiveConditionSelect=10             --budget benchWarmSingletonResolve=2             --budget benchFirstAutowiredResolve=30             --budget benchSequenceNext=200             --budget benchWriteTenThousandByTen=150000             --budget benchDispatchLastOfFiftyRoutes=5             --budget benchEnvelopeBuild=2             --budget benchSuppressedRecord=0.5
+          python3 tools/bench_budget_gate.py build/logs/head.xml             --budget benchHydrateWarm=5             --budget benchBuildFiveConditionSelect=10             --budget benchWarmSingletonResolve=2             --budget benchFirstAutowiredResolve=30             --budget benchSequenceNext=200             --budget benchWriteTenThousandByTen=150000             --budget benchDispatchLastOfFiftyRoutes=5             --budget benchEnvelopeBuild=2             --budget benchSuppressedRecord=0.5             --budget benchCryptoRoundTrip=60
       - name: NFR-01 ratio — hydration vs manual construction
         if: steps.cfg.outputs.present == 'true'
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,8 @@ jobs:
             --budget benchWriteTenThousandByTen=150000 \
             --budget benchDispatchLastOfFiftyRoutes=5 \
             --budget benchEnvelopeBuild=2 \
-            --budget benchSuppressedRecord=0.5
+            --budget benchSuppressedRecord=0.5 \
+            --budget benchCryptoRoundTrip=60
 
       - name: NFR-01 ratio — hydration vs manual construction
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **phpbench benchmark for NFR-13** (spec §4, RFC-0002; roadmap item **12.5**): `CryptoBench`
+  under `src/bench/php/d4np/utils/`, wired into `bench_budget_gate.py` in both `ci.yml` and
+  `nightly.yml` (`benchCryptoRoundTrip=60`). Measures `Crypto::encrypt()` immediately followed
+  by `decrypt()` on a 1 KiB payload — the round trip the spec names, since `decrypt()` cannot be
+  measured honestly without a real token a matching `encrypt()` call produced. No new control
+  subject: `RowNormalizerBench::benchInlineTrimHundredRows` already serves that role for this
+  benchmark job (one control per CI job, not one per file — item 12.4's finding, filed as item
+  **12.6**). This does not close Milestone 12: item 12.6 remains open.
+
 - **`D4np\Utils\Mail\` — the `Mail` group**: `EmailAddress`, `MailMessage`, the `Mailer` interface
   and `NativeMailer` over PHP's `mail()`, with `D4np\Utils\Support\MailException` joining the
   exception hierarchy (spec FR-43/FR-44, RFC-0002; roadmap item **12.4**; **ADR-0056**). It replaces

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,9 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-08 — Three answers to the same bytes, and a corpus that could not fail](docs/journal/2026/08/2026-08-08-mail-group.md).
+  [2026-08-08 — The last planned item, and the milestone that still doesn't close](docs/journal/2026/08/2026-08-08-crypto-benchmark.md).
   Previous:
+  [2026-08-08 — Three answers to the same bytes, and a corpus that could not fail](docs/journal/2026/08/2026-08-08-mail-group.md),
   [2026-08-08 — The idiomatic enum was too slow, and one of my own arguments was dead](docs/journal/2026/08/2026-08-08-logging-channels.md),
   [2026-08-07 — A tag that shrinks, a key nobody checks, and a guard that never fired](docs/journal/2026/08/2026-08-07-crypto.md).
 
@@ -1417,8 +1418,29 @@ AEAD crypto, PSR-3 channel composition, and the Mail group (RFC-0002 FR-40…FR-
       width** — the same failure class as a benchmark measuring the wrong shape (ADR-0018/0020). The
       15th "miss" was not a defect: lower-casing before slicing the domain is byte-equivalent to
       slicing then lower-casing.*
-- [ ] 12.5 phpbench: NFR-13 (crypto 1 KiB round-trip) (RFC-0002) (step:optimize) — size: XS ·
-      route: fast / medium
+- [x] 12.5 phpbench: NFR-13 (crypto 1 KiB round-trip) (RFC-0002) (step:optimize) — size: XS ·
+      route: fast / medium *(session model matched the route — Sonnet 5)*. *`CryptoBench::
+      benchCryptoRoundTrip()` measures `Crypto::encrypt()` immediately followed by `decrypt()` on a
+      1 KiB payload — the round trip the spec names, not either half alone: `decrypt()` cannot be
+      measured honestly without a real token (a hand-built or cached ciphertext would skip the nonce
+      generation and tag verification a real call pays for). Local sanity (informative only, this
+      box's own CLI capture is broken per the standing note — direct `hrtime()` timing instead):
+      **~14 µs**, comfortable headroom under the 60 µs ceiling and nowhere near NFR-11's
+      knife-edge. Budget wired into `ci.yml`/`nightly.yml`'s existing `bench_budget_gate.py`
+      invocation (`benchCryptoRoundTrip=60`), not a `Bench\Assert` — one home per number, the
+      pattern every prior bench item in this milestone kept. **No new control subject**: item
+      12.4's finding (filed as 12.6) is that a run-wide runner slowdown moves every subject in one
+      CI job together, and `RowNormalizerBench::benchInlineTrimHundredRows` already serves that
+      role for this benchmark job — one control per job, not one per file. No ADR: this item wires
+      an existing spec number into the existing harness, the same shape as items 9.6 and 11.5,
+      neither of which needed one either.*
+      ***M12's planned scope is now complete — but the milestone stays open.*** *README's M12 row
+      stays "⏳ planned" and `consistency_lint`'s milestone check enforces that structurally: item
+      12.6, filed at item 12.4, is unchecked, so the milestone cannot be marked done by mistake
+      even if someone tried. This is the same shape M11 closed in — 11.4/11.5 finished the planned
+      work while 11.6/11.7 stayed open — except M11's two open items are both maintainer decisions
+      on numbers, while 12.6 is a decision on the **gate's own design** (does a control-subject
+      breach invalidate a run, and if so, how).*
 - [ ] 12.6 Decide how the **relative** benchmark gate should treat a run-wide slowdown. Filed from
       item 12.4's CI, where the *same commit* failed **two different gates on two runs** and neither
       failure was attributable to the diff (a new `Mail` group nothing else imports). Run 1: the

--- a/docs/journal/2026/08/2026-08-08-crypto-benchmark.md
+++ b/docs/journal/2026/08/2026-08-08-crypto-benchmark.md
@@ -1,0 +1,43 @@
+# 2026-08-08 — The last planned item, and the milestone that still doesn't close
+
+Roadmap item **12.5**, `CryptoBench` for NFR-13. Route `fast / medium`; the session model was
+switched to Sonnet 5 immediately before this item — first match this milestone rather than a
+recorded mismatch.
+
+Small on purpose. The spec names one number — a 1 KiB `Crypto` encrypt+decrypt round trip,
+≤ 60 µs — and the class does exactly that: one subject, the round trip rather than either half
+alone, because `decrypt()` cannot be measured honestly without a real token a matching
+`encrypt()` produced. Local sanity (this box's phpbench CLI has a standing, documented capture
+bug, so direct `hrtime()` timing stood in): **~14 µs**, comfortable headroom, nowhere near the
+knife-edge item 11.7 lives on.
+
+## The decision that wasn't made twice
+
+Two things this item did *not* add, both because yesterday's item already settled them.
+
+**No `Bench\Assert`.** The budget lives in `bench_budget_gate.py`'s CI/nightly invocation, same as
+every prior item this milestone — one home per number, so a future reader checking "what is
+NFR-13's ceiling" has exactly one place to look instead of two that could disagree.
+
+**No new control subject.** Item 12.4 found that a run-wide runner slowdown moves *every* subject
+in one CI job together — control included — and filed the fix as item 12.6.
+`RowNormalizerBench::benchInlineTrimHundredRows` already plays that role for this job. Adding a
+second control here would not catch anything the first one doesn't; it would just be a second
+copy of the same signal in the same log.
+
+## The milestone stays open
+
+M12's *planned* scope is done, and `README.md`'s row for it stays "⏳ planned" anyway —
+`consistency_lint`'s milestone check enforces that structurally, since item 12.6 (filed at 12.4)
+is still an unchecked `- [ ]`. Same shape M11 closed in: 11.4/11.5 finished the written work while
+11.6/11.7 stayed open as maintainer decisions on numbers. 12.6 is a different kind of open item —
+not a number to pick, but a question about the gate's own design (does a control-subject breach
+invalidate a run, or does the comparison itself need to change) — and it is exactly the item this
+session filed the evidence for a few hours ago.
+
+## Lesson
+
+Not every item needs its own instrument. The temptation, having just learned that a control
+subject would have saved a wrong diagnosis, is to add one everywhere. The right scope is one per
+place the signal actually differs — here, one per CI job, because that is the granularity at which
+"the runner got slow" is true or false.

--- a/src/bench/php/d4np/utils/CryptoBench.php
+++ b/src/bench/php/d4np/utils/CryptoBench.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace D4np\Utils\Bench;
+
+use D4np\Utils\Security\Crypto;
+use D4np\Utils\Security\SecretKey;
+use PhpBench\Attributes as Bench;
+
+/**
+ * NFR-13: a 1 KiB `Crypto` encrypt+decrypt round-trip in ≤ 60 µs (roadmap item 12.5, RFC-0002).
+ *
+ * **The round trip, not the two halves separately.** The spec names one number for
+ * encrypt-then-decrypt, and every prior instance of this pattern in this project (NFR-01's
+ * hydration, NFR-09's gateway) budgets the operation a consumer actually performs rather than
+ * a half nobody calls alone. `Crypto::decrypt()` cannot be measured without a real token to feed
+ * it, so a round trip is also the only shape that measures decryption honestly — a hand-built or
+ * cached ciphertext would skip the nonce generation and tag verification the real call pays for.
+ *
+ * **1 KiB is the size the spec names**, not a size chosen for convenience — GCM's cost is
+ * dominated by AES-NI throughput once the fixed per-call overhead (nonce generation,
+ * base64url encode/decode, tag slicing) is paid, so the ratio between those two costs is what a
+ * different size would change, not a number this class controls.
+ *
+ * **No separate control subject.** Item 12.4's finding (ADR pending as item 12.6) was that a
+ * run-wide runner slowdown moves *every* subject in one CI job together, and
+ * `RowNormalizerBench::benchInlineTrimHundredRows` already serves that role for this benchmark
+ * job — one control per job is what the finding calls for, not one per file. A second control
+ * here would duplicate that signal without adding one.
+ *
+ * The ≤ 60 µs ceiling carries the same caveat as every other absolute budget in this project
+ * (NFR-01's, NFR-03's): it is tied to spec NFR-06's reference machine, not asserted here as a
+ * hard gate for that reason — `tools/bench_budget_gate.py` enforces it against CI hardware
+ * instead, which is a **weaker** claim than the specification's and says so in its own output.
+ */
+#[Bench\BeforeMethods('setUp')]
+#[Bench\Iterations(10)]
+#[Bench\Revs(1000)]
+#[Bench\RetryThreshold(5)]
+final class CryptoBench
+{
+    private Crypto $crypto;
+
+    private string $plaintext = '';
+
+    public function setUp(): void
+    {
+        // A fresh key per benchmark run, not per rev: SecretKey::generate() is deliberately not
+        // part of what NFR-13 budgets — it is a one-time cost at wiring, not a per-message one.
+        $this->crypto = new Crypto(SecretKey::generate());
+
+        // Content is irrelevant to GCM's timing (it is not data-dependent at this level); the
+        // length is what the spec names.
+        $this->plaintext = \str_repeat('a', 1024);
+    }
+
+    /**
+     * NFR-13's subject. Budget enforced by `tools/bench_budget_gate.py` in `ci.yml` and
+     * `nightly.yml` (`--budget benchCryptoRoundTrip=60`) — one home for the number, following the
+     * pattern items 12.3 and prior established rather than a `Bench\Assert` here.
+     */
+    public function benchCryptoRoundTrip(): void
+    {
+        $token = $this->crypto->encrypt($this->plaintext);
+        $this->crypto->decrypt($token);
+    }
+}


### PR DESCRIPTION
## Summary

Roadmap item **12.5** — the last *planned* item in Milestone 12: `CryptoBench` measures **NFR-13**,
a 1 KiB `Crypto` encrypt+decrypt round trip against a **60 µs** ceiling.

## Motivation

Spec NFR-13 names one number for the round trip, and `decrypt()` cannot be measured honestly
without a real token a matching `encrypt()` call produced — a hand-built or cached ciphertext
would skip the nonce generation and tag verification a real call pays for. So the subject is the
round trip, not either half.

Local sanity (informative only — this box's phpbench CLI has the standing, documented capture bug
noted in prior PRs; direct `hrtime()` timing stood in): **~14 µs**, comfortable headroom, nowhere
near NFR-11's knife-edge (item 11.7).

## Two things this item deliberately does not add

Both because item 12.4, merged a few hours earlier, already settled them:

- **No `Bench\Assert`.** The budget is wired into `bench_budget_gate.py`'s existing invocation in
  both `ci.yml` and `nightly.yml` (`--budget benchCryptoRoundTrip=60`) — one home per number, the
  pattern every prior bench item in this milestone kept.
- **No new control subject.** Item 12.4's finding (filed as **item 12.6**) is that a run-wide
  runner slowdown moves *every* subject in one CI job together, control included.
  `RowNormalizerBench::benchInlineTrimHundredRows` already plays that role for this benchmark job.
  One control per job is what the finding calls for, not one per file — a second one here would
  duplicate the signal rather than add to it.

## Changes

- `src/bench/php/d4np/utils/CryptoBench.php` — one subject, `benchCryptoRoundTrip()`.
- `.github/workflows/{ci,nightly}.yml` — `--budget benchCryptoRoundTrip=60`.
- `ROADMAP.md` — 12.5 checked with its retrospective, explicit that M12 stays open on item 12.6.
- `CHANGELOG.md`, journal entry.

**No ADR.** This wires an existing spec number into the existing harness — the same shape as items
9.6 and 11.5, neither of which needed one.

## M12 does not close here

Item 12.6 (filed at 12.4: how the relative benchmark gate should treat a run-wide slowdown) is
still an unchecked roadmap item, so `consistency_lint`'s milestone check keeps `README.md`'s M12
row at "⏳ planned" structurally — the same shape Milestone 11 closed in, with 11.6/11.7 left open
as the maintainer's calls.

## Verification

- [x] 2831 tests, unchanged (bench-only item, no new test surface)
- [x] PHPStan max clean · PHP-CS-Fixer clean
- [x] deptrac 342 allowed / 0 uncovered / 0 violations (bench files sit outside `src/main`, so no
      layer is touched)
- [x] `python tools/consistency_lint.py` OK
- [x] `benchmark / reproducible perf` — **green, first attempt, no re-run needed.**
      `benchCryptoRoundTrip` measured **4.266 µs** against the ≤ 60 µs ceiling — **14× headroom**,
      and both the relative gate and every other absolute budget passed alongside it. Local sanity
      had said ~14 µs; CI's real figure is ~3× smaller, consistent with this box's usual
      overstatement of CPU-bound work. Updating the ROADMAP retrospective's "informative only"
      local number with this one in a follow-up commit if useful — flag if you'd rather I fold it
      in now.

## Documentation Impact

- [ ] README.md — unchanged by design (M12 stays "planned"; see above)
- [x] ROADMAP.md — 12.5 checked with retrospective
- [ ] ADR — none; see Changes
- [ ] docs/patterns/README.md — unchanged
- [ ] Spec — unchanged (NFR-13 was implementable exactly as written)
- [x] CHANGELOG.md — Added
- [x] PR metadata — assignee (owner), label `enhancement`, milestone `v0.11.0`

## Lesson

Not every item needs its own instrument. Having just learned a control subject would have saved a
wrong diagnosis, the temptation is to add one everywhere — the right scope is one per place the
signal actually differs, which here is one per CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
