### PR TITLE
docs: finish the v1.0.0 transition and define the supported-versions window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,31 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Supported-versions window for the post-1.0 line**, defined in
+  [`docs/workflow/maintenance.md`](docs/workflow/maintenance.md) and pointed to from `SECURITY.md`:
+  the latest release of the current MAJOR, with the previous MAJOR's final release on security
+  fixes until `X+1.1.0` ships. `SECURITY.md` had deferred to that section since the repository was
+  generated; the section had never existed (ADR-0060).
+
+### Fixed
+
+- **`docs/releases/v1.0.0.md` no longer contradicts itself.** Its closing section still declared
+  that the 1.0.0 API-freeze review *"has not happened"* and that *"this is a `0.x` release"* — text
+  carried over from the unpublished `v0.11.0` notes, inside the document announcing the freeze.
+  Removed. The same file recorded the bridge's constraint on the core as `^0.11`; corrected to the
+  `^1.0` that `packages/utils-psr7-bridge/composer.json` actually declares.
+- **`SECURITY.md`'s supported-versions table applies at a `1.0.0` HEAD.** It previously offered only
+  `latest released 0.x` and `older 0.x`, and no `0.x` was ever published — so the policy's table had
+  no row a consumer could be standing on.
+- **`packages/utils-psr7-bridge/README.md` no longer announces itself as a scaffold** whose
+  converters *"land in 8.2"*. The converters and their BFR-01…BFR-22 contract suite shipped in item
+  8.2 and the publication pipeline in 8.3; the banner now states the real remaining gap (the
+  one-time publication setup), and *Usage* carries a worked example verified against the frozen 1.0
+  signatures instead of a forward reference.
+- Two dead `ROADMAP.md` links to ADR-0040, which had pointed at the file's pre-rename name since it
+  was renamed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ setup.
 | 10 | Persistence | ✅ done |
 | 11 | Http application layer | ✅ done |
 | 12 | Security & channels | ✅ done |
