### PR TITLE
fix(bench): invalidate the run when a control subject moves past threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,9 @@ jobs:
             --max-regression 10 \
             --exclude "FileSequenceBench::benchSequenceNext" \
             --exclude "HashBench::benchMakeArgon2id" \
-            --exclude "HashBench::benchVerifyArgon2id"
+            --exclude "HashBench::benchVerifyArgon2id" \
+            --control "RowNormalizerBench::benchInlineTrimHundredRows" \
+            --control "LoggingBench::benchSinkDirectly"
       - name: Keep the reports
         if: steps.cfg.outputs.present == 'true' && always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`tools/bench_regression_gate.py` gains `--control Benchmark::subject`** (spec NFR-06; roadmap
+  item **12.6**; **ADR-0057**): a repeatable flag naming a subject that calls no code this
+  project owns. When such a subject's measured delta — in either direction — exceeds
+  `--max-regression`, the gate reports the whole run `INVALID` (exit `2`, distinct from `0` pass
+  and `1` fail) instead of reporting individual regressions a compromised same-runner A/B cannot
+  vouch for. Filed from item 12.4's CI, where the *same commit*, measured twice, failed **two
+  different gates on two different runs**: once the relative gate on five subjects including
+  `RowNormalizerBench::benchInlineTrimHundredRows` — a hand-written inline loop with no library
+  dependency, and therefore unable to regress — and once the absolute ceiling, with every subject
+  27–103% slower than the first run on identical code. Both were a runner-wide slowdown between
+  measurements, not a code change; `--exclude` (ADR-0045) does not catch this shape, since it
+  answers "this one subject is individually noisy," not "nothing in this run can be trusted."
+  Wired in `ci.yml` with two controls — `RowNormalizerBench::benchInlineTrimHundredRows` and
+  `LoggingBench::benchSinkDirectly` — so a slowdown localized to one part of the job cannot land
+  outside both sentinels' measurement windows. A name may not appear in both `--control` and
+  `--exclude`, refused at parse time.
+
 - **phpbench benchmark for NFR-13** (spec §4, RFC-0002; roadmap item **12.5**): `CryptoBench`
   under `src/bench/php/d4np/utils/`, wired into `bench_budget_gate.py` in both `ci.yml` and
   `nightly.yml` (`benchCryptoRoundTrip=60`). Measures `Crypto::encrypt()` immediately followed

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ setup.
 | 9 | Support & values | ✅ done |
 | 10 | Persistence | ✅ done |
 | 11 | Http application layer | ⏳ planned |
-| 12 | Security & channels | ⏳ planned |
+| 12 | Security & channels | ✅ done |
 
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,9 @@ items are additive either way, so the mapping shifts without rework.
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
   API-freeze review**, not an automatic bump.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-08 — The last planned item, and the milestone that still doesn't close](docs/journal/2026/08/2026-08-08-crypto-benchmark.md).
+  [2026-08-08 — Closing the milestone by fixing the tool that kept flagging it as open](docs/journal/2026/08/2026-08-08-benchmark-run-invalidation.md).
   Previous:
+  [2026-08-08 — The last planned item, and the milestone that still doesn't close](docs/journal/2026/08/2026-08-08-crypto-benchmark.md),
   [2026-08-08 — Three answers to the same bytes, and a corpus that could not fail](docs/journal/2026/08/2026-08-08-mail-group.md),
   [2026-08-08 — The idiomatic enum was too slow, and one of my own arguments was dead](docs/journal/2026/08/2026-08-08-logging-channels.md),
   [2026-08-07 — A tag that shrinks, a key nobody checks, and a guard that never fired](docs/journal/2026/08/2026-08-07-crypto.md).
@@ -1441,7 +1442,7 @@ AEAD crypto, PSR-3 channel composition, and the Mail group (RFC-0002 FR-40…FR-
       work while 11.6/11.7 stayed open — except M11's two open items are both maintainer decisions
       on numbers, while 12.6 is a decision on the **gate's own design** (does a control-subject
       breach invalidate a run, and if so, how).*
-- [ ] 12.6 Decide how the **relative** benchmark gate should treat a run-wide slowdown. Filed from
+- [x] 12.6 Decide how the **relative** benchmark gate should treat a run-wide slowdown. Filed from
       item 12.4's CI, where the *same commit* failed **two different gates on two runs** and neither
       failure was attributable to the diff (a new `Mail` group nothing else imports). Run 1: the
       relative gate failed with five subjects at **+11.19% … +19.44%**, among them
@@ -1462,8 +1463,37 @@ AEAD crypto, PSR-3 channel composition, and the Mail group (RFC-0002 FR-40…FR-
       cancels; **(c)** interleave the base and head measurements instead of running them in
       sequence; **(d)** accept the flapping and re-run by hand, as this item's own PR did. (b) is
       the most precise and the easiest to get subtly wrong; (a) is the smallest change that stops a
-      false failure being indistinguishable from a real one — size: S · route: standard / medium ·
-      ADR (it revises ADR-0030/ADR-0045's gate design)
+      false failure being indistinguishable from a real one — size: S · route: standard / medium
+      *(session model was Sonnet 5 — `fast` tier, kept from the user's explicit `/model` switch
+      before item 12.5 — against a filed `standard` route; mismatch recorded, not glossed)* ·
+      **ADR-0057**. *The choice among (a)–(d) is an engineering call about the gate's own
+      mechanism, not a spec or budget number — ADR-0040 reserves the latter for the maintainer;
+      ADR-0045 made the same kind of call unilaterally when it added `--exclude`. Proceeded on the
+      maintainer's explicit "procedi con M12.6." Chose **(a)**:
+      `bench_regression_gate.py` gains a repeatable `--control Benchmark::subject` flag; when a
+      control's delta exceeds `--max-regression` **in either direction** (a runner speeding up
+      is the same broken comparison as one slowing down, and could hide a real regression under
+      an apparent improvement), the gate prints `INVALID`, names the breaching control(s), states
+      that no other subject's number from that run can be trusted, and exits **`2`** — distinct
+      from `0` (pass) and `1` (a trustworthy failure) — rather than reporting individual
+      regressions a compromised A/B cannot vouch for. **(b)** (net each subject against the
+      control's own delta) was rejected for now, not dismissed: run 2's subjects moved
+      27–103%, not by one consistent factor, so a naive subtraction risks manufacturing a false
+      pass or fail from real per-subject drift; filed as a follow-up if plain invalidation proves
+      too coarse. **Two controls wired into `ci.yml`** (not `nightly.yml`, which never ran the
+      relative comparison per ADR-0030 §3): `RowNormalizerBench::benchInlineTrimHundredRows`
+      (item 10.11's origin) and `LoggingBench::benchSinkDirectly` (item 12.3's) — two rather than
+      one, so a slowdown localized to one part of the job's timeline cannot land entirely outside
+      a single sentinel's measurement window. **A name may not appear in both `--control` and
+      `--exclude`**, refused loudly at parse time: a control's value is being a clean signal,
+      and excluding it would silently defeat the property the flag depends on. **Verified against
+      8 synthetic `phpbench --dump-file` fixtures** (no permanent pytest suite exists for
+      `tools/*.py`, the standing method from items 10.5/10.9), including an exact reproduction of
+      item 12.4's run-1 numbers (`benchInlineTrimHundredRows` +19.44%, `benchNormalizeHundredRows`
+      +13.82%) now producing `INVALID`/exit 2 with **no** old-style `FAIL — 2 subject(s)` block,
+      and the identical numbers with no `--control` given reproducing the pre-existing `FAIL`
+      output byte-for-byte — proving the change is additive, not a behavior change for anyone not
+      opting into a control.*
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1274,7 +1274,20 @@ The console-side trio: client, router, envelope (RFC-0002 FR-37…FR-39).
       decision: the mean sits clearly over budget and the cause is understood, so option (a) or (b)
       is still the question — but a ceiling this close to the runner's own variance makes the gate
       **flap** rather than fail, and whichever option is chosen should leave headroom against that
-      variance rather than against the measured mean. Options, none taken unilaterally
+      variance rather than against the measured mean. **A seventh measurement and a new
+      consequence, added at item 12.6** (2026-08-08): `benchDispatchLastOfFiftyRoutes` measured
+      **7.069 µs** on PR #79's CI, breaching the ceiling again — the running set is now
+      6.874–7.145 · 5.188 · 5.673 · 4.735 · 7.021 · **7.069** µs, still centered clearly over
+      budget. More consequential than the number itself: **this breach is a `bench_budget_gate.py`
+      failure at step 8 of the `benchmark` job, and GitHub Actions stops a job at its first failed
+      step by default** — steps 9–13, including the **regression gate** where item 12.6's new
+      `--control` invalidation logic lives, were all reported `skipped`, not run. This is the same
+      structural shape item 10.10's journal named when NFR-09 blocked the regression gate's
+      `--exclude` step from ever executing in CI: as long as 11.7 stays open, **any** downstream
+      benchmark diagnostic added to this job — 12.6's included — is untested on real CI until a PR
+      happens to avoid tripping this ceiling. Resolving 11.7 removes that side effect as well as
+      the router's own gap; left open, the cost of leaving it open keeps compounding onto whatever
+      is added next. Options, none taken unilaterally
       ([ADR-0040](docs/adr/0040-run-infection-outside-the-dependency-graph-and-hold-the-floor-at-the-specs-70.md)
       reserves spec numbers for the maintainer): **(a)** raise NFR-11's router budget to a value
       the current linear scan clears (the measured number, with headroom, e.g. ≤ 10 µs); **(b)**

--- a/docs/adr/0057-invalidate-the-run-when-a-control-subject-moves-past-threshold.md
+++ b/docs/adr/0057-invalidate-the-run-when-a-control-subject-moves-past-threshold.md
@@ -171,6 +171,18 @@ premise.
 gotten less stable since ADR-0030's baseline measurement, and the same-runner A/B's own premise
 should be re-measured, not silently worked around with a wider threshold.
 
+**Not yet exercised on real CI, and that is itself evidence of a second problem.** The PR that
+introduced this mechanism failed `ci.yml`'s `benchmark` job at the *absolute-budget* step (item
+11.7's router regression, unrelated to this change), and GitHub Actions stops a job at its first
+failed step by default — every step after it, including the regression gate this ADR's own logic
+lives in, was reported `skipped`. This repeats the exact shape item 10.10's journal already named
+once, with NFR-09 in the blocking role that 11.7 plays here: as long as any absolute-budget item
+stays open, every diagnostic added downstream of it in the same job — this one included — ships
+untested against real CI until a PR happens not to trip that ceiling. Correctness here rests on
+the eight synthetic-fixture cases in Verification, not on a live CI run; the note is recorded on
+item 11.7 rather than fixed here, on the same restraint item 10.10 held to (a step-ordering fix is
+a different, job-wide decision from this ADR's subject).
+
 ## References
 
 - ROADMAP item 12.4 (the evidence), item 10.11 (`benchInlineTrimHundredRows`'s origin as a

--- a/docs/adr/0057-invalidate-the-run-when-a-control-subject-moves-past-threshold.md
+++ b/docs/adr/0057-invalidate-the-run-when-a-control-subject-moves-past-threshold.md
@@ -1,0 +1,178 @@
+# ADR-0057: Invalidate the run when a control subject moves past threshold
+
+- **Status:** Accepted
+- **Date:** 2026-08-08
+- **Deciders:** tech-lead (agent-drafted), maintainer (merge)
+- **Related:** ROADMAP item **12.6**, filed from item 12.4 · spec NFR-06 ·
+  [ADR-0030](0030-same-runner-ab-because-a-stored-baseline-cannot-carry-a-10-percent-gate.md)
+  (the same-runner A/B this amends) ·
+  [ADR-0045](0045-exclude-io-bound-and-memory-hard-subjects-from-the-relative-gate.md)
+  (`--exclude`, the sibling mechanism this is not a duplicate of) ·
+  item 10.12 (the control-subject method this generalizes from one bench file's design choice
+  into a gate-level mechanism)
+
+## Context
+
+Item 12.4's CI ran the same commit twice and failed **two different gates on two different runs**,
+neither attributable to the diff (a new `Mail` group nothing else imports):
+
+- **Run 1** — the relative gate (`bench_regression_gate.py`, ADR-0030) failed on five subjects,
+  **+11.19% … +19.44%**. One of them was `RowNormalizerBench::benchInlineTrimHundredRows` — a
+  hand-written inline `trim()` loop with no dependency on this project's code, added at item
+  10.11 specifically as *"the floor the overhead is measured against."* It cannot regress. It
+  moved anyway.
+- **Run 2** — the relative gate passed and the *absolute* ceiling (`bench_budget_gate.py`) failed
+  instead, on item 11.7's router (7.021 µs against 5). Every subject in run 2 measured
+  **27–103% slower** than the identical subjects in run 1 —
+  `benchWriteTenThousandByTen` alone moved 9 691 → 19 660 µs.
+
+Both runs measured a **slow runner**, not a code change. The mechanism is specific to ADR-0030's
+design: base and head are measured **sequentially** on one runner (`git worktree`, then two
+`phpbench` invocations in the same job), which is what makes the comparison immune to
+*runner-to-runner* variance (ADR-0030's own problem) but leaves it exposed to *within-run* drift —
+a runner that changes speed **between** the two measurements shifts every subject in one
+direction, and the gate attributes the shift to whichever half ran second.
+
+`--exclude` (ADR-0045) does not fix this. It removes one *named, individually noisy* subject from
+the pass/fail decision because that subject's own mechanism (filesystem locking, memory-hard
+hashing) cannot supply 10%-precision on shared hardware. `benchInlineTrimHundredRows` is the
+opposite case: it is not noisy on its own — it is one of the *quietest* subjects in the suite, a
+pure PHP loop with nothing to contend for — and it moving is exactly what makes it useful. It is
+not the subject that needs excluding; it is the **signal that nothing else in the run can be
+trusted.**
+
+## Decision
+
+### `bench_regression_gate.py` gains a repeatable `--control Benchmark::subject` flag
+
+A control names a subject that calls no code this project owns. When a control's measured delta —
+in **either** direction — exceeds `--max-regression`, the gate prints `INVALID`, lists the
+breaching control(s) with their measured change, states plainly that no other subject's number
+from this run should be trusted, and exits **`2`** — a code distinct from `0` (pass) and `1` (a
+real, or at least trustworthy, failure).
+
+**Both directions, deliberately.** The observed incident was a slowdown, but the mechanism —
+runner speed changing mid-job — is directional-agnostic: a runner speeding up between the two
+halves would show every subject as an *improvement*, which is just as untrustworthy a comparison
+and, worse, could mask a genuine regression underneath it. `abs(delta) > max_regression` is what
+the reasoning demands, not only the sign that happened to be observed.
+
+**A distinct exit code, not exit `0`.** GitHub Actions has no built-in notion of "this check is
+neither pass nor fail, please re-run it" — any non-zero exit still shows the job red. Exiting `0`
+was considered and rejected: an invalidated run tells us nothing about whether the code regressed,
+and reporting that as a pass would let a real regression through under exactly the cover this
+finding describes. `2` keeps the job red — requiring the same human attention a real failure
+would — while giving the log an unambiguous instruction (*"re-run the job"*, not *"read the
+diff"*) and leaving room for CI tooling to act on the distinction later without a second change to
+this script.
+
+**Individual regressions are not still reported as a separate `FAIL` when a control breaches.**
+Case 4 in this item's verification (a control breaching *alongside* a subject whose own delta
+looks like a real regression) is the reason: once the comparison itself is compromised, that
+other subject's number carries no more information than the control's does. Printing both an
+`INVALID` control notice and a `FAIL` regression list for the same run would let a reader pick
+whichever framing they preferred; only one can be true.
+
+### `RowNormalizerBench::benchInlineTrimHundredRows` and `LoggingBench::benchSinkDirectly` are the
+### first two named controls
+
+Both already existed as controls in their own bench files' design (items 10.11 and 12.3
+respectively) — this wires that existing property into the gate rather than inventing a new
+subject. **One control is not enough by construction**: a runner slowdown localized to one part
+of a job's timeline could, in principle, land entirely inside one control's measurement window and
+outside the other's. Two independent, cheap sentinels in the same job cost nothing extra to run
+and halve that blind spot. `ci.yml`'s regression-gate step now reads:
+
+```
+--control "RowNormalizerBench::benchInlineTrimHundredRows"
+--control "LoggingBench::benchSinkDirectly"
+```
+
+Not wired into `nightly.yml`: that workflow never ran the relative comparison at all (ADR-0030
+§3), so there is nothing for `--control` to guard there.
+
+### A name may not appear in both `--control` and `--exclude`
+
+Refused loudly at argument-parsing time, before either file is even read. A control's entire value
+is being a clean, low-noise signal; excluding it from pass/fail would silently defeat the property
+`--control` depends on to mean anything, and the two flags giving contradictory instructions about
+the same subject is exactly the kind of thing this project refuses rather than tolerates (the same
+stance `LoggerFactory`'s closed key set and `Level::rankOf()`'s validate-before-filter took at
+item 12.3).
+
+## Verification
+
+No permanent pytest suite exists for `tools/*.py` in this repository — the standing method
+(items 10.5, 10.9) is a synthetic `phpbench --dump-file` XML fixture. Eight cases, including an
+exact reproduction of item 12.4's run-1 numbers:
+
+1. The reproduced incident (`benchInlineTrimHundredRows` +19.44%, `benchNormalizeHundredRows`
+   +13.82%) with the control named → `INVALID`, exit `2`, and **no** old-style `FAIL — 2
+   subject(s)` block.
+2. The same two numbers with **no** `--control` given → the pre-existing `FAIL — 2 subject(s)
+   exceeded the 10% budget` behaviour, byte-for-byte unchanged. Proves the change is additive.
+3. A control that moves but stays inside the threshold → ordinary `OK`, unaffected.
+4. A control breach coexisting with a separately-regressed, unrelated subject → still `INVALID`,
+   not a `FAIL` for the other subject (the reasoning behind the "no separate FAIL block" choice
+   above, performed rather than only argued).
+5. A control that improves *past* the threshold in the negative direction → still `INVALID`
+   (the symmetric-direction decision, performed).
+6. An unknown `--control` name → loud `FAIL`, same discipline `--exclude` already holds to.
+7. A name given to both `--control` and `--exclude` → loud `FAIL` before either report is read.
+8. `--exclude` alone, reproducing ADR-0045's original scenario → unchanged `OK` with a `skipped`
+   marker, confirming the two mechanisms do not interfere.
+
+## Alternatives
+
+1. **(b) Net each subject's delta against the control's own delta**, so a run-wide shift cancels
+   out arithmetically (e.g. subtract the control's % from every other subject's %) — the option
+   named in the roadmap item as *"the most precise and the easiest to get subtly wrong."*
+   Rejected for now: it assumes the runner's slowdown is *uniform* across every subject, which is
+   an assumption this incident's own data does not fully support (run 2's subjects moved
+   27–103%, not a single consistent factor), so a naive subtraction could under- or
+   over-correct and manufacture a false pass or a false fail from real drift. Left as a follow-up
+   if simple invalidation proves too coarse in practice — the mechanism this ADR adds
+   (`--control`) is the prerequisite either way, since (b) still needs a named, trusted-zero
+   subject to measure the shift against.
+2. **(c) Interleave base and head measurements** instead of running them sequentially — rejected
+   as a larger change than this finding requires: it touches `ci.yml`'s worktree/phpbench
+   choreography (ADR-0030 §1) rather than the gate script, multiplies the job's complexity, and
+   does not eliminate the need for a sanity check that the two halves are comparable at all.
+3. **(d) Accept flapping, re-run by hand** — the status quo this ADR replaces, and the roadmap
+   item's own evidence against it: item 12.4 needed three CI attempts (one lost to an unrelated
+   concurrency cancellation, one to a phpbench timeout, one that finally produced a clean signal)
+   before a human could tell "re-run" from "investigate" apart — exactly the ambiguity `INVALID`
+   now states directly in the log.
+4. **Exit `0` on invalidation** (treat it as a soft pass) — rejected in the Decision section above:
+   it would hide a real regression exactly when the runner's noise is large enough to mask one.
+5. **A single, shared control across `ci.yml` and `nightly.yml`** — rejected: `nightly.yml` never
+   ran the relative comparison ADR-0030 §3 scoped to `ci.yml` alone, so there is nothing there for
+   a control to guard against.
+
+## Consequences
+
+**Easier:** a run-wide runner slowdown is now named in the log as exactly that, rather than
+requiring a human to notice a suspicious pattern (a "regressed" subject that calls no library
+code) the way this ADR's own incident was diagnosed. Re-running is now the tool's own advice, not
+folklore a contributor has to already know.
+
+**Harder / accepted:** two control subjects are two more things every benchmark PR's CI output
+must carry, and `INVALID` is a third possible outcome a reader of `gh pr checks` must learn to
+distinguish from `FAIL` — the same kind of ambiguity item 12.4 hit when a `cancelled` job read
+identically to a `failed` one in the checks rollup. `2` is a plain exit code, not a GitHub Actions
+"neutral" status, so the job still shows red either way; the distinction lives in the log, not
+(yet) in the checks UI. A genuine regression that happens to land in the *same* run as a
+runner-wide slowdown is invisible until the job is re-run clean — accepted, because there is no
+way to separate the two signals from inside one compromised run, which is this ADR's whole
+premise.
+
+**Watch for:** if `INVALID` starts firing often enough that it becomes background noise itself
+(the same fate `--exclude`'s subjects were rescued from), that is evidence CI's runners have
+gotten less stable since ADR-0030's baseline measurement, and the same-runner A/B's own premise
+should be re-measured, not silently worked around with a wider threshold.
+
+## References
+
+- ROADMAP item 12.4 (the evidence), item 10.11 (`benchInlineTrimHundredRows`'s origin as a
+  control), item 12.3 (`benchSinkDirectly`'s origin), item 12.6 (this decision)
+- ADR-0030 (the same-runner A/B this amends), ADR-0045 (`--exclude`, the sibling mechanism)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,3 +72,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0054](0054-authenticated-encryption-with-fixed-lengths-and-a-key-only-secretkey-can-produce.md) | Authenticated encryption, with fixed lengths and a key only `SecretKey` can produce | Accepted |
 | [0055](0055-one-ordering-validation-before-filtering-and-a-swallow-only-at-the-leaf.md) | One ordering, validation before filtering, and a swallow only at the leaf | Accepted |
 | [0056](0056-refuse-the-terminator-at-construction-and-hand-mail-an-array.md) | Refuse the terminator at construction, and hand `mail()` an array | Accepted |
+| [0057](0057-invalidate-the-run-when-a-control-subject-moves-past-threshold.md) | Invalidate the run when a control subject moves past threshold | Accepted |

--- a/docs/journal/2026/08/2026-08-08-benchmark-run-invalidation.md
+++ b/docs/journal/2026/08/2026-08-08-benchmark-run-invalidation.md
@@ -1,0 +1,107 @@
+# 2026-08-08 — Closing the milestone by fixing the tool that kept flagging it as open
+
+Roadmap item **12.6**, the last item in Milestone 12. Route `standard / medium`; session model
+Sonnet 5 (`fast` tier, kept from the switch before item 12.5) — mismatch recorded, not glossed.
+Proceeded on the maintainer's explicit go-ahead; the choice among the four filed options is an
+engineering call about a gate's own mechanism, the same kind ADR-0045 made unilaterally, not a
+spec or budget number reserved for the maintainer under ADR-0040.
+
+## What was actually broken
+
+Item 12.4's CI ran one commit twice and failed two different gates on two different runs, neither
+attributable to the diff. Run 1 failed the *relative* gate on five subjects, one of them
+`RowNormalizerBench::benchInlineTrimHundredRows` — a hand-written inline `trim()` loop with no
+dependency on this project's code, added specifically as a floor to measure overhead against. It
+cannot regress. It moved +19.44% anyway. Run 2 passed the relative gate and failed the *absolute*
+ceiling instead, with every subject 27–103% slower than run 1 on identical code.
+
+Both were the same fact seen from two angles: the runner got slower (or, in principle, faster)
+*between* the sequential base and head measurements ADR-0030's same-runner A/B relies on, and that
+shift lands on whichever half ran second, indistinguishable from a real regression.
+
+`--exclude` (ADR-0045) was built for a different shape of problem — a subject that is
+individually noisy on its own mechanism (filesystem locking, memory-hard hashing) — and does not
+generalize to this one. The control subject is not noisy; it is one of the quietest subjects in
+the suite, and that is precisely what makes its movement meaningful.
+
+## The fix, and the one I didn't take
+
+Four options were on the table. (a): name control subjects and invalidate the run when one moves.
+(b): net every subject against the control's own delta, so a uniform shift cancels arithmetically.
+(c): interleave base and head instead of measuring them sequentially. (d): keep re-running by
+hand.
+
+Chose (a). Not because (b) is wrong in principle, but because run 2's own numbers argue against
+trusting it yet: subjects moved 27–103%, not by one consistent factor, so subtracting a single
+control's delta from everything else could as easily manufacture a false pass on real drift as
+fix a false fail on none. (a) needs the same infrastructure (a named, trusted-zero subject) and
+makes no arithmetic claim beyond "this shouldn't have moved, so nothing here is trustworthy" —
+which is exactly what the evidence supports. (b) is filed as a follow-up if (a) proves too coarse.
+
+(c) touches `ci.yml`'s worktree choreography, not the gate script, and is a larger change for the
+same finding. (d) is the status quo the finding is evidence against: item 12.4 needed three CI
+attempts before a human could tell "re-run" from "investigate" apart, and two of those three
+weren't even gate verdicts (a concurrency cancellation from my own ill-timed re-run, then a
+30-minute phpbench timeout) — a separate lesson about reading a job's `conclusion` and duration
+before diagnosing anything, already carried from that session.
+
+## The decision I almost got wrong: which direction to check
+
+The observed incident was a slowdown. The temptation is to check only for regressions past the
+threshold. But the mechanism — a runner's speed changing mid-job — has no reason to only go one
+way, and a runner *speeding up* between the two halves would show every subject as an improvement,
+which is exactly as untrustworthy a comparison and, worse, could hide a genuine regression
+underneath an apparent win. `abs(delta) > threshold` is what the reasoning demands; checking only
+the regression direction would have been consistent with the one incident on record and wrong
+about the mechanism that produced it.
+
+## What "invalidate" means concretely
+
+The gate did not gain a third healthy state GitHub Actions understands. Exit code `2` is still
+just a non-zero exit — the job still shows red. What changes is the log: `INVALID` and a named
+control breach read differently from `FAIL — N subject(s) exceeded the budget`, and the message
+says "re-run the job" rather than implying "read the diff." Exiting `0` on invalidation was
+considered and rejected outright: an invalidated run tells us nothing about whether the code
+regressed, and reporting that as a pass would let a real regression through under the exact cover
+this finding describes.
+
+One more decision fell out of testing rather than being planned: when a control breaches
+*alongside* a subject that looks like a real regression, the gate reports only `INVALID`, not
+`INVALID` plus a separate `FAIL` for the other subject. Once the comparison is compromised, that
+other subject's number carries no more information than the control's does — printing both would
+let a reader pick whichever framing suited them, and the verification suite's case 4 exists to
+prove this is what the code actually does, not only what the ADR argues.
+
+## Verification, the usual way
+
+No permanent pytest suite exists for any `tools/*.py` in this repository — the standing method,
+carried from items 10.5 and 10.9, is a synthetic `phpbench --dump-file` XML fixture. Eight cases,
+including an exact reproduction of item 12.4's run-1 numbers now producing `INVALID`/exit 2 with
+no old-style `FAIL` block, and the same numbers with no `--control` given reproducing the
+pre-existing output byte-for-byte — the proof that this is additive, not a behavior change for
+anyone who has not opted a subject into `--control`.
+
+## Two controls, not one
+
+`RowNormalizerBench::benchInlineTrimHundredRows` (item 10.11's) and `LoggingBench::benchSinkDirectly`
+(item 12.3's) both went in. One control's blind spot is a slowdown that lands entirely inside its
+own measurement window and outside another's — two independent, already-existing sentinels in the
+same job cost nothing extra and roughly halve that risk. Neither is new code; both already existed
+as controls in their own bench files' design. This item only told the gate to look at them.
+
+## The milestone closes
+
+M12's six items are all checked. README's row flips to done — the last of the four RFC-0002
+milestones this session has walked start to finish (M9 Support & values, M10 Persistence, M11
+Http application layer with two open decisions, M12 Security & channels with none). Three open
+maintainer decisions remain across the whole plan: 11.6 (a noisy budget with no clear cause),
+11.7 (the router's NFR-11 ceiling, now six measurements deep), and — filed by this item's own
+predecessor — none from 12.6, since this item is the decision, not another deferral.
+
+## Lesson
+
+A gate that cannot tell its own noise from a real signal will eventually be trusted less than no
+gate at all — the same fate item 10.5 nearly gave `--exclude`'s two subjects before ADR-0045 named
+the criterion. The fix here is not a bigger threshold or a longer retry list; it is a second,
+independent measurement — the control — whose only job is answering the question the primary
+measurement cannot ask of itself: *is this run even trustworthy?*

--- a/docs/journal/2026/08/2026-08-08-benchmark-run-invalidation.md
+++ b/docs/journal/2026/08/2026-08-08-benchmark-run-invalidation.md
@@ -98,6 +98,28 @@ maintainer decisions remain across the whole plan: 11.6 (a noisy budget with no 
 11.7 (the router's NFR-11 ceiling, now six measurements deep), and — filed by this item's own
 predecessor — none from 12.6, since this item is the decision, not another deferral.
 
+## Postscript — the mechanism has never run on real CI
+
+The PR carrying this change failed `ci.yml`'s `benchmark` job — at the absolute-budget step, on
+item 11.7's already-known router regression (`benchDispatchLastOfFiftyRoutes` 7.069 µs, a seventh
+data point for that open decision). GitHub Actions stops a job at its first failed step by
+default, so every step after it — steps 9 through 13, including the regression gate this item's
+own `--control` logic lives in — was reported `skipped`, not run.
+
+I had already lived this exact shape once, from the other side: item 10.10's journal recorded that
+its own new regression-gate step "never actually executes in CI, only locally," blocked by NFR-09
+staying red. That entry did not stop the same structure from repeating — this time 11.7 sits in
+NFR-09's old seat, and item 12.6 sits where 10.9's `--exclude` sat, untested in production for the
+same reason. Recognizing a pattern once is not the same as having fixed it; the fix was never in
+scope for either item, since a step-ordering change is a job-wide decision neither item's own
+subject warranted making unilaterally.
+
+So this item's correctness rests entirely on the eight synthetic-fixture cases above, not on a
+live confirmation — worth saying plainly rather than letting a green PR checklist imply more than
+the evidence supports. Noted on item 11.7 rather than patched here, for the same reason ADR-0057
+does not reorder `ci.yml`'s steps: that fix belongs to whoever resolves 11.7, since it is a
+property of the job, not of this one gate's logic.
+
 ## Lesson
 
 A gate that cannot tell its own noise from a real signal will eventually be trusted less than no
@@ -105,3 +127,8 @@ gate at all — the same fate item 10.5 nearly gave `--exclude`'s two subjects b
 the criterion. The fix here is not a bigger threshold or a longer retry list; it is a second,
 independent measurement — the control — whose only job is answering the question the primary
 measurement cannot ask of itself: *is this run even trustworthy?*
+
+And a second lesson, sharper for having now happened twice: naming a recurring structural problem
+in a journal does not fix it for the next item that walks into the same trap. If a pattern is
+worth writing down twice, it is worth turning into a decision someone can act on — which is what
+the note on item 11.7 now is, rather than a third journal entry waiting to happen.

--- a/src/bench/php/d4np/utils/LoggingBench.php
+++ b/src/bench/php/d4np/utils/LoggingBench.php
@@ -100,6 +100,11 @@ final class LoggingBench
      * The control: the sink on its own. Unaffected by anything item 12.3 changed, so its movement
      * between runs is the runner's noise floor, and no claim below that spread is worth making
      * (item 10.12's standing rule on this harness).
+     *
+     * **Wired as `ci.yml`'s regression-gate `--control` alongside `RowNormalizerBench::
+     * benchInlineTrimHundredRows`** (roadmap item 12.6, ADR-0057) — a second, independent
+     * runner-noise sentinel in the same CI job, so a run-wide slowdown localized to one part of
+     * the suite is still caught if the other control happens to sit inside the threshold.
      */
     #[Bench\Subject]
     public function benchSinkDirectly(): void

--- a/src/bench/php/d4np/utils/RowNormalizerBench.php
+++ b/src/bench/php/d4np/utils/RowNormalizerBench.php
@@ -77,6 +77,13 @@ final class RowNormalizerBench
      * The floor the overhead is measured against: the same guard and the same `trim()`, written
      * inline with no policy object at all — the loop the surveyed estate hand-wrote seventeen
      * times, and the one {@see GatewayBench::benchHandWrittenPdoLoop()} keeps.
+     *
+     * **Wired as `ci.yml`'s regression-gate `--control` (roadmap item 12.6, ADR-0057).** It calls
+     * no code this project owns, so it cannot regress; if it ever moves past the 10% threshold in
+     * CI, that is a runner-wide slowdown, not a code change, and the gate reports the whole run
+     * invalid rather than trusting any subject's number from it. Item 12.4's CI is the case this
+     * was written for: this exact subject moved +19.44% on a PR that never touched
+     * `RowNormalizerBench` or `RowNormalizer`.
      */
     public function benchInlineTrimHundredRows(): void
     {

--- a/tools/bench_regression_gate.py
+++ b/tools/bench_regression_gate.py
@@ -47,6 +47,28 @@ what NFR-10 and NFR-05 actually specify (a ceiling, or a range); the relative ch
 was demanding 10%-precision these two subjects' underlying mechanism cannot supply on a shared
 runner. ADR-0045 names the exact criterion for which subjects qualify, so this stays a rule, not
 a per-name carve-out.
+
+**`--control` (roadmap item 12.6, ADR-0057) — a different failure mode from `--exclude`'s.**
+`--exclude` answers "this one subject is too noisy to judge on its own." Item 12.4's CI produced
+a case `--exclude` cannot fix: the *same commit*, measured twice, failed **two different gates on
+two different runs**. Run 1 failed the relative gate on five subjects, +11.19%…+19.44%, one of
+them `RowNormalizerBench::benchInlineTrimHundredRows` — a hand-written inline loop that calls no
+library code and therefore cannot regress. Run 2 passed the relative gate and failed the absolute
+ceiling instead, with **every** subject 27–103% slower than run 1 on identical code. Both runs
+measured a **slow runner**, not a code change: ADR-0030's same-runner A/B measures base and head
+*sequentially*, so a runner that changes speed *between* the halves shifts every subject in one
+direction, and the gate reports it as a regression in whichever half ran second.
+
+A subject that calls no code this project owns cannot have regressed. If it moves anyway, the
+*comparison* is what broke, not the code — and every other subject's number in that same run is
+equally untrustworthy, because they were measured on the same compromised A/B. `--control
+Benchmark::subject` (repeatable) names such a subject; when its **absolute** delta — regression or
+improvement, since a runner change is directionally symmetric — exceeds `--max-regression`, the
+gate reports the run **invalid** rather than reporting individual regressions it cannot vouch for,
+and exits with a distinct code (`2`) so a human — or, eventually, CI automation — reads "re-run
+this" rather than "investigate this diff." A name may not appear in both `--control` and
+`--exclude`: a control's whole value is being a clean signal, and excluding it would silently
+defeat the one property this flag depends on.
 """
 
 import argparse
@@ -128,8 +150,28 @@ def main(argv=None):
         "absolute budget in bench_budget_gate.py is the real spec requirement and whose "
         "same-runner variance exceeds --max-regression on its own (ADR-0045)",
     )
+    ap.add_argument(
+        "--control",
+        action="append",
+        default=[],
+        metavar="Benchmark::subject",
+        help="a subject that calls no code this project owns (repeatable) — if its measured "
+        "delta, in EITHER direction, exceeds --max-regression, the run is reported INVALID "
+        "(exit 2) instead of reporting individual regressions a compromised A/B cannot "
+        "vouch for (ADR-0057)",
+    )
     args = ap.parse_args(argv)
     excluded = set(args.exclude)
+    controls = set(args.control)
+
+    overlap = sorted(excluded & controls)
+    if overlap:
+        print(
+            "bench-regression gate: FAIL\n\n  named as both --control and --exclude: "
+            f"{', '.join(overlap)}. A control's value is being a clean signal; excluding it "
+            "would silently defeat the property --control depends on."
+        )
+        return 1
 
     try:
         base = mode_times(args.baseline)
@@ -147,10 +189,21 @@ def main(argv=None):
         )
         return 1
 
+    unknown_controls = sorted(controls - set(head))
+    if unknown_controls:
+        print(
+            "bench-regression gate: FAIL\n\n  --control named a subject absent from "
+            f"{args.current}: {', '.join(unknown_controls)}. A control that does not exist "
+            "cannot detect anything, which is worse than not naming one at all — the run would "
+            "look protected when it is not."
+        )
+        return 1
+
     rows = []
     regressions = []
     new_subjects = []
     skipped = []
+    control_breaches = []
 
     for name in sorted(head):
         if name not in base:
@@ -168,6 +221,8 @@ def main(argv=None):
 
         delta = (after - before) / before * 100.0
         rows.append((name, before, after, delta))
+        if name in controls and abs(delta) > args.max_regression:
+            control_breaches.append((name, before, after, delta))
         if name in excluded:
             skipped.append((name, before, after, delta))
         elif delta > args.max_regression:
@@ -198,6 +253,23 @@ def main(argv=None):
             f"(ADR-0045); measured {delta:+.2f}% here. Its absolute budget in "
             "bench_budget_gate.py is what actually gates it."
         )
+
+    if control_breaches:
+        print(
+            f"\nbench-regression gate: INVALID — {len(control_breaches)} control subject(s) "
+            f"moved by more than {args.max_regression:g}% while calling no code this project "
+            "owns (ADR-0057):"
+        )
+        for name, before, after, delta in control_breaches:
+            print(f"  {name}: {before:.3f} -> {after:.3f} ({delta:+.2f}%)")
+        print(
+            "\n  This run's own A/B comparison is not trustworthy: a runner-wide slowdown (or "
+            "speed-up) moves every subject together, indistinguishably from a real regression. "
+            "Any subject above also flagged as a regression in this run may be a real one, or "
+            "may be this same noise — re-run the job on a fresh runner rather than investigating "
+            "the diff."
+        )
+        return 2
 
     if regressions:
         print(


### PR DESCRIPTION
## Summary

Roadmap item **12.6**, the last item in Milestone 12: `bench_regression_gate.py` gains a
repeatable `--control Benchmark::subject` flag that reports a benchmark run **`INVALID`** (exit
`2`) when a subject known to call no library code moves past the regression threshold — instead of
reporting individual regressions a compromised run cannot vouch for. **ADR-0057**. Closes M12.

## Motivation

Item 12.4's CI ran the same commit twice and failed **two different gates on two different runs**,
neither attributable to the diff:

- **Run 1** — the relative gate failed on five subjects, +11.19%…+19.44%, one of them
  `RowNormalizerBench::benchInlineTrimHundredRows` — a hand-written inline `trim()` loop with **no
  dependency on this project's code**. It cannot regress. It moved anyway.
- **Run 2** — the relative gate passed and the absolute ceiling failed instead, with **every**
  subject 27–103% slower than run 1 on identical code.

Both were a runner-wide slowdown between the sequential base/head measurements ADR-0030's
same-runner A/B relies on — not a code change. `--exclude` (ADR-0045) doesn't generalize to this:
it answers *"this one subject is individually noisy,"* not *"nothing in this run can be trusted."*

## Decision

`--control` names a subject that calls no code this project owns. When its delta — **in either
direction** — exceeds `--max-regression`, the gate prints `INVALID`, names the breaching
control(s), states that no other subject's number from that run is trustworthy, and exits `2`
(distinct from `0` pass and `1` fail).

**Symmetric on purpose.** The incident was a slowdown, but the mechanism — a runner's speed
changing mid-job — has no reason to only go one way; a runner *speeding up* between the halves
would show every subject as an improvement, which is exactly as untrustworthy and could hide a
real regression underneath an apparent win.

**No separate `FAIL` alongside `INVALID`.** When a control breaches next to a subject that looks
like a real regression, the gate reports only `INVALID` — once the comparison is compromised, that
other subject's number carries no more information than the control's does. This is verified, not
just argued (case 4 below).

**Two controls wired into `ci.yml`** (not `nightly.yml`, which never ran the relative comparison —
ADR-0030 §3): `RowNormalizerBench::benchInlineTrimHundredRows` (item 10.11's) and
`LoggingBench::benchSinkDirectly` (item 12.3's) — two, so a slowdown localized to part of the
job's timeline can't land outside both sentinels' windows.

**A name may not appear in both `--control` and `--exclude`**, refused at parse time: a control's
value is being a clean signal, and excluding it would defeat that.

## The option not taken

Four options were filed. Chose **(a)** invalidation over **(b)** netting each subject against the
control's own delta: run 2's subjects moved 27–103%, not by one consistent factor, so a naive
subtraction risks manufacturing a false pass or fail from real per-subject drift. Filed as a
follow-up if plain invalidation proves too coarse — not dismissed. **(c)** interleaving base/head
measurement touches `ci.yml`'s worktree choreography for the same finding, a larger change than
this warrants. **(d)** — keep re-running by hand — is the status quo the finding argues against:
item 12.4 needed three CI attempts before a human could tell "re-run" from "investigate" apart.

This is an engineering call about the gate's own mechanism — the same kind ADR-0045 made
unilaterally when it added `--exclude` — not a spec/budget number ADR-0040 reserves for the
maintainer. Proceeded on the explicit go-ahead to take item 12.6.

## Changes

- `tools/bench_regression_gate.py` — `--control`, the overlap check against `--exclude`, the
  `INVALID` report path.
- `.github/workflows/ci.yml` — two `--control` flags on the regression-gate step.
- `src/bench/php/d4np/utils/{RowNormalizerBench,LoggingBench}.php` — docblocks noting each
  subject's now-wired role as a control.
- `docs/adr/0057-...md`, indexed.
- `ROADMAP.md` — 12.6 checked with retrospective; `README.md` — M12 flips to **done**.
- `CHANGELOG.md`, journal entry.

## Verification

No permanent pytest suite exists for `tools/*.py` (the standing situation, per items 10.5/10.9) —
verified with **8 synthetic `phpbench --dump-file` XML fixtures**, including an exact reproduction
of item 12.4's run-1 numbers:

1. Reproduced incident, control named → `INVALID`, exit `2`, **no** old-style `FAIL` block.
2. Same numbers, **no** `--control` → pre-existing `FAIL — 2 subject(s)` output, byte-for-byte.
   Proves the change is additive.
3. Control moves but stays inside the threshold → ordinary `OK`.
4. Control breach *coexisting* with a separately-regressed subject → still `INVALID`, not a mixed
   verdict.
5. Control *improves* past the threshold → still `INVALID` (the symmetric-direction decision).
6. Unknown `--control` name → loud `FAIL`.
7. Same name in both `--control` and `--exclude` → loud `FAIL` before either report is read.
8. `--exclude` alone (ADR-0045's original scenario) → unchanged.

- [x] All 8 cases pass
- [x] 2831 tests unchanged (no PHP test-surface change)
- [x] PHPStan max clean · CS-Fixer clean
- [x] deptrac 342 allowed / 0 uncovered / 0 violations
- [x] `python tools/consistency_lint.py` OK — confirms README's M12 "done" agrees with every
      ROADMAP checkbox in the milestone
- [ ] **`benchmark / reproducible perf` on real CI — never reached this change.** The job failed
      at the *absolute-budget* step on item 11.7's already-known router regression
      (`benchDispatchLastOfFiftyRoutes` **7.069 µs**, a seventh data point for that open decision;
      appended to 11.7's text). GitHub Actions stops a job at its first failed step by default, so
      steps 9–13 — including the regression gate this PR's `--control` logic lives in — were all
      `skipped`, not run. This is the same shape item 10.10's journal already named once (NFR-09
      blocking the regression gate's `--exclude` step); recognizing it before did not prevent it
      recurring, since a step-ordering fix is a job-wide decision out of scope for either item. Not
      patched here, on the same restraint item 10.10 held to — noted on 11.7 instead, and stated
      plainly in both ADR-0057 and the journal: this item's correctness rests on the 8 synthetic
      fixtures below, not on a live CI run.

## Documentation Impact

- [x] README.md — M12 row: ⏳ planned → ✅ done
- [x] ROADMAP.md — 12.6 checked with retrospective
- [x] ADR — **ADR-0057**, indexed; amends ADR-0030, sibling to ADR-0045
- [ ] docs/patterns/README.md — unchanged
- [ ] Spec — unchanged; this is a CI-tooling fix, not a spec requirement (same precedent as items
      10.9/10.10, neither of which touched the Spec Coverage Map)
- [x] CHANGELOG.md — Added
- [x] PR metadata — assignee (owner), label `enhancement`. **No milestone** — the same reasoning as
      item 10.9/10.6-type gate fixes: this isn't a roadmap milestone's user-visible feature, it's
      the tooling that verifies them all.

## Lesson

A gate that cannot tell its own noise from a real signal will eventually be trusted less than no
gate at all — the same fate `--exclude`'s two subjects nearly had before ADR-0045 named the
criterion. The fix here is not a bigger threshold; it's a second, independent measurement whose
only job is answering the question the primary one can't ask of itself: *is this run even
trustworthy?*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
