### PR TITLE
docs(docs): record the v1.0.0 gate bypass instead of claiming the gate approved it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Fixed
 
+- **`docs/releases/v1.0.0.md` no longer claims the release gate approved it.** The notes stated the
+  published tree was *"the one the gate approved"*; it is not. `v1.0.0`'s tag is unsigned, so
+  `release.yml`'s `The tag must be signed` step failed (run 31283673519), the tagged-tree 8.1/8.2/8.3
+  matrix and the draft-Release job were both **skipped**, and the GitHub Release was published by
+  hand 13 minutes later. The sentence is gone and a `How this release was published` section records
+  the bypass, what the missing matrix would have proved, that `quality / backward compatibility`
+  reported green on the release PR having compared nothing (no `v*.*.*` tag existed), and that the
+  copy of these notes *inside the tagged tree* still carries the stale `0.x` text a tag's
+  immutability puts out of reach. The GitHub Release body carries the same correction. The signing
+  decision itself stands and is not reopened here; completing the signing chain is issue #115
+  (ROADMAP item 13.1).
+- **The same claim removed from the two other places it had been copied to.**
+  `docs/changelog/v1/v1.0.0.md`'s *Superseded pre-release* section said the shipped tree "is the
+  one the gate approved" and now records the bypass instead; **ADR-0059**'s Decision point 4 said
+  it too, and carries a Status annotation correcting the fact while leaving the decision intact
+  (ADR-0041's annotate-don't-edit precedent). Both were written before the tag was pushed, which is
+  how a claim about the future ended up recorded as history.
 - **`docs/releases/v1.0.0.md` no longer contradicts itself.** Its closing section still declared
   that the 1.0.0 API-freeze review *"has not happened"* and that *"this is a `0.x` release"* — text
   carried over from the unpublished `v0.11.0` notes, inside the document announcing the freeze.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -20,7 +20,7 @@ replacing it.
 
 ## Issues (newest → oldest)
 