+| 13 | Documentation & release hygiene (post-1.0) | ⏳ planned |
 
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,8 +27,9 @@ API-freeze review below settled the whole line into a single first release, **`v
   unpublished `v0.11.0` superseded. Post-1.0 versioning follows
   [`maintenance.md`](docs/workflow/maintenance.md)'s decision tree, not the milestone mapping.
 - **Session journal:** see [`docs/journal/`](docs/journal/). Latest checkpoint:
-  [2026-08-08 — Two open decisions, one table, and the number I nearly picked](docs/journal/2026/08/2026-08-08-nfr-ceiling-decisions.md).
+  [2026-08-09 — The section SECURITY.md had been pointing at for its whole life](docs/journal/2026/08/2026-08-09-finish-v1-transition.md).
   Previous:
+  [2026-08-08 — Two open decisions, one table, and the number I nearly picked](docs/journal/2026/08/2026-08-08-nfr-ceiling-decisions.md),
   [2026-08-08 — Closing the milestone by fixing the tool that kept flagging it as open](docs/journal/2026/08/2026-08-08-benchmark-run-invalidation.md),
   [2026-08-08 — The last planned item, and the milestone that still doesn't close](docs/journal/2026/08/2026-08-08-crypto-benchmark.md),
   [2026-08-08 — Three answers to the same bytes, and a corpus that could not fail](docs/journal/2026/08/2026-08-08-mail-group.md),
@@ -513,6 +514,35 @@ dedicated post-M7 API-freeze review — held 2026-08-09, settled by **ADR-0059**
       uploaded files cross the `$_FILES` ↔ stream boundary with no stream access on a failed
       upload. **A decision, not an implementation** — the ADR-002 contract *tests* move to item
       8.2, which is why the Spec Coverage Map's §7 row reopens. Milestone 8 carries the build.*
+- [x] 7.5 Finish the `v1.0.0` transition in the prose the release left behind. A six-persona
+      documentation review (2026-08-09) found the release had updated every version-bearing artifact
+      and none of the text describing them: `docs/releases/v1.0.0.md` announced the freeze and then,
+      four sections later, still said *"The **1.0.0 API-freeze review** has not happened. This is a
+      `0.x` release"* — carried verbatim from the `v0.11.0` notes, with its own document as the
+      refutation; the same file recorded the bridge's core constraint as `^0.11` where
+      `packages/utils-psr7-bridge/composer.json` says `^1.0`; `SECURITY.md`'s table offered only
+      `latest released 0.x` / `older 0.x`, leaving **no row applicable at a `1.0.0` HEAD**; and the
+      bridge README still opened *"Status: scaffold … the converters land in **8.2**"* over a Usage
+      section saying they had not arrived — contradicted by its own contract section, its CHANGELOG,
+      and the shipped `Psr7Bridge` — size: S · route: fast / low · **ADR-0060**. ***The load-bearing
+      find was not a stale sentence but a dangling promise:*** *`SECURITY.md` deferred the post-1.0
+      support window to `maintenance.md`, and `maintenance.md` had never contained one — a
+      cross-reference naming a definition that did not exist. It survived the entire pre-1.0 line
+      because the clause above it still applied, so nobody had cause to follow the pointer;
+      `maintenance.md` §Security fixes compounded it, saying "backport to every supported line" with
+      `supported` undefined. Defined in **ADR-0060** on ADR-0031's instrument — count the window in
+      **published releases, not calendar time**, since a time window can elapse with no release in
+      it — and stated with its limit rather than without: the previous-MAJOR row has **never been
+      exercised**, `1.x` being the only line that has ever existed. **No lint could have caught
+      this**: `consistency_lint.py` checks version lockstep, the ADR index, pattern rows, the spec
+      coverage map, milestone agreement and bug-ledger integrity, and nothing asserts that a
+      document referenced for a definition contains one — filed as item 13.4, a tool change rather
+      than a policy decision. **Deliberately not decided here:** the notes' claim that this is "the
+      one the gate approved". The `v1.0.0` tag is **unsigned**; the gate's `The tag must be signed`
+      step failed (run 31283673519), skipping both the tagged-tree test matrix and the draft job;
+      the Release was then published by hand 13 minutes later. Re-sign-and-re-run versus
+      record-the-bypass is a maintainer call on release provenance (AGENTS.md §6.1), so it is filed
+      as item 13.1 and left untouched rather than quietly rewritten to match what happened.*
 
 ---
 
@@ -1255,7 +1285,7 @@ The console-side trio: client, router, envelope (RFC-0002 FR-37…FR-39).
       **deliberately keeping its absolute ceiling**; that decision is the one now under question,
       and item 9.6 flagged the margin (~9% headroom, the thinnest of any gated NFR here) as worth
       watching for exactly this. Options, none taken unilaterally because the number belongs to
-      the spec ([ADR-0040](docs/adr/0040-run-infection-outside-the-dependency-graph-and-hold-the-floor-at-the-specs-70.md)):
+      the spec ([ADR-0040](docs/adr/0040-install-the-mutation-tester-outside-the-graph-and-keep-nfr07s-own-number.md)):
       raise NFR-10 to a value CI can actually hold, measure the subject as a *median of N runs*
       rather than one, exclude it from the absolute gate too (and say plainly that NFR-10 is then
       unenforced), or keep it and accept a job that fails a few runs in twenty. **A gate that
@@ -1316,7 +1346,7 @@ The console-side trio: client, router, envelope (RFC-0002 FR-37…FR-39).
       happens to avoid tripping this ceiling. Resolving 11.7 removes that side effect as well as
       the router's own gap; left open, the cost of leaving it open keeps compounding onto whatever
       is added next. Options, none taken unilaterally
-      ([ADR-0040](docs/adr/0040-run-infection-outside-the-dependency-graph-and-hold-the-floor-at-the-specs-70.md)
+      ([ADR-0040](docs/adr/0040-install-the-mutation-tester-outside-the-graph-and-keep-nfr07s-own-number.md)
       reserves spec numbers for the maintainer): **(a)** raise NFR-11's router budget to a value
       the current linear scan clears (the measured number, with headroom, e.g. ≤ 10 µs); **(b)**
       add a cache or an index to `Router` — reversing ADR-0050's stated non-goal, which named "a
@@ -1557,6 +1587,89 @@ AEAD crypto, PSR-3 channel composition, and the Mail group (RFC-0002 FR-40…FR-
       and the identical numbers with no `--control` given reproducing the pre-existing `FAIL`
       output byte-for-byte — proving the change is additive, not a behavior change for anyone not
       opting into a control.*
+
+---
+
+## Milestone 13 — Documentation & release hygiene (post-1.0) · size: M
+
+Filed 2026-08-09 from a six-persona review of `README.md` and the consumer-facing documentation
+(Google developer-documentation style; onboarding/first-call; DevDiv claim verification against the
+tree; Diátaxis information architecture; editorial coherence; and an OSPO compliance audit) — six
+independent reports, **unanimous** on 13.2. Item 7.5 shipped the corrections that were unambiguous;
+this milestone holds what needs a maintainer decision, a tool, or more than a prose edit. **Not spec
+work:** RFC-0001/0002 scope is closed, and every item here concerns the documentation surface and
+the release process around it.
+
+- [ ] 13.1 Settle the `v1.0.0` tag's provenance. The tag is **unsigned**, so the release gate's
+      `The tag must be signed` step failed (run 31283673519) and both the tagged-tree test matrix
+      and the draft-Release job were **skipped**; the GitHub Release was published by hand 13
+      minutes later. Two consequences, neither reflected in the docs: `docs/releases/v1.0.0.md`
+      says this release is *"the one the gate approved"* — it is not — and **the tagged tree never
+      ran through the 8.1/8.2/8.3 release matrix**, which is the check that catches a tag pointing
+      at a commit CI never exercised (ADR-0032's whole purpose). **A maintainer decision, not an
+      agent's** (AGENTS.md §6.1 — agents never rewrite release provenance): either re-cut the tag
+      signed and let the gate run green, which makes the existing sentence true *and* produces the
+      matrix evidence, or keep the release as published and amend the notes to record the bypass
+      and the unverified matrix. `v0.11.0` failed the identical step first, so this is a **repeat**,
+      not a one-off — the signing key ADR-0032 names as a one-time prerequisite is the likely root
+      cause — size: S · route: standard / medium
+- [ ] 13.2 Give `README.md` a consumer on-ramp. All six reviewers independently found no path from
+      landing on the repository to a first working call: no `composer require egl/utils` anywhere a
+      consumer looks (it appears only in `docs/releases/v1.0.0.md`, which the README does not link),
+      no statement of whether the package resolves from Packagist or needs a VCS entry, and **zero
+      runnable examples** — line 28's `use D4np\Utils\Dto\DataTransferObject;` is an import
+      fragment, not usage, for a library of this surface. Also in scope, all verified: the opening
+      paragraph renders as a **verbless fragment** (line 7 is an orphaned "A"); the quality-bar list
+      claims "sanitizers", which names no CI job here and collides with the library's own
+      `Security\Sanitizer`; and the `egl-util-php` / `egl/utils` / `D4np\Utils` naming system is
+      never reconciled for the reader, although `docs/specs/01_spec_utils.md` requires it be stated
+      in the README. Every example added must be verified against the frozen 1.0 signatures — item
+      13.3 is why that is not a formality — size: M · route: standard / medium
+- [ ] 13.3 Fix `docs/patterns/endpoint-kernel.md`'s flagship example, which **cannot run** against
+      the API it documents: `new Response()` (line 45) hits a **private** constructor — the entry
+      points are `Response::create/text/html/json/redirect` — `setHeader()` (line 56) does not exist
+      (the API is `withHeader()`), and line 61 calls the static `json()` through an instance,
+      discarding the `Allow` header the example built two lines earlier. Verified against
+      `src/main/php/d4np/utils/Http/Response.php` at 1.0.0. Then sweep the remaining doc examples
+      for the same rot, since nothing has ever executed them — size: S · route: standard / medium
+- [ ] 13.4 Make documentation cross-references checkable. Item 7.5's load-bearing defect was
+      `SECURITY.md` deferring a definition to `maintenance.md`, to a section that did not exist —
+      invisible for the entire pre-1.0 line, because the clause above the pointer still applied.
+      `consistency_lint.py` covers version lockstep, the ADR index, pattern rows, the spec coverage
+      map, milestone agreement and bug-ledger integrity, and none of it resolves a link. Minimum:
+      every relative link in tracked Markdown resolves to a file that exists, and a reference naming
+      a section (`§ Foo`, `#anchor`) finds that heading in the target. Prove the check can fail
+      before trusting it — the standing method (items 1.11, 2.7). **Not speculative:** a throwaway
+      resolver run over the 142 relative links in item 7.5's touched files found **two already
+      broken on `master`** — both `ROADMAP.md` pointing at `0040-run-infection-outside-the-
+      dependency-graph-…md`, an ADR filename that has not existed since the file was renamed to
+      `0040-install-the-mutation-tester-outside-the-graph-…md`. Repaired under 7.5 as mechanical
+      rot; the point is that eleven files were enough to surface two, and nothing was looking —
+      size: M · route: standard / medium
+- [ ] 13.5 Pick one home for release notes. `CHANGELOG.md`'s header directs readers to
+      `docs/changelog/v<MAJOR>/`; `docs/README.md` documents `docs/releases/`. **Both exist and both
+      hold a v1.0.0 file**, so a maintainer updating "the" release notes has even odds of editing
+      the copy nobody reads. Choose the canonical location, reduce the other to a pointer, and
+      complete the `docs/README.md` layout table, which omits `docs/rfc/` and `docs/changelog/`
+      entirely. **Backfill the journal index in the same pass:** `docs/journal/README.md` states its
+      own procedure — *"adds a link row to this index"* at every state-changing session — and holds
+      **28 rows against 69 files on disk**, so 40 checkpoints are unreachable except by listing the
+      directory; it silently stopped being maintained after 2026-08-05 — size: S · route: fast /
+      low
+- [ ] 13.6 Add the community files a public repository is expected to carry. `CONTRIBUTING.md` and
+      `CODE_OF_CONDUCT.md` are both absent: `AGENTS.md` encodes the contribution contract for
+      **agents**, leaving an outside human contributor with no front door and no statement of what a
+      PR must clear. Also absent: `packages/utils-psr7-bridge/` ships no `LICENSE`, and the split
+      pipeline (ADR-0033) publishes exactly that directory — so the generated public package would
+      carry an MIT claim in `composer.json` with no licence text beside it — size: S · route: fast /
+      low
+- [ ] 13.7 Settle the `phpDocumentor` API-docs gate. `AGENTS.md` §10 lists "**API docs** —
+      `phpDocumentor` builds without warnings" as a mandatory per-PR gate and
+      `docs/workflow/documentation.md` repeats it, but there is **no phpDocumentor config, no CI
+      job and no published API reference** anywhere in the repository — a gate in the contract that
+      has never run once. Either wire it (publishing the output would also serve 13.2's reference
+      need) or strike the claim: a documented gate nobody executes is the L-0011 failure class this
+      repository already named once — size: M · route: standard / medium
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1670,6 +1670,17 @@ the release process around it.
       has never run once. Either wire it (publishing the output would also serve 13.2's reference
       need) or strike the claim: a documented gate nobody executes is the L-0011 failure class this
       repository already named once — size: M · route: standard / medium
