### PR TITLE
release: v1.0.0, the API freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@ _Nothing yet._
 
 | Version | Date | Notes |
 |---------|------|-------|
-| [v0.11.0](docs/changelog/v0/v0.11.0.md) | 2026-08-09 | The first release — every milestone M1–M12. |
+| [v1.0.0](docs/changelog/v1/v1.0.0.md) | 2026-08-09 | The first release — every milestone M1–M12 — and the API freeze (ADR-0059). |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > General-purpose PHP utility helpers shared across EGL projects
 
-![Status](https://img.shields.io/badge/Status-v0.11.0-blue)
+![Status](https://img.shields.io/badge/Status-v1.0.0-blue)
 
 A
 library written in **PHP 8.1+**, built and governed to an enterprise quality

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,12 +16,16 @@ approved 2026-08-05 at PR #49) by the same three-role protocol — all roles wor
 session agent, per-artifact authority checked and recorded in the journal; scope = RFC-0002's
 decision in full, owner-confirmed by the RFC approval and the explicit plan instruction.
 **M9–M12 map to core versions `v0.8.0`–`v0.11.0`** (M8 was bridge-scoped and consumed no core
-minor); the standing post-M7 **1.0.0 API-freeze review** may re-map them to 1.x MINORs — the
-items are additive either way, so the mapping shifts without rework.
+minor). In the event none of those minors were published: with every milestone closed, the
+API-freeze review below settled the whole line into a single first release, **`v1.0.0`**.
 
 - **Versioning start:** pre-1.0 milestone-driven — one minor per milestone
   (M1 → `v0.1.0` … M7 → `v0.7.0`); the **1.0.0 decision is a dedicated post-M7
-  API-freeze review**, not an automatic bump.
+  API-freeze review**, not an automatic bump. **Held 2026-08-09 and settled by
+  [ADR-0059](docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md):**
+  the API is frozen at `v1.0.0`, with `@internal` symbols outside the frozen surface, and the
+  unpublished `v0.11.0` superseded. Post-1.0 versioning follows
+  [`maintenance.md`](docs/workflow/maintenance.md)'s decision tree, not the milestone mapping.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
   [2026-08-08 — Two open decisions, one table, and the number I nearly picked](docs/journal/2026/08/2026-08-08-nfr-ceiling-decisions.md).
   Previous:
@@ -436,8 +440,8 @@ The application-facing groups (RFC-0001).
 
 ## Milestone 7 — Release engineering & bridge (`v0.7.0`) · size: M
 
-Ship `egl/utils` and settle the bridge (RFC-0001). The **1.0.0 decision** follows as a
-dedicated post-M7 API-freeze review.
+Ship `egl/utils` and settle the bridge (RFC-0001). The **1.0.0 decision** followed as a
+dedicated post-M7 API-freeze review — held 2026-08-09, settled by **ADR-0059**.
 
 - [x] 7.1 phpbench nightly CI harness (NFR-06 methodology) with >10% regression failure
       (RFC-0001) (severity:medium) — route: standard / medium *(session model matched the route)* ·

--- a/docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md
+++ b/docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md
@@ -1,0 +1,104 @@
+# ADR-0059: Freeze the API at 1.0.0, with `@internal` symbols outside the frozen surface
+
+- **Status:** Accepted
+- **Date:** 2026-08-09
+- **Deciders:** tech-lead (drafted), maintainer (decided — both questions below were put to
+  them explicitly and answered before this record was written)
+- **Related:** [ADR-0031](0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md)
+  (BC gate by bump) · [ADR-0032](0032-verify-the-tag-before-drafting-and-let-packagist-pull.md)
+  (signed tags) · [ADR-0022](0022-argon2id-by-default-with-a-fallback-decided-at-construction.md)
+  (`Hash::selectAlgorithm` seam) · [ROADMAP](../../ROADMAP.md) (the standing "post-M7 API-freeze
+  review") · [maintenance.md](../workflow/maintenance.md) (the deprecation window this ADR arms)
+
+## Context
+
+`ROADMAP.md` has carried one standing commitment since the plan phase: *"the **1.0.0 decision**
+is a dedicated post-M7 API-freeze review, not an automatic bump."* This is that review.
+
+The preconditions are met and were checked rather than assumed: **every roadmap item across
+M1–M12 is closed** (0 unchecked boxes), `CHANGELOG.md`'s `[Unreleased]` is empty, and CI is green
+on the release commit. So 1.0.0 carries **no functional delta**. Its entire content is a promise:
+that the surface listed in [spec §5](../specs/01_spec_utils.md) is now stable, and that
+[`maintenance.md`](../workflow/maintenance.md)'s deprecation window — deprecate in a MINOR, ship
+one full published MINOR deprecated, remove only in a MAJOR — starts binding.
+
+That promise is expensive in exactly one direction, which is what makes this a review rather than
+a bump: **pre-1.0, a break is free** (SemVer §4, and `tools/bc_gate.py` permits a break in a
+pre-1.0 MINOR — this project has already used that latitude twice on `SqlStatement`, ADR-0039 and
+ADR-0041). After 1.0.0 the same correction costs a MAJOR. Anything we would regret must be found
+now or lived with.
+
+The review surfaced one finding worth a decision.
+
+### The finding: two public symbols documented `@internal`
+
+PHP has no package-private visibility. Two symbols are therefore `public` for mechanical reasons
+and `@internal` by intent:
+
+| Symbol | Why it is public | Why it is `@internal` |
+|---|---|---|
+| `Security\SecretKey::bytes()` | `Crypto` needs the raw key material and lives in another class | exposing raw key bytes to consumers "would defeat the point of wrapping them" (its own docblock) |
+| `Security\Hash::selectAlgorithm()` | extracted as a pure function so the refusal, the bcrypt selection and the WARNING level are assertable (ADR-0022) | "the availability argument has exactly one honest value in production, and that value is supplied by the constructor" |
+
+`roave/backward-compatibility-check` reasons about **public symbols**, not docblocks. Frozen
+naively, `SecretKey::bytes()` becomes part of the 1.x contract — a getter for raw key material
+that we could never remove without a MAJOR, and whose existence in the frozen list invites the
+use it was written to discourage.
+
+## Decision
+
+**Freeze the public API at 1.0.0**, with `@internal`-documented symbols **outside** the frozen
+surface.
+
+1. **What is frozen** — the surface enumerated in [spec §5](../specs/01_spec_utils.md): the PSR-4
+   namespace `D4np\Utils\`, the public signatures of the nine groups, the exception hierarchy's
+   shape, `DatabaseConnection`'s pinned-default semantics, and strict-mode hydration behavior.
+   The bridge package versions on its own tag line (ADR-0033) and is not frozen by this ADR.
+2. **What is not** — a symbol carrying `@internal` in its docblock is **not** part of the frozen
+   surface. Removing or changing one is permitted in a MINOR. It is documented as internal at the
+   point of definition, so a consumer calling it has been told.
+3. **The mechanical consequence, stated rather than wished away.** The BC checker will still
+   report such a removal as a break, because it reads visibility and not intent. When that day
+   comes the gate is overridden **with a written reason naming this ADR** — a deliberate, visible,
+   reviewed act, not a silent exclusion list that rots. `likely`: Roave offers no `@internal`
+   suppression this project can configure from the throwaway-project install ADR-0031 uses; this
+   was not proved, so the decision does not depend on it either way.
+4. **1.0.0 supersedes the unpublished v0.11.0.** That version was tagged and never published —
+   the tag was unsigned, `verify-tag` refused it (ADR-0032), no Release was drafted, Packagist
+   had no such package. Its tag is deleted and its changelog re-cut as `v1.0.0`, so the first
+   installable version is the one the release gate approved. No code differs.
+
+## Alternatives
+
+1. **Freeze `@internal` symbols as public API too** — the maximally honest reading ("if it is
+   `public`, it is API"). Rejected by the maintainer: it permanently pins a raw-key-bytes getter
+   into the 1.x contract to buy tooling convenience, and the docblock already tells consumers the
+   truth. The cost lands on the wrong party — consumers keep a footgun so that maintainers avoid
+   one future gate override.
+2. **Restrict the two symbols before freezing** (the free-break window): fold the key bytes into a
+   `Crypto`-facing seal, drop the test seam. Rejected as scope: it is code and test work inside a
+   release PR that otherwise contains no code, and it would trade a documented, reviewed exception
+   for a redesign of two working, tested classes on the last day of the free window — the worst
+   moment to redesign a security type.
+3. **Defer 1.0.0** and keep shipping 0.x. Rejected: every milestone is closed and the surface has
+   been stable through twelve of them; staying pre-1.0 tells consumers "not ready" while the real
+   state is "no planned changes", and it postpones the deprecation discipline that makes the
+   library safe to depend on.
+4. **Publish v0.11.0 first, freeze later.** Rejected with the maintainer: it requires either
+   publishing from an unsigned tag — which is what ADR-0032 exists to prevent — or a signed
+   re-tag of a version that would be superseded days later, leaving two first releases where one
+   will do.
+
+## Consequences
+
+**Easier:** consumers get a SemVer promise with teeth, `composer require egl/utils:^1.0` is a
+safe constraint, and the deprecation window becomes a real contract instead of documentation.
+Post-1.0 the decision tree in `maintenance.md` answers version questions without a debate.
+
+**Harder / accepted costs:** the free-break window closes — the two `SqlStatement` corrections
+that pre-1.0 latitude allowed would now each cost a MAJOR. A future `@internal` removal requires a
+written BC-gate override (point 3), which is friction by design. And the freeze is a claim about a
+surface **no external consumer has yet exercised**: this library has never been installed from
+Packagist, so 1.0.0 states confidence earned from tests, benchmarks and review rather than from
+field use. That is the honest basis, and it is recorded here rather than implied by the version
+number.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,3 +74,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0056](0056-refuse-the-terminator-at-construction-and-hand-mail-an-array.md) | Refuse the terminator at construction, and hand `mail()` an array | Accepted |
 | [0057](0057-invalidate-the-run-when-a-control-subject-moves-past-threshold.md) | Invalidate the run when a control subject moves past threshold | Accepted |
 | [0058](0058-an-absolute-ceiling-needs-twice-the-worst-reading-and-catches-accumulation.md) | An absolute ceiling needs twice the worst reading, and it catches accumulation — not steps | Accepted |
+| [0059](0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md) | Freeze the API at 1.0.0, with `@internal` symbols outside the frozen surface | Accepted |

--- a/docs/changelog/v1/v1.0.0.md
+++ b/docs/changelog/v1/v1.0.0.md
@@ -1,8 +1,20 @@
-# v0.11.0 — 2026-08-09
+# v1.0.0 — 2026-08-09
 
-The first release of `egl-util-php`, carrying every milestone from M1 through M12.
+The first release of `egl-util-php`, carrying every milestone from M1 through M12, and the
+version at which the public API is **frozen** (**ADR-0059**).
+
 Rolled from `CHANGELOG.md`'s `[Unreleased]` section at release time; entries appear
-newest-first, as they were written.
+newest-first, as they were written. This file was prepared as `v0.11.0` and re-cut as
+`v1.0.0` **before either was ever published** — see *Superseded pre-release* at the end.
+
+### Added
+
+- **The public API is frozen at 1.0.0** (**ADR-0059**). From here the deprecation policy in
+  [`docs/workflow/maintenance.md`](../../workflow/maintenance.md) binds: a public symbol is
+  deprecated in a MINOR, ships deprecated for one full published MINOR, and is removed only in a
+  MAJOR. Symbols documented `@internal` (`Security\SecretKey::bytes()`,
+  `Security\Hash::selectAlgorithm()`) are **outside** the frozen surface — they are public only
+  because PHP has no package-private visibility.
 
 ### Changed
 
@@ -1152,3 +1164,14 @@ newest-first, as they were written.
   cross-file comparison to disagree with.
 
 ---
+
+## Superseded pre-release
+
+This release was first prepared as **v0.11.0** (roadmap milestone-per-minor mapping, M12 →
+`v0.11.0`) and its tag was pushed. It was **never published**: the tag was unsigned, so
+`release.yml`'s `verify-tag` job refused it (**ADR-0032**), no GitHub Release was ever drafted,
+and the package was not yet registered on Packagist — nothing could resolve or install it.
+
+Rather than leave a version that exists as a tag but never passed the release gate, the same
+tree is released as **v1.0.0** and the `v0.11.0` tag is deleted. There is exactly one first
+release, and it is the one the gate approved. No code differs between the two.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,4 +10,4 @@ README badge.
 
 | Version | Date | Highlights | Notes |
 |---------|------|------------|-------|
-| v0.11.0 | 2026-08-09 | The first release — every milestone M1–M12: DTOs, Database + Persistence, Security, Http, Errors, Mail, Support | [v0.11.0.md](v0.11.0.md) |
+| v1.0.0 | 2026-08-09 | The first release — every milestone M1–M12: DTOs, Database + Persistence, Security, Http, Errors, Mail, Support — and the API freeze (ADR-0059) | [v1.0.0.md](v1.0.0.md) |

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,10 +1,30 @@
-# v0.11.0 — the first release
+# v1.0.0 — the first release, and the API freeze
 
-**2026-08-09** · [changelog](../changelog/v0/v0.11.0.md) · Packagist: `egl/utils`
+**2026-08-09** · [changelog](../changelog/v1/v1.0.0.md) · Packagist: `egl/utils`
 
-The first published version of `egl-util-php`, carrying every milestone from **M1** through **M12**.
-Nothing was released before it: the tag line starts here, and the version reflects the roadmap's
-milestone-per-minor mapping (M12 → `v0.11.0`), not a count of prior releases.
+The first published version of `egl-util-php`, carrying every milestone from **M1** through **M12**,
+and the version at which the public API is **frozen** ([ADR-0059](../adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md)).
+
+Nothing was released before it. A `v0.11.0` was prepared under the roadmap's milestone-per-minor
+mapping and tagged, but never published — its tag was unsigned, so the release gate refused it
+(ADR-0032) and no Release was ever drafted. The same tree ships here instead, so there is exactly
+one first release and it is the one the gate approved. **1.0.0 is not a bigger version than
+0.11.0 — it is the same code with a promise attached.**
+
+## What the freeze means for you
+
+`composer require egl/utils:^1.0` is a safe constraint. Within the 1.x line: no public signature
+is removed or altered, the `D4np\Utils\` namespace is stable, the exception hierarchy keeps its
+shape, `DatabaseConnection`'s pinned defaults keep their semantics, and strict-mode hydration
+keeps its behavior. Anything deprecated ships deprecated for one full published MINOR before a
+MAJOR may remove it ([maintenance.md](../workflow/maintenance.md)).
+
+Two symbols are **deliberately outside** that promise, documented `@internal` at the point of
+definition because PHP has no package-private visibility: `Security\SecretKey::bytes()` and
+`Security\Hash::selectAlgorithm()`. Do not build on them.
+
+Honest basis for the number: this library has never been installed from Packagist, so 1.0.0
+states confidence earned from tests, benchmarks and review rather than from field use.
 
 ```bash
 composer require egl/utils
@@ -31,7 +51,7 @@ deptrac rather than by convention:
 | `D4np\Utils\Mail\` | Validated `EmailAddress`, a `MailMessage` that cannot carry a header terminator, `Mailer`/`NativeMailer` |
 | `D4np\Utils\Support\` | `Str`, `File`, `Csv`, `Url`, `Lookup`, `Env`, `Json`, `FileSequence`, and the exception hierarchy everything above throws into |
 
-The full entry-by-entry history is in the [changelog](../changelog/v0/v0.11.0.md); this page is the
+The full entry-by-entry history is in the [changelog](../changelog/v1/v1.0.0.md); this page is the
 short version plus the things worth knowing before you install.
 
 ## The design stance, in one paragraph

--- a/packages/utils-psr7-bridge/CHANGELOG.md
+++ b/packages/utils-psr7-bridge/CHANGELOG.md
@@ -11,6 +11,13 @@ release does not imply a bridge release, or the reverse.
 
 ## [Unreleased]
 
+### Changed
+
+- **Core constraint widened to `egl/utils: ^1.0`** (was `^0.11`). The core's API-freeze review cut
+  its first release as `1.0.0` rather than `0.11.0` (**ADR-0059**), and a `0.x` caret does not
+  reach across a major — `^0.11` means `>=0.11.0 <0.12.0` and would have missed the only release
+  that exists. Caught in the core's release PR, before the first real install could fail on it.
+
 ### Added
 
 - Publication pipeline (roadmap item **8.3**, **ADR-0035**): this package is released from a signed

--- a/packages/utils-psr7-bridge/README.md
+++ b/packages/utils-psr7-bridge/README.md
@@ -25,17 +25,20 @@ composer require egl/utils-psr7-bridge
 ```
 
 **Not yet possible — but for a narrower reason than before.** This package requires
-`egl/utils: ^0.11`, and the core's `v0.11.0` **is** its first release, so the dependency now names a
+`egl/utils: ^1.0`, and the core's `v1.0.0` **is** its first release, so the dependency now names a
 version that exists. What is still missing is *this* package's own publication: item 8.3's pipeline
 needs the split repository and its token configured (`docs/workflow/release.md` § *One-time
 maintainer prerequisites*), and no `utils-psr7-bridge-v*` tag has been cut. Until then the bridge is
 developed and tested inside the monorepo, where CI resolves the core from the working tree
 (spec 02 §7).
 
-The constraint was `^0.7` until the core's first release. Composer reads `^0.7` on a `0.x` package as
-`>=0.7.0 <0.8.0`, so once the core released as `0.11.0` that constraint named a version which would
-never exist — widened to `^0.11` in the release PR rather than left to fail at the first real
-install.
+This constraint has been corrected twice, both times in a release PR and both times because a
+`0.x` caret is narrower than it looks. It was `^0.7` while the core was pre-release; when the
+core's release was prepared as `0.11.0` that became `>=0.7.0 <0.8.0` against a version which would
+never exist, so it was widened to `^0.11`. The API-freeze review then cut the core's first release
+as **`1.0.0`** instead ([ADR-0059](../../docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md)),
+and `^0.11` would have missed it for the same reason — corrected to `^1.0`, which is the first
+constraint here that a SemVer-stable core actually widens over time.
 
 You also need a PSR-17 factory implementation — any of them:
 

--- a/packages/utils-psr7-bridge/composer.json
+++ b/packages/utils-psr7-bridge/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "egl/utils": "^0.11",
+        "egl/utils": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^2.0"
     },

--- a/src/main/php/d4np/utils/Version.php
+++ b/src/main/php/d4np/utils/Version.php
@@ -14,7 +14,7 @@ namespace D4np\Utils;
  */
 final class Version
 {
-    public const VERSION = '0.11.0';
+    public const VERSION = '1.0.0';
 
     private function __construct()
     {


### PR DESCRIPTION
## Summary

The release PR for **v1.0.0** — the dedicated post-M7 **API-freeze review** `ROADMAP.md` has
carried as a standing commitment since the plan phase, held rather than skipped, and recorded as
**ADR-0059**.

Preconditions were checked, not assumed: every roadmap item across **M1–M12 is closed** (0
unchecked boxes), `CHANGELOG.md`'s `[Unreleased]` is empty, CI is green on the base commit. So
1.0.0 carries **no functional delta** — its entire content is the promise that the surface in
spec §5 is stable and that `maintenance.md`'s deprecation window (deprecate in a MINOR, ship one
full published MINOR deprecated, remove only in a MAJOR) now binds.

That promise is expensive in exactly one direction, which is what makes this a review: pre-1.0 a
break is free — this project used that latitude twice on `SqlStatement` (ADR-0039, ADR-0041) —
and after 1.0.0 the same correction costs a MAJOR.

## The two decisions (both put to the maintainer, answered before drafting)

1. **`@internal` symbols are outside the frozen surface.** `Security\SecretKey::bytes()` and
   `Security\Hash::selectAlgorithm()` are `public` only because PHP has no package-private
   visibility. Roave reads visibility, not docblocks, so frozen naively a raw-key-bytes getter
   becomes part of the 1.x contract. They are excluded by ADR; a future removal takes a written
   BC-gate override naming the ADR — friction by design, rather than a suppression list that rots.
2. **v1.0.0 supersedes the unpublished v0.11.0.** That version was tagged and never published:
   the tag was unsigned, `verify-tag` refused it (ADR-0032), no Release was drafted, Packagist had
   no such package. Leaving it would turn a tag the release gate never approved into an installable
   version. Its changelog is re-cut as `v1.0.0` and **the `v0.11.0` tag has been deleted**
   (local + origin, done). No code differs between the two.

## The defect this review caught

The bridge package required `egl/utils: ^0.11`. A `0.x` caret does not reach across a major —
`^0.11` means `>=0.11.0 <0.12.0`, so it would have **missed 1.0.0, the only release that exists**,
and the first real install would have failed on it. Corrected to `^1.0` here, with the package's
own changelog line and its README's constraint history brought up to date. (Third correction to
that constraint, each in a release PR — the README now says why.)

## Changes

- `docs/adr/0059-…md` — the freeze decision, its four alternatives, and the honest basis for the
  number; `docs/adr/README.md` index row.
- `src/main/php/d4np/utils/Version.php` `0.11.0` → `1.0.0`; `README.md` status badge.
- `docs/changelog/v0/v0.11.0.md` → `docs/changelog/v1/v1.0.0.md` (+ freeze entry, + *Superseded
  pre-release* section); `CHANGELOG.md` index row.
- `docs/releases/v0.11.0.md` → `docs/releases/v1.0.0.md` (+ *What the freeze means for you*);
  `docs/releases/README.md` index row.
- `ROADMAP.md` — the standing "1.0.0 decision" lines now record the review as held and settled.
- `packages/utils-psr7-bridge/` — `composer.json` constraint, `CHANGELOG.md`, `README.md`.

## Verification

- [x] `python tools/consistency_lint.py` — OK (version lockstep across constant, badge and
      changelog split; ADR index; spec map; milestones)
- [x] `python tools/release_gate.py --tag v1.0.0` — OK (tag agrees with the constant; release
      notes and changelog split exist and are indexed)
- [x] Bridge constraint re-read from the parsed manifest after editing: `^1.0`
- [x] No test asserts the version constant (checked) — the only couplings are the two gates above
- [x] Full CI green on this PR — matrix 8.1/8.2/8.3, PHPStan, CS-Fixer, deptrac, coverage
      floor, mutation, both PSR-7 bridge contract runs, prefer-lowest, benchmarks
- [x] **`quality / backward compatibility` is green but verified nothing — stated, not
      cited.** Read the job, not the checks column (the lesson from item 10.8): it emitted
      *"This repository has no `v*.*.*` tag … the gate self-enables at the first tag"* and
      self-skipped, because deleting the unsigned `v0.11.0` left the repo with zero tags.
      Nothing is being hidden by that: this PR changes no source behavior (one constant, docs,
      one dependency constraint), and even with the tag present the comparison would have been
      `0.11.0 → 1.0.0` — a major bump, where `bc_gate.py` permits breaks by construction. The
      gate arms itself for real at the `v1.0.0` tag, which is the first baseline it can ever
      have.

## Documentation Impact

- [x] README.md, ROADMAP.md, CHANGELOG.md, release notes, ADR + index all updated in this PR
- [x] ADR opened — ADR-0059 (the decision *is* the deliverable)
- [ ] docs/patterns/ — unchanged
- [x] Spec — unchanged deliberately: the freeze ratifies §5 as written; it does not amend it
- [x] PR metadata — assignee (owner); label `documentation`; milestone none (release PR)

## After merge

1. Tag: `git tag -a -s v1.0.0 -m "v1.0.0 — the first release, and the API freeze"` then
   `git push origin v1.0.0`. **The `-s` is not optional** — the last tag was refused for exactly
   this. A signing key registered on the GitHub account is the one outstanding prerequisite.
2. `verify-tag` → `test-tagged-tree` (8.1/8.2/8.3) → the workflow drafts the Release. **Publishing
   is yours.**
3. Register `egl/utils` on Packagist (one-time, `docs/workflow/release.md`). Only then can the
   bridge's own publication pipeline run at all — it resolves the core as a consumer would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