-- [ ] [#122](https://github.com/danielPoloWork/egl-util-php/issues/122) **release: settle the v1.0.0 tag provenance and correct the gate-approved claim** — The flagship release notes assert the opposite of the repository's own audit trail — route: standard / medium
+- [x] [#122](https://github.com/danielPoloWork/egl-util-php/issues/122) **release: settle the v1.0.0 tag provenance and correct the gate-approved claim** — The flagship release notes assert the opposite of the repository's own audit trail — route: standard / medium
 - [ ] [#121](https://github.com/danielPoloWork/egl-util-php/issues/121) **build: register egl/utils on Packagist and verify the tag resolves** — Whether anyone can install the frozen 1.0 today is unverifiable from the repository — route: fast / low
 - [ ] [#120](https://github.com/danielPoloWork/egl-util-php/issues/120) **release: complete the utils-psr7-bridge publication (split repo, Packagist, first bridge tag)** — The library's entire interop story is implemented and contract-tested but not installable — route: standard / medium
 - [ ] [#119](https://github.com/danielPoloWork/egl-util-php/issues/119) **build: add export-ignore rules and cut a v1.0.1 dist-hygiene patch** — The Packagist dist ships 524 files / 3.6 MB of which 97 are production code — route: fast / medium

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1600,7 +1600,7 @@ this milestone holds what needs a maintainer decision, a tool, or more than a pr
 work:** RFC-0001/0002 scope is closed, and every item here concerns the documentation surface and
 the release process around it.
 
-- [ ] 13.1 Settle the `v1.0.0` tag's provenance. The tag is **unsigned**, so the release gate's
+- [x] 13.1 Settle the `v1.0.0` tag's provenance. The tag is **unsigned**, so the release gate's
       `The tag must be signed` step failed (run 31283673519) and both the tagged-tree test matrix
       and the draft-Release job were **skipped**; the GitHub Release was published by hand 13
       minutes later. Two consequences, neither reflected in the docs: `docs/releases/v1.0.0.md`
@@ -1612,7 +1612,27 @@ the release process around it.
       matrix evidence, or keep the release as published and amend the notes to record the bypass
       and the unverified matrix. `v0.11.0` failed the identical step first, so this is a **repeat**,
       not a one-off — the signing key ADR-0032 names as a one-time prerequisite is the likely root
-      cause — size: S · route: standard / medium
+      cause — size: S · route: standard / medium *(issue #122; the fork was put to the maintainer
+      and answered: **record the bypass**, do not re-cut the tag)*. *The release stays as published
+      and the documents were corrected to match it. `docs/releases/v1.0.0.md` loses the
+      "the one the gate approved" clause, gains a lead-in warning above the fold and a
+      `How this release was published` section stating the failed signing step by run number, that
+      the tagged-tree 8.1/8.2/8.3 matrix and the draft-Release job were skipped, and that the
+      Release was hand-published 13 minutes later; the GitHub Release body carries the same
+      correction. **The signing decision itself was not reopened** — it was taken twice with the
+      outcome known, and only the documentation claim was ever the defect; completing the chain
+      stays issue #115, and the section says in as many words that a later signed re-cut replaces it
+      rather than being edited around. **Two things the correction found that the item had not
+      named.** First, the notes' verification paragraph needed a scope, not just a caveat: its
+      numbers were measured on the pull request for `be7f34e`, and what the skipped matrix would have
+      added is the independent re-run *at the tag* — so the paragraph now says which tree it speaks
+      for. Second, and the reason this item's own evidence had to be re-read rather than cited:
+      `quality / backward compatibility` passed on release PR #82 **in six seconds having compared
+      nothing** (`v0.11.0` was already deleted, so the job found no `v*.*.*` tag and self-skipped).
+      Counting it inside "fifteen checks green" would have reproduced, in the fix, the exact class of
+      claim the item exists to remove — item 10.8's "read the job, not the checks column", now with a
+      second instance. Named explicitly in the notes. The stale `0.x` text frozen inside the tagged
+      copy of the document is acknowledged at HEAD, since a tag cannot be edited.*
 - [ ] 13.2 Give `README.md` a consumer on-ramp. All six reviewers independently found no path from
       landing on the repository to a first working call: no `composer require egl/utils` anywhere a
       consumer looks (it appears only in `docs/releases/v1.0.0.md`, which the README does not link),

--- a/docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md
+++ b/docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md
@@ -1,6 +1,15 @@
 # ADR-0059: Freeze the API at 1.0.0, with `@internal` symbols outside the frozen surface
 
-- **Status:** Accepted
+- **Status:** Accepted — **factual correction to Decision point 4** (2026-08-09, item 13.1 /
+  issue #122): that point closes "so the first installable version is the one the release gate
+  approved", which is **false**. `v1.0.0`'s tag was pushed unsigned as well, so `verify-tag`
+  refused it exactly as it had refused `v0.11.0` (run 31283673519), the tagged-tree matrix and the
+  draft-Release job were skipped, and the Release was published by hand. **Nothing decided here
+  changes** — superseding `v0.11.0` with `v1.0.0` and deleting its tag stand as recorded; only the
+  claim about how the replacement was published was wrong, and it was written before the tag was
+  pushed. The full account is in
+  [`docs/releases/v1.0.0.md`](../releases/v1.0.0.md) § "How this release was published".
+  Annotated rather than edited, per ADR-0041's precedent.
 - **Date:** 2026-08-09
 - **Deciders:** tech-lead (drafted), maintainer (decided — both questions below were put to
   them explicitly and answered before this record was written)
@@ -67,6 +76,9 @@ surface.
    the tag was unsigned, `verify-tag` refused it (ADR-0032), no Release was drafted, Packagist
    had no such package. Its tag is deleted and its changelog re-cut as `v1.0.0`, so the first
    installable version is the one the release gate approved. No code differs.
+   **[Correction, 2026-08-09 — see Status above: the closing clause is false.** `v1.0.0` was
+   pushed unsigned too and the gate refused it identically; the Release was hand-published. The
+   supersession and the tag deletion stand. **Only the last sentence of this point is wrong.]**
 
 ## Alternatives
 

--- a/docs/changelog/v1/v1.0.0.md
+++ b/docs/changelog/v1/v1.0.0.md
@@ -1174,4 +1174,12 @@ and the package was not yet registered on Packagist — nothing could resolve or
 
 Rather than leave a version that exists as a tag but never passed the release gate, the same
 tree is released as **v1.0.0** and the `v0.11.0` tag is deleted. There is exactly one first
-release, and it is the one the gate approved. No code differs between the two.
+release. No code differs between the two.
+
+**The v1.0.0 tag did not pass that gate either.** It was pushed unsigned for the same reason —
+no signing key is registered on the account yet — so `verify-tag` refused it (run 31283673519),
+the tagged-tree 8.1/8.2/8.3 matrix and the draft-Release job were skipped, and the GitHub
+Release was published by hand. This paragraph corrects a sentence that originally read
+"and it is the one the gate approved"; what actually happened, and what the skipped matrix
+would have proved, is set out in [`docs/releases/v1.0.0.md`](../../releases/v1.0.0.md)
+§ "How this release was published" (item 13.1 / issue #122).

--- a/docs/journal/2026/08/2026-08-09-v1-tag-provenance.md
+++ b/docs/journal/2026/08/2026-08-09-v1-tag-provenance.md
@@ -1,0 +1,101 @@
+# 2026-08-09 — The release notes said the gate approved it, and the gate had refused it
+
+Roadmap item **13.1**, filed by the 2026-08-09 release review board and tracked as issue **#122**.
+Route `standard / medium`; session model Opus 5 — matched.
+
+The item is one sentence long in its effect: `docs/releases/v1.0.0.md` told a consumer that the
+tree they were about to install was *"the one the gate approved"*, and the gate had refused it.
+Everything else in this entry is what fixing one sentence honestly turned out to require.
+
+## The fork was the maintainer's, and it was put to them
+
+AGENTS.md §6.1 reserves release provenance to the maintainer, and the item was filed with two
+mutually exclusive remedies rather than a recommendation:
+
+- **re-cut the tag signed**, let `release.yml` run green, and the existing sentence becomes true —
+  the version that also produces the tagged-tree matrix evidence;
+- **record the bypass** — keep the release as published and amend the documents to say what
+  actually happened.
+
+The maintainer chose to record the bypass. Worth naming why the choice was live at all: the signed
+re-cut is still *clean* here, because `egl/utils` is not registered on Packagist (issue #121), so
+nothing in the world can resolve the tag and deleting it breaks no consumer. That window closes at
+registration. The decision was not a concession to difficulty.
+
+Equally worth naming: **the signing decision itself was never the defect and was not reopened.** It
+was taken twice — at `v0.11.0` and again at `v1.0.0` — with the outcome known in advance both
+times. The defect was a document asserting the opposite of the repository's own audit trail. Only
+that was fixed.
+
+## What the gate's refusal actually cost
+
+`verify-tag` failing is not one missing checkmark. Every later job in `release.yml` depends on it,
+so run 31283673519 skipped:
+
+- the **tagged-tree 8.1/8.2/8.3 matrix** — the job that re-runs the suite against the tree *the tag
+  points at*, which exists precisely to catch a tag pointing at a commit CI never exercised
+  (ADR-0032). Nothing else in the pipeline substitutes for it;
+- the **draft-Release job** — hence the hand-published Release thirteen minutes later.
+
+So the notes needed more than a deletion. They needed a *scope* on the verification numbers: those
+2 831 tests were real, measured on the pull request for `be7f34e`, which is the commit the tag
+points at — what is missing is the independent re-run at the tag. The notes now say which tree they
+speak for, and tell a reader who needs that assurance to verify the tag against `be7f34e`
+themselves.
+
+## The finding that made me re-read the evidence instead of citing it
+
+Writing "and all fifteen checks passed on the release PR" was the obvious sentence, and it is
+true. I pulled the job logs anyway, because this item exists to remove a claim someone made without
+pulling them.
+
+`quality / backward compatibility` passed on PR #82 **in six seconds having compared nothing**:
+
+```
+##[notice]This repository has no v*.*.* tag, and roave/backward-compatibility-check
+needs one to compare against. The gate self-enables at the first tag.
+```
+
+`v0.11.0` had already been deleted, so the job found no tag, self-skipped, and reported green. That
+is correct behaviour for a first release — there was no predecessor to compare against — but
+folding it into a count of fifteen would have reproduced, *inside the fix*, the exact class of claim
+the item exists to delete. It is named explicitly in the notes instead.
+
+This is item **10.8**'s lesson — *read the job, not the checks column* — with a second instance, and
+the second instance is the interesting one: recognising the pattern once did not stop me from
+nearly walking into it while repairing an example of it.
+
+## One artefact that cannot be repaired
+
+The copy of `docs/releases/v1.0.0.md` **inside the tagged tree** still ends with a section carried
+over from the unpublished `v0.11.0` notes — the 1.0.0 API-freeze review *"has not happened"*, this
+is *"a `0.x` release"* — and records the bridge's constraint on the core as `^0.11`. Both are false
+of what shipped. PR #83 corrected them at `HEAD`; a tag is immutable, so a reader arriving via the
+tag meets the stale text regardless. The only available remedy is to say so at HEAD, which the
+notes now do.
+
+## The claim had been copied twice, and the copies are the tell
+
+`grep` found the sentence in two more tracked files, neither named by the issue:
+
+- `docs/changelog/v1/v1.0.0.md` § *Superseded pre-release* — corrected in place, with the bypass
+  recorded;
+- **ADR-0059** Decision point 4 — *annotated, not rewritten*, per ADR-0041's precedent: a Status
+  note correcting the fact, plus an inline marker at the point itself so a reader who lands there
+  directly is not left with the falsehood. Nothing decided in that ADR changes; superseding
+  `v0.11.0` and deleting its tag stand exactly as recorded.
+
+**Why all three said the same wrong thing is the reusable part.** None of them was a mistake about
+the past. All three were written *before the tag was pushed*, describing a release gate that was
+expected to pass — and then the tag went up unsigned and nobody revisited the prose. A claim about
+the future, recorded in the past tense, reads identically to a verified fact once the moment passes.
+Release documents drafted ahead of the release should state intent as intent, or be re-read against
+the run afterwards. This project has a lint for version lockstep, the ADR index, pattern rows, the
+spec coverage map and milestone agreement; none of it can catch a true-when-written sentence going
+false. Item 13.4's link checker will not catch this class either.
+
+## Left deliberately undone
+
+The GitHub Release body carries the same correction, but editing a published Release is an
+outward-facing act: it was drafted here and applied only on the maintainer's explicit confirmation,
+not as a side effect of the merge.

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -8,8 +8,13 @@ and the version at which the public API is **frozen** ([ADR-0059](../adr/0059-fr
 Nothing was released before it. A `v0.11.0` was prepared under the roadmap's milestone-per-minor
 mapping and tagged, but never published — its tag was unsigned, so the release gate refused it
 (ADR-0032) and no Release was ever drafted. The same tree ships here instead, so there is exactly
-one first release and it is the one the gate approved. **1.0.0 is not a bigger version than
-0.11.0 — it is the same code with a promise attached.**
+one first release. **1.0.0 is not a bigger version than 0.11.0 — it is the same code with a
+promise attached.**
+
+> **This release did not pass the release gate.** `v1.0.0`'s tag is unsigned too, so the gate
+> refused it for the identical reason and this Release was published by hand. What that means for
+> you is in [How this release was published](#how-this-release-was-published) — read it before the
+> verification numbers further down, because it bounds what they certify.
 
 ## What the freeze means for you
 
@@ -92,11 +97,54 @@ Pre-1.0 permits breaking changes in a minor, and two landed during development. 
   own publication needs the split repository configured (roadmap item 8.3). Its constraint on the
   core is `^1.0` as of this release — this release is the first version that constraint can resolve.
 
+## How this release was published
+
+The `v1.0.0` tag is **annotated but unsigned**. `release.yml`'s `The tag must be signed` step
+therefore failed ([run 31283673519](https://github.com/danielPoloWork/egl-util-php/actions/runs/31283673519)),
+and because every later job depends on it, two things did not happen:
+
+- the **tagged-tree test matrix never ran**. The 8.1/8.2/8.3 job that re-runs the suite *against the
+  tree the tag points at* was skipped. That job exists to catch a tag pointing at a commit CI never
+  exercised (ADR-0032), and it is the one check nothing else substitutes for;
+- the **draft-Release job was skipped**. This GitHub Release was created by hand roughly 13 minutes
+  later, by the maintainer, from the same tree.
+
+This was a deliberate maintainer decision, taken with the outcome known — the signing key ADR-0032
+names as a one-time prerequisite is not yet registered on the account, and `v0.11.0` had already
+failed the identical step. It is recorded here rather than left implied, because a release document
+that contradicted the repository's own audit trail on a supply-chain fact would be the worst place
+in the project to be wrong. Completing the signing chain is tracked as
+[issue #115](https://github.com/danielPoloWork/egl-util-php/issues/115); should the tag later be
+re-cut signed and the gate run green, this section gets replaced by that run, not edited around.
+
+**What this does and does not undermine.** Every number in *Verification behind this release* below
+was measured — on the pull request that became `be7f34e`, which the tag points at, and where all
+fifteen checks passed. What is missing is the independent re-run *at the tag*: nothing mechanically
+re-verified that the published tag and the verified tree are the same thing. If you need that
+assurance, verify the tag yourself against `be7f34e` before depending on this release.
+
+One of those fifteen deserves naming rather than counting. `quality / backward compatibility`
+reported green in six seconds having **compared nothing**: `v0.11.0` had been deleted by then and
+the repository held no `v*.*.*` tag, so the job emitted `This repository has no v*.*.* tag […] The
+gate self-enables at the first tag` and stopped. That is correct behaviour for a first release —
+there was no predecessor to compare against — but a green square on that row certifies nothing here,
+and the freeze this document announces is exactly the promise that check exists to police from
+`v1.0.1` onward.
+
+**One artefact cannot be fixed.** The copy of this document *inside the tagged tree* still ends with
+a section carried over from the unpublished `v0.11.0` notes, declaring that the 1.0.0 API-freeze
+review *"has not happened"* and that *"this is a `0.x` release"*, and recording the bridge's
+constraint on the core as `^0.11`. Both statements are false of what shipped. A tag is immutable, so
+they were corrected at `HEAD` instead
+([PR #83](https://github.com/danielPoloWork/egl-util-php/pull/83)); this paragraph is the
+acknowledgement that a reader arriving via the tag will meet the stale text.
+
 ## Verification behind this release
 
-2 831 tests / 6 022 assertions on PHP 8.1, 8.2 and 8.3; ≥ 90% line coverage enforced; PHPStan at max
-level; PHP-CS-Fixer (PSR-12); deptrac with 342 allowed edges and zero uncovered; Infection mutation
-score 79% against a 70% floor; `composer audit` and a `--prefer-lowest` install; ten absolute NFR
-budgets and a same-runner relative regression gate, both green. Every performance claim in the
-documentation is backed by a benchmark under `src/bench/` — the methodology and the honest caveats
-are in [`docs/benchmarks/`](../benchmarks/).
+Measured on the pull request for `be7f34e`, the commit the tag points at — not re-run at the tag
+itself, for the reason above. 2 831 tests / 6 022 assertions on PHP 8.1, 8.2 and 8.3; ≥ 90% line
+coverage enforced; PHPStan at max level; PHP-CS-Fixer (PSR-12); deptrac with 342 allowed edges and
+zero uncovered; Infection mutation score 79% against a 70% floor; `composer audit` and a
+`--prefer-lowest` install; ten absolute NFR budgets and a same-runner relative regression gate, both
+green. Every performance claim in the documentation is backed by a benchmark under `src/bench/` —
+the methodology and the honest caveats are in [`docs/benchmarks/`](../benchmarks/).


### PR DESCRIPTION
## Summary

`docs/releases/v1.0.0.md` told consumers the tree they were about to install was *"the one the gate
approved"*. The release gate had refused it. This PR removes the claim, records what actually
happened, and cleans up the two other files the same sentence had been copied into.

**No tag is touched.** The maintainer was given item 13.1's two forks — re-cut the tag signed, or
keep the release as published and amend the notes — and chose to record the bypass. The signing
decision itself was taken twice with the outcome known in advance and is not reopened here;
completing the signing chain stays #115.

## Motivation

Closes #122 · ROADMAP item **13.1** · AGENTS.md §6.1 (release provenance is a maintainer decision,
never an agent's) · ADR-0032 · ADR-0059 Decision point 4.

Filed by the 2026-08-09 release review board, where four seats found it independently — Release
Manager, Senior Technical Writer and Product Manager as majors, Senior Security Engineer as a
minor. The board's single most serious condition.

## Changes

- **`docs/releases/v1.0.0.md`** — the "gate approved" clause is gone. A warning sits above the fold,
  and a new **How this release was published** section states: the tag is annotated but unsigned, so
  `release.yml`'s signing step failed ([run 31283673519](https://github.com/danielPoloWork/egl-util-php/actions/runs/31283673519));
  every later job depends on it, so the **tagged-tree 8.1/8.2/8.3 matrix** and the **draft-Release
  job** were both skipped; the Release was hand-published ~13 minutes later. It says what the
  skipped matrix would have proved — a tag pointing at a commit CI never exercised, ADR-0032's whole
  purpose — and that a later signed re-cut *replaces* the section rather than being edited around.
- **The verification paragraph gets a scope, not a caveat.** Its numbers were measured on the pull
  request for `be7f34e`, the commit the tag points at. What the skipped matrix would have added is
  the independent re-run *at the tag*. It now says which tree it speaks for, and tells a reader who
  needs that assurance to verify the tag against `be7f34e` themselves.
- **`docs/changelog/v1/v1.0.0.md`** § *Superseded pre-release* carried the same sentence — corrected
  in place, with the bypass recorded.
- **`ADR-0059`** Decision point 4 carried it too — **annotated, not rewritten** (ADR-0041's
  precedent): a Status note correcting the fact, plus an inline marker at the point itself so a
  reader landing there directly is not left with the falsehood. Nothing it decided changes;
  superseding `v0.11.0` and deleting its tag stand exactly as recorded.
- **The tagged tree's own copy** still ends with leftover `v0.11.0` text — the freeze *"has not
  happened"*, this is *"a `0.x` release"*, bridge constraint `^0.11`. A tag is immutable, so it is
  acknowledged at HEAD instead.
- `CHANGELOG.md` `[Unreleased]` → `Fixed`; ROADMAP 13.1 flipped with the decision recorded; #122
  ticked in `ISSUES.md`; journal entry added.

## The finding that came out of fixing it

Writing *"and all fifteen checks passed on the release PR"* was the obvious sentence, and it is
true. I pulled the job logs anyway, because this item exists to remove a claim someone made without
pulling them.

`quality / backward compatibility` passed on release PR #82 **in six seconds having compared
nothing**:

```
##[notice]This repository has no v*.*.* tag, and roave/backward-compatibility-check
needs one to compare against. The gate self-enables at the first tag.
```

`v0.11.0` had already been deleted, so the job found no tag and self-skipped. Correct behaviour for
a first release — there was no predecessor — but folding it into a count of fifteen would have
reproduced, *inside the fix*, the exact class of claim the item exists to delete. It is named
explicitly in the notes instead. Second instance of item **10.8**'s *read the job, not the checks
column*, and the second instance is the interesting one: recognising the pattern once did not stop
me nearly walking into it while repairing an example of it.

**Why the claim existed in three places at all.** None of the three was a mistake about the past.
All three were written *before the tag was pushed*, describing a gate that was expected to pass;
then the tag went up unsigned and nobody re-read the prose. A claim about the future, recorded in
the past tense, is indistinguishable from a verified fact once the moment passes.

## Design Patterns

None — documentation correction.

## Verification

- [x] `python tools/consistency_lint.py` passes
- [x] Every factual claim re-derived from the source rather than from the review board's summary:
      the failed step and skipped jobs from run 31283673519, the fifteen checks and the BC job's
      self-skip from PR #82's job logs, the tagged tree's stale text from `git show v1.0.0:docs/releases/v1.0.0.md`
- [x] `grep` over all tracked Markdown confirms no remaining assertion of the claim — the only
      surviving occurrences are inside corrections that quote it
- [ ] Builds cleanly on the full CI matrix (Linux (PHP 8.1, 8.2, 8.3))
- n/a Unit tests / CS-Fixer / PHPStan / coverage / benchmarks — no source or test file changes

## Documentation Impact

- [x] ROADMAP.md checkbox flipped (13.1)
- [x] ADR updated — ADR-0059 annotated, not rewritten
- [x] CHANGELOG.md updated
- [x] `ISSUES.md` #122 ticked; journal entry added
- [ ] README.md — not affected
- [ ] Spec / patterns catalogue — not affected
- [x] PR metadata set — assignee (owner), one type label (`documentation`); no milestone, matching
      #83 and #123 (no M13 milestone exists)

## Left deliberately for the maintainer

The **GitHub Release body** carries the same correction — and it is worse than the file was: the
live body is still the pre-#83 text, so on top of the "gate approved" claim it also states the
bridge constraint as `^0.11` and closes with *"the 1.0.0 API-freeze review has not happened. This is
a `0.x` release"* on the release announcing the freeze. A corrected body is prepared, but editing a
published Release is an outward-facing act and is applied only on explicit confirmation, not as a
side effect of this merge.

## Lesson

A release document drafted before the release describes an expectation; once the moment passes it
reads as verified history. State intent as intent, or re-read it against the run.