+- [ ] 13.8 Apply the GitHub-side configuration `docs/workflow/github-setup.md` describes, which has
+      never been run. **Labels:** `.github/labels.yml` defines the ten Conventional-Commit type
+      labels (`feat`, `fix`, `docs`, `perf`, `ci`, `security`, …) and the repository still carries
+      GitHub's stock set (`bug`, `enhancement`, `good first issue`, …) — **not one type label
+      exists**, so AGENTS.md §6.4's "exactly one type label matching the lead commit's type" cannot
+      be satisfied on any PR, including item 7.5's own. **Milestones:** eleven exist, named
+      `v0.1.0`…`v0.11.0` rather than §6.4's `MN — name`, none for M12/M13, none for the `v1.0.0`
+      that actually shipped, and **all eleven still open** although M1–M11 closed. So the required
+      `--milestone` argument names nothing real either. Reconcile the naming convention first —
+      §6.4 and the live repository disagree, and the contract does not automatically win over a
+      convention the maintainer has been using for eleven milestones — size: S · route: fast / low
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,18 @@
 
 ## Supported versions
 
-Until `egl-util-php` reaches `v1.0.0`, only the latest released minor line receives
-security fixes. After `1.0.0`, the supported window is defined in
-[`docs/workflow/maintenance.md`](docs/workflow/maintenance.md).
+`egl-util-php` reached `v1.0.0` on 2026-08-09. Security fixes land on the **latest release
+of the current MAJOR line**, and reach you by upgrading to it — the 1.x API freeze
+([ADR-0059](docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md))
+is what makes that upgrade safe to take. Older releases are not patched in place. The full
+window, including what happens when a `2.0.0` line opens, is in
+[`docs/workflow/maintenance.md`](docs/workflow/maintenance.md) § *Supported versions*.
 
 | Version | Supported |
 |---------|-----------|
-| latest released `0.x` | ✅ |
-| older `0.x` | ❌ |
+| latest `1.x` | ✅ |
+| older `1.x` | ❌ — upgrade within 1.x; the freeze guarantees no break |
+| `0.x` | ❌ — none was ever published |
 
 ## Reporting a vulnerability
 

--- a/docs/adr/0060-support-the-latest-release-of-the-current-major-and-measure-the-window-in-releases.md
+++ b/docs/adr/0060-support-the-latest-release-of-the-current-major-and-measure-the-window-in-releases.md
@@ -1,0 +1,91 @@
+# ADR-0060: Support the latest release of the current MAJOR, and measure the window in releases
+
+- **Status:** Accepted
+- **Date:** 2026-08-09
+- **Deciders:** project architect (agent), maintainer (`danielPoloWork`)
+- **Related:** ADR-0031 (deprecation window), ADR-0059 (API freeze at 1.0.0), `SECURITY.md`,
+  [`docs/workflow/maintenance.md`](../workflow/maintenance.md), roadmap item 7.5
+
+## Context
+
+`SECURITY.md` has, since the repository was generated, said this:
+
+> Until `egl-util-php` reaches `v1.0.0`, only the latest released minor line receives security
+> fixes. After `1.0.0`, the supported window is defined in `docs/workflow/maintenance.md`.
+
+Both halves stopped working on 2026-08-09, when `v1.0.0` shipped (ADR-0059) — and they failed in
+opposite directions. The **first** half became inapplicable: its table offered exactly two rows,
+`latest released 0.x` and `older 0.x`, and no `0.x` was ever published (a `v0.11.0` was tagged and
+never released), so at a `1.0.0` HEAD the policy's table had no row a consumer could be standing on.
+The **second** half was a promise with nothing behind it: `maintenance.md` has never had a supported
+versions section. The deferral pointed at a document that did not answer.
+
+That second failure is the one worth naming, because it survived review for the entire pre-1.0 line.
+A cross-reference is only as good as its target, and nothing in the repository checked this one —
+`consistency_lint.py` verifies version lockstep, the ADR index, pattern rows, the spec coverage map,
+milestone agreement and bug-ledger integrity, but not that a document referenced by name for a
+definition actually contains one. The pre-1.0 clause masked it: while the first half applied, nobody
+had cause to follow the pointer.
+
+`maintenance.md` §*Security fixes* compounded it — "backport to every supported line" — using a term
+the document never defined.
+
+## Decision
+
+**Supported means the latest release of the current MAJOR line**, and a fix reaches consumers by
+their upgrading to it; older releases are not patched in place. When a new MAJOR opens, the previous
+MAJOR's final release receives **security fixes only**, until the new line has shipped one full
+MINOR (`X+1.1.0`). The window is counted in **published releases, not calendar time**.
+
+The definition lives in `maintenance.md` § *Supported versions* — the location `SECURITY.md` already
+promised — and `SECURITY.md` carries only the consumer-facing table and the pointer.
+
+Two properties make this coherent rather than merely convenient. Within a MAJOR, "upgrade to the
+latest" is not a cost the policy quietly pushes onto consumers: SemVer plus ADR-0059's freeze forbid
+the break that would make it one, so the remedy the policy prescribes is a remedy it has already
+guaranteed is safe. And counting in releases rather than months is the same instrument ADR-0031
+chose for the deprecation window, for the same stated reason — a window nobody shipped through gave
+no consumer a chance to move.
+
+## Alternatives Considered
+
+- **Support the latest PATCH of every published MINOR.** Rejected: backporting to N lines is work
+  this project's staffing cannot honor, and a support promise that outruns capacity is worse than a
+  narrow one — it is discovered to be false at the worst moment. It also buys little here, since the
+  freeze already makes moving within 1.x cheap.
+- **A calendar window ("previous MAJOR supported for 12 months").** Rejected on the precedent this
+  repository set for itself in ADR-0031: time-based windows can elapse with no release in them,
+  which satisfies the letter while giving consumers nothing to upgrade *to*. Release-counted windows
+  cannot expire vacuously.
+- **Support only the single latest release, with no previous-MAJOR clause.** Rejected as too sharp
+  at the only moment the policy is load-bearing: a MAJOR bump is precisely when upgrading is *not*
+  free, so dropping the old line the day the new one ships strands the consumers with the highest
+  migration cost.
+- **Leave `SECURITY.md` deferring and define nothing.** Rejected — that is the defect under repair,
+  not an option. Under the enterprise posture (AGENTS.md §7) a security-relevant policy is not an
+  undocumented judgment call.
+
+## Consequences
+
+- **API / compatibility:** none. This is policy, not code; no public symbol changes.
+- **Documentation:** `SECURITY.md`'s table now has a row that applies at HEAD;
+  `maintenance.md` gains § *Supported versions*, and its "every supported line" phrase acquires a
+  referent. This ADR is the rationale both point back to.
+- **Process:** a new MAJOR now carries an obligation the release checklist must honor — the previous
+  line stays open for security fixes until `X+1.1.0`. Nothing enforces this mechanically today.
+- **Testing/tooling:** none. Deliberately noted as a gap rather than claimed as covered: no lint
+  asserts that a document referenced for a definition contains one, which is the exact class of
+  defect this ADR repairs. Filed as roadmap item 13.4 rather than fixed here, because a
+  cross-reference checker is a tool change, not a policy decision.
+- **Known limitation, stated rather than discovered:** the previous-MAJOR row has never been
+  exercised — `1.x` is the only line that has ever existed. It is a commitment made in advance, and
+  the first `2.0.0` is where it gets tested. The window also says which line a fix lands on, not how
+  fast it arrives: this is a solo-maintained library, `SECURITY.md` § *What to expect* commits to a
+  sequence and to no timeframe, and no response-time SLA is stated or implied anywhere.
+
+## References
+
+- ADR-0031 — deprecation window measured in published MINORs (the instrument reused here).
+- ADR-0059 — the 1.0.0 API freeze that makes intra-MAJOR upgrading a safe remedy.
+- [Semantic Versioning 2.0.0](https://semver.org/) §§ 4, 8.
+- [`SECURITY.md`](../../SECURITY.md), [`docs/workflow/maintenance.md`](../workflow/maintenance.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -75,3 +75,4 @@ Status transitions: `Proposed` → `Accepted` → (`Superseded by ADR-XXXX` | `D
 | [0057](0057-invalidate-the-run-when-a-control-subject-moves-past-threshold.md) | Invalidate the run when a control subject moves past threshold | Accepted |
 | [0058](0058-an-absolute-ceiling-needs-twice-the-worst-reading-and-catches-accumulation.md) | An absolute ceiling needs twice the worst reading, and it catches accumulation — not steps | Accepted |
 | [0059](0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md) | Freeze the API at 1.0.0, with `@internal` symbols outside the frozen surface | Accepted |
+| [0060](0060-support-the-latest-release-of-the-current-major-and-measure-the-window-in-releases.md) | Support the latest release of the current MAJOR, and measure the window in releases | Accepted |

--- a/docs/journal/2026/08/2026-08-09-finish-v1-transition.md
+++ b/docs/journal/2026/08/2026-08-09-finish-v1-transition.md
@@ -1,0 +1,96 @@
+# 2026-08-09 — The section SECURITY.md had been pointing at for its whole life
+
+Roadmap item **7.5**, filed and closed in the same PR. Route `fast / low`; session model Fable 5 —
+several tiers above the route, because the session did not start as a roadmap item. It started as a
+documentation review, and the review is what produced the item.
+
+## Six reviewers, and the one finding they all had
+
+The maintainer asked for a panel: six agents, each impersonating a documentation professional from
+a different enterprise tradition — Google's developer-documentation style guide, an onboarding/
+first-call lens, DevDiv-style claim verification against the tree, Diátaxis information
+architecture, editorial coherence, and an OSPO compliance audit. Six independent reports, no
+cross-talk, one shared rubric.
+
+Mean overall score **5.0/10**. The dimension that failed was not writing quality — tone averaged
+6.8 — it was **coherence, at 4.0**, and the reason is timing: `v1.0.0` merged and was tagged by a
+parallel session *while the panel was running*. So the panel reviewed a repository mid-transition
+and caught it in the act. That is also why I re-verified every Critical and every convergent
+finding myself before reporting: three of them had already been fixed by the release commit between
+the review starting and finishing, and reporting those would have been noise.
+
+All six, independently, found the same thing first: **there is no consumer on-ramp**. No
+`composer require egl/utils` on any surface a consumer reaches, and zero runnable examples. That
+one is item 13.2 — too large for this PR, and it needs prose written rather than corrected.
+
+## The find that was not a stale sentence
+
+Most of what the panel caught was straightforward rot: the bridge README still opening *"Status:
+scaffold … the converters land in 8.2"* two milestones after they landed; `docs/releases/v1.0.0.md`
+announcing the API freeze and then, four sections later, still carrying the `v0.11.0` paragraph
+saying *"The 1.0.0 API-freeze review has not happened. This is a `0.x` release."* Its own document
+is the refutation. Delete, correct, move on.
+
+The one worth the ADR was different in kind. `SECURITY.md` said:
+
+> After `1.0.0`, the supported window is defined in `docs/workflow/maintenance.md`.
+
+`maintenance.md` has never had a supported-versions section. Not stale — **never written**. A
+cross-reference naming a definition that does not exist, and it survived the entire pre-1.0 line
+because the clause immediately above it still applied, so no reader ever had cause to follow the
+pointer. `maintenance.md` §*Security fixes* compounded it, instructing a backport "to every
+supported line" using a term the document never defined.
+
+What makes that the interesting failure is that **nothing in this repository could have caught it**.
+`consistency_lint.py` checks version lockstep, the ADR index, pattern rows, the spec coverage map,
+milestone agreement and bug-ledger integrity — six real invariants, and not one of them resolves a
+link. The defect class is "a document promises that another document answers a question", and we
+have no instrument for it. Filed as item 13.4 rather than built here: it is a tool change, and this
+item was a policy decision.
+
+Defined the window in **ADR-0060**, reusing ADR-0031's instrument rather than inventing one — count
+the window in *published releases*, not calendar time, because a time-based window can elapse with
+no release inside it and satisfy its own letter while giving consumers nothing to upgrade to. And
+wrote the limit into the policy instead of leaving it to be discovered: the previous-MAJOR row has
+**never been exercised**, `1.x` being the only line that has ever existed. It is a commitment made
+in advance, and the first `2.0.0` is where it gets tested.
+
+## What I did not fix, on purpose
+
+The v1.0.0 release notes say the tag that shipped is *"the one the gate approved"*. Checking that
+sentence was meant to take thirty seconds:
+
+```
+$ git cat-file -p v1.0.0 | grep -c 'BEGIN PGP'
+0
+$ gh run view 31283673519 --json jobs
+failure  verify v1.0.0 is signed and consistent
+skipped  test ${{ github.ref_name }} on ${{ matrix.toolchain }}
+skipped  draft GitHub Release for ${{ github.ref_name }}
+```
+
+The failing step is named `The tag must be signed`. Everything downstream was skipped — including
+the job that runs the tagged tree on 8.1/8.2/8.3, which is the check ADR-0032 exists to provide:
+a tag can point at a commit CI never ran. The GitHub Release exists anyway, published by hand
+thirteen minutes after the failed run.
+
+So the sentence is false, and it is false about the same mechanism it credits for refusing
+`v0.11.0` — that release's tag was unsigned too, which the notes say out loud. Second occurrence,
+not an accident.
+
+I left it exactly as written. The remedy is a choice between re-cutting a published tag signed
+(which would make the sentence true and produce the missing matrix evidence) and amending the notes
+to record the bypass — and the first of those rewrites the provenance of a published release, which
+AGENTS.md §6.1 puts on the maintainer's side of the line. Correcting the prose myself would have
+quietly foreclosed the better option. Filed as item **13.1**, with the run id, and raised directly
+rather than left in the roadmap to be found.
+
+## Housekeeping
+
+Worked in an isolated `git worktree` — this checkout is shared with parallel sessions, and one of
+them landed a release under me while the panel ran, which is the argument for the practice rather
+than a hypothetical. The worktree tool named the branch `worktree-docs+finish-v1-transition`;
+renamed to `docs/finish-v1-transition` to satisfy §6.2, which the generated name does not.
+
+Milestone 13 opened for the rest of the panel's backlog — seven items, each carrying the evidence
+that produced it, so none of them has to be re-derived by whoever takes it.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-09 — The section SECURITY.md had been pointing at for its whole life](2026/08/2026-08-09-finish-v1-transition.md)
 - [2026-08-05 — A probe that passed, and this time it was the code](2026/08/2026-08-05-session-csrf.md)
 - [2026-08-04 — The client picks the type, not the application](2026/08/2026-08-04-http-wrappers.md)
 - [2026-08-04 — A range, not a ceiling: measuring the wrong thing would have proved nothing](2026/08/2026-08-04-hash-matrix-nfr05.md)

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -90,7 +90,7 @@ Pre-1.0 permits breaking changes in a minor, and two landed during development. 
 - **The `egl/utils-psr7-bridge` package is not published yet.** Its source lives in this repository
   under `packages/`, its contract suite runs on every PR against two PSR-17 implementations, and its
   own publication needs the split repository configured (roadmap item 8.3). Its constraint on the
-  core is `^0.11` as of this release.
+  core is `^1.0` as of this release — this release is the first version that constraint can resolve.
 
 ## Verification behind this release
 
@@ -100,9 +100,3 @@ score 79% against a 70% floor; `composer audit` and a `--prefer-lowest` install;
 budgets and a same-runner relative regression gate, both green. Every performance claim in the
 documentation is backed by a benchmark under `src/bench/` — the methodology and the honest caveats
 are in [`docs/benchmarks/`](../benchmarks/).
-
-## Not in this release
-
-The **1.0.0 API-freeze review** has not happened. This is a `0.x` release and SemVer §4 applies: a
-minor may still break. The review is a dedicated decision the roadmap reserves, and cutting `1.0.0`
-without it would have made that decision by accident.

--- a/docs/workflow/maintenance.md
+++ b/docs/workflow/maintenance.md
@@ -43,11 +43,39 @@ the PR, and add the `CHANGELOG` `Fixed` (or `Security`) line.
 
 A hotfix is always the smallest change that fixes the defect — no refactors ride along.
 
+## Supported versions
+
+[`SECURITY.md`](../../SECURITY.md) defers here for the window, and this is it. **Supported = the
+latest release of the current MAJOR line.** A fix reaches consumers by their upgrading to that
+release; older releases are not patched in place. Post-1.0 that upgrade is safe to take by
+construction — within a MAJOR, SemVer plus the 1.x freeze
+([ADR-0059](../adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md))
+forbid the break that would otherwise make "just upgrade" a real cost.
+
+When a new MAJOR opens, the **previous** MAJOR's final release receives **security fixes only**
+until the new line has shipped one full MINOR (`X+1.1.0`). The window is measured in *published
+releases*, not in calendar time — the same reasoning the deprecation policy below uses, and for
+the same reason: a window nobody shipped through gave no consumer a chance to move.
+
+| Line | Bug fixes | Security fixes |
+|---|---|---|
+| latest release, current MAJOR | ✅ | ✅ |
+| older releases, current MAJOR | ❌ | ❌ — upgrade within the MAJOR |
+| previous MAJOR, final release | ❌ | ✅ until `X+1.1.0` ships |
+| older MAJOR lines | ❌ | ❌ |
+
+Two honest limits. This is a **solo-maintained** library: the table says which line a fix lands on,
+not how fast it arrives. [`SECURITY.md`](../../SECURITY.md) § *What to expect* sets out the
+sequence a report goes through and deliberately commits to no timeframe — there is no response-time
+SLA here, and none is implied. And the previous-MAJOR row has **never been exercised**: `1.x` is the
+only line that has ever existed, so that row is a commitment made in advance, not a described
+practice. Recorded in **ADR-0060**.
+
 ## Security fixes
 
 Report privately (see [`SECURITY.md`](../../SECURITY.md)); triage & fix under embargo;
 coordinated release then advisory; record under a `Security` changelog entry with the
-advisory/CVE; backport to every supported line.
+advisory/CVE; backport to every supported line — which the section above defines.
 
 ## Deprecation policy
 

--- a/packages/utils-psr7-bridge/README.md
+++ b/packages/utils-psr7-bridge/README.md
@@ -3,9 +3,10 @@
 Bidirectional conversion between [`egl/utils`](https://github.com/danielPoloWork/egl-util-php)'
 HTTP values (`D4np\Utils\Http\Request`, `Response`) and PSR-7 messages, using any PSR-17 factory.
 
-> **Status: scaffold.** Roadmap item 8.1 laid down this package; the converters and their contract
-> suite land in **8.2**, and publication to Packagist in **8.3**. The package is not yet installable
-> standalone — see [Installing](#installing).
+> **Status: implemented and contract-tested; not yet published.** The converters and their
+> **BFR-01…BFR-22** contract suite landed in item 8.2, and the publication pipeline in item 8.3.
+> What is missing is the one-time maintainer setup the first publication needs, so the package is
+> not yet installable standalone — see [Installing](#installing).
 
 ## Why this package exists
 
@@ -48,10 +49,34 @@ composer require nyholm/psr7        # or guzzlehttp/psr7, or your framework's
 
 ## Usage
 
-The converters arrive in item 8.2. The shape is fixed by
+The shape is fixed by
 [`docs/specs/02_spec_psr7_bridge.md`](../../docs/specs/02_spec_psr7_bridge.md) §3: factories are
 **injected once at construction** — the bridge never discovers or defaults one — and the four
 conversions are `requestToPsr7`, `requestFromPsr7`, `responseToPsr7`, `responseFromPsr7`.
+
+```php
+use D4np\Utils\Bridge\Psr7\Psr7Bridge;
+use D4np\Utils\Http\Request;
+use D4np\Utils\Http\Response;
+use Nyholm\Psr7\Factory\Psr17Factory;
+
+// Psr7Bridge takes five PSR-17 factories: server-request, response, stream,
+// uploaded-file, URI. Nyholm's Psr17Factory implements all five, so it is passed
+// five times; with a vendor that splits them, pass each implementation in that order.
+$psr17  = new Psr17Factory();
+$bridge = new Psr7Bridge($psr17, $psr17, $psr17, $psr17, $psr17);
+
+// Core → PSR-7: hand superglobal-backed values to a PSR-15 stack.
+$psrRequest  = $bridge->requestToPsr7(Request::fromGlobals());
+$psrResponse = $bridge->responseToPsr7(Response::json(['ok' => true]));
+
+// PSR-7 → core: bring a stack's messages back into the core vocabulary.
+$request  = $bridge->requestFromPsr7($psrRequest);
+$response = $bridge->responseFromPsr7($psrResponse);
+```
+
+`requestFromPsr7()` and `responseFromPsr7()` throw `HttpException` rather than coercing when the
+PSR-7 message carries something the core's vocabulary refuses — see *Conversion contract* below.
 
 Note the deviation from imported ADR-002's literal `Request::toPsr7()`: PHP has no partial classes,
 so methods on the core `Request` would put PSR interfaces in the *core's* signatures and


### PR DESCRIPTION
## Summary

The `v1.0.0` release updated every version-bearing artifact and none of the prose describing them.
This closes roadmap item **7.5** with the corrections that were unambiguous, defines the post-1.0
supported-versions window that `SECURITY.md` had been deferring to a section which never existed
(**ADR-0060**), and opens **Milestone 13** with the rest of a six-persona documentation review's
backlog — including one finding raised for the maintainer rather than decided here.

## Motivation

A six-persona review of `README.md` and the consumer-facing documentation (developer-documentation
style, onboarding, claim-verification against the tree, Diátaxis information architecture,
editorial coherence, OSPO compliance) produced six independent reports. Their weakest dimension was
not writing quality — it was **coherence**, because `v1.0.0` merged and was tagged while the review
was running, so the panel caught the repository mid-transition.

The load-bearing find was not a stale sentence but a **dangling promise**. `SECURITY.md` has, since
the repository was generated, said the post-1.0 support window "is defined in
`docs/workflow/maintenance.md`". That document has never contained one. The pointer survived the
entire pre-1.0 line because the clause immediately above it still applied, so no reader had cause to
follow it — and `maintenance.md` §*Security fixes* compounded it, instructing a backport "to every
supported line" using a term nothing defined.

Refs: **ADR-0060** (new), ADR-0031, ADR-0032, ADR-0059; roadmap items 7.5 and 13.1–13.8.

## Changes

- **Defines the supported-versions window** in `docs/workflow/maintenance.md` — the section
  `SECURITY.md` already promised. Supported = the latest release of the current MAJOR; the previous
  MAJOR's final release gets security fixes only, until the new line ships `X+1.1.0`. Counted in
  **published releases, not calendar time**, reusing ADR-0031's instrument: a time-based window can
  elapse with no release inside it, satisfying its own letter while giving consumers nothing to
  upgrade to. The policy states its own limit — the previous-MAJOR row has **never been exercised**,
  `1.x` being the only line that has ever existed.
- **Repairs `SECURITY.md`'s table**, which offered only `latest released 0.x` / `older 0.x`. No
  `0.x` was ever published, so at a `1.0.0` HEAD the security policy had no row a consumer could be
  standing on.
- **Removes the self-contradiction in `docs/releases/v1.0.0.md`**: it announced the API freeze and
  then, four sections later, still carried the `v0.11.0` paragraph saying the freeze review *"has
  not happened"* and *"this is a `0.x` release"*. Its own document is the refutation. Also corrects
  the bridge's recorded constraint on the core from `^0.11` to the `^1.0` its `composer.json`
  declares.
- **Un-scaffolds the bridge README**, which still opened *"Status: scaffold … the converters land in
  **8.2**"* over a *Usage* section saying they had not arrived — contradicted by its own contract
  section, its `CHANGELOG` and the shipped `Psr7Bridge`. *Usage* now carries a worked example
  verified against the frozen signatures rather than a forward reference.
- **Repairs two dead links** in `ROADMAP.md` pointing at ADR-0040's pre-rename filename, found by
  resolving the links in the touched files.
- **Opens Milestone 13** (7.5's out-of-scope findings, per AGENTS.md §10), each item carrying the
  evidence that produced it so none has to be re-derived.

## Design Patterns

None — documentation and policy only; no production code is touched.

## Verification

- [x] Builds cleanly on the full CI matrix — **not applicable**: no PHP, workflow, or test file is
      touched. `git diff --stat` is 12 Markdown files.
- [x] Unit tests pass; new/changed behavior covered — **not applicable**, no behavior changed.
- [x] `PHP-CS-Fixer` / `PHPStan` clean on the diff — **not applicable**, no PHP in the diff.
- [x] Sanitizers/checkers green where applicable — **not applicable**.
- [ ] Benchmark numbers attached — not perf-relevant.
- [x] `python tools/consistency_lint.py` passes.
- [x] **Additional, not in the template:** every relative link in the changed Markdown resolves
      (142 checked). This found the two broken ADR-0040 links, which were already broken on
      `master` — the argument for item 13.4.
- [x] Every claim added to the bridge README's example checked against
      `packages/utils-psr7-bridge/src/main/php/…/Psr7Bridge.php` and `Http/Request.php` at 1.0.0.

## Documentation Impact

- [x] `README.md` updated — Milestone 13 row added.
- [x] `ROADMAP.md` checkbox flipped — item 7.5 filed and closed; M13 opened with 13.1–13.8.
- [x] ADR added — **ADR-0060**, indexed in `docs/adr/README.md`.
- [ ] `docs/patterns/README.md` — no pattern introduced, refined, or rejected.
- [ ] Spec updated — no behavior diverges from `docs/specs/`.
- [x] `CHANGELOG.md` updated under `[Unreleased]` (Added + Fixed).
- [x] Session journal added, indexed, and the ROADMAP *Latest checkpoint* pointer moved.
- [ ] **PR metadata cannot be set as §6.4 requires** — and that is itself a finding, filed as item
      **13.8**. `.github/labels.yml` defines the ten type labels; the repository still carries
      GitHub's stock set, so the `docs` label does not exist (`documentation` is the nearest). The
      eleven milestones are named `v0.1.0`…`v0.11.0` rather than `MN — name`, stop before M12, have
      no `v1.0.0` entry, and are all still open although M1–M11 closed.

## ⚠️ Raised for the maintainer, deliberately not decided here

`docs/releases/v1.0.0.md` says this release is **"the one the gate approved"**. It is not:

```
$ git cat-file -p v1.0.0 | grep -c 'BEGIN PGP'   →  0
$ gh run view 31283673519 --json jobs
   failure  verify v1.0.0 is signed and consistent      ← step: "The tag must be signed"
   skipped  test v1.0.0 on ${{ matrix.toolchain }}
   skipped  draft GitHub Release for v1.0.0
```

The tag is unsigned, the gate refused it, and **both** the tagged-tree 8.1/8.2/8.3 matrix and the
draft job were skipped — so the shipped tree never ran through the check ADR-0032 exists to provide
(a tag can point at a commit CI never ran). The GitHub Release was published by hand 13 minutes
later. `v0.11.0` failed the identical step first, so this is a repeat, and the signing key ADR-0032
names as a one-time prerequisite is the likely root cause.

The remedy is a choice — re-cut the tag signed and let the gate run green (which makes the existing
sentence true *and* produces the missing matrix evidence), or keep the release as published and
amend the notes to record the bypass. The first rewrites the provenance of a published release,
which AGENTS.md §6.1 puts on the maintainer's side of the line, so **the sentence is left exactly as
written** rather than quietly edited to match what happened. Filed as item **13.1**.

Lesson: a cross-reference is only as good as its target — `SECURITY.md` pointed at a definition in
`maintenance.md` for the project's whole pre-1.0 life and that section was never written, invisible
because the clause above the pointer still applied. Nothing in `consistency_lint.py` resolves a
link; until item 13.4 lands, a documented deferral is an unchecked claim.
