### PR TITLE
build(build): register egl/utils on Packagist, verify the tag resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Added
 
+- **`egl/utils` registered on Packagist** (issue #121), with the GitHub integration wired so
+  future tags publish by webhook. Verified end to end: `composer require egl/utils:^1.0` in a
+  clean throwaway project resolves `v1.0.0` at source commit `be7f34e` — the exact commit the tag
+  points at — installs cleanly with no security advisories, and its autoloaded classes load.
+  `README.md` gains a minimal `## Install` section stating the fact; `docs/releases/v1.0.0.md`'s
+  "never been installed from Packagist" line is corrected without being rewritten to look
+  prescient; `docs/workflow/release.md`'s prerequisite is marked done with the evidence.
+  **Not closed by this**: the bridge vendor squat-protection this issue also names is blocked on
+  the split repository issue #120 creates — Packagist needs a `composer.json` at a repository
+  root, and the bridge's lives under `packages/` in this monorepo, not at one.
 - **Supported-versions window for the post-1.0 line**, defined in
   [`docs/workflow/maintenance.md`](docs/workflow/maintenance.md) and pointed to from `SECURITY.md`:
   the latest release of the current MAJOR, with the previous MAJOR's final release on security

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -21,7 +21,7 @@ replacing it.
 ## Issues (newest → oldest)
 
 - [x] [#122](https://github.com/danielPoloWork/egl-util-php/issues/122) **release: settle the v1.0.0 tag provenance and correct the gate-approved claim** — The flagship release notes assert the opposite of the repository's own audit trail — route: standard / medium
-- [ ] [#121](https://github.com/danielPoloWork/egl-util-php/issues/121) **build: register egl/utils on Packagist and verify the tag resolves** — Whether anyone can install the frozen 1.0 today is unverifiable from the repository — route: fast / low
+- [ ] [#121](https://github.com/danielPoloWork/egl-util-php/issues/121) **build: register egl/utils on Packagist and verify the tag resolves** — `egl/utils` registered + resolution verified 2026-08-10; open only on the bridge vendor squat-protection, blocked on #120's split repo — route: fast / low
 - [ ] [#120](https://github.com/danielPoloWork/egl-util-php/issues/120) **release: complete the utils-psr7-bridge publication (split repo, Packagist, first bridge tag)** — The library's entire interop story is implemented and contract-tested but not installable — route: standard / medium
 - [ ] [#119](https://github.com/danielPoloWork/egl-util-php/issues/119) **build: add export-ignore rules and cut a v1.0.1 dist-hygiene patch** — The Packagist dist ships 524 files / 3.6 MB of which 97 are production code — route: fast / medium
 - [ ] [#118](https://github.com/danielPoloWork/egl-util-php/issues/118) **docs: ship the consumer on-ramp (composer require, runnable examples, naming map, full surface)** — ROADMAP 13.2 — unanimous across the review: no path from landing on the repo to a first working call — route: standard / medium

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Provide EGL PHP projects (framework-based and native/legacy) with a modern utili
 The frozen specification is in
 [`docs/specs/01_spec_utils.md`](docs/specs/01_spec_utils.md).
 
+## Install
+
+```bash
+composer require egl/utils:^1.0
+```
+
+Registered on [Packagist](https://packagist.org/packages/egl/utils); `^1.0` resolves `v1.0.0`.
+A full consumer on-ramp (runnable examples, the naming map, the rest of the surface) is tracked
+as [issue #118](https://github.com/danielPoloWork/egl-util-php/issues/118) — this line only
+states that the package installs.
+
 ## Build, test, run
 
 ```bash

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -28,8 +28,14 @@ Two symbols are **deliberately outside** that promise, documented `@internal` at
 definition because PHP has no package-private visibility: `Security\SecretKey::bytes()` and
 `Security\Hash::selectAlgorithm()`. Do not build on them.
 
-Honest basis for the number: this library has never been installed from Packagist, so 1.0.0
-states confidence earned from tests, benchmarks and review rather than from field use.
+Honest basis for the number: at the moment of writing this library had never been installed from
+Packagist, so 1.0.0 stated confidence earned from tests, benchmarks and review rather than from
+field use. **`egl/utils` was registered on Packagist on 2026-08-10** (issue #121), with the
+GitHub integration wired so future tags publish by webhook. `composer require egl/utils:^1.0` was
+then verified in a clean throwaway project: it resolves `v1.0.0` at source commit `be7f34e`
+(the exact commit the tag points at), installs psr/container and psr/log as its only
+dependencies, and the autoloaded classes load. That is now the first field evidence this release
+has; the sentence above is left as it read at cut time rather than rewritten to look prescient.
 
 ```bash
 composer require egl/utils

--- a/docs/workflow/release.md
+++ b/docs/workflow/release.md
@@ -91,6 +91,9 @@ Both are the maintainer's, not the agent's, and the first release cannot succeed
    each tag push, which is why no Packagist token lives in this repository. The workflow prints the
    package URL to confirm after publishing; it deliberately does not call the Packagist API, since
    that would both duplicate the integration and cross the agent-vs-human line below.
+   **Done 2026-08-10** (issue #121): `egl/utils` is registered with the integration wired, and
+   `composer require egl/utils:^1.0` was verified in a clean throwaway project — it resolves
+   `v1.0.0` at source commit `be7f34e`, the exact commit the tag points at.
 3. **For the bridge only** — a **split repository** and a token that can write to it:
    - create the repository (e.g. `danielPoloWork/egl-utils-psr7-bridge`), empty, and treat it as
      **read-only**: it is generated, and accepts no commits or pull requests;


### PR DESCRIPTION
## Summary

`egl/utils` is registered on Packagist and `composer require egl/utils:^1.0` was verified,
end to end, to resolve `v1.0.0`. Records the evidence; no code changed.

## Motivation

Issue #121 · `docs/workflow/release.md:90-92` (names the integration as a one-time prerequisite
whose confirmation lived in the release workflow skipped during the v1.0.0 hand-publication) ·
related to the consumer on-ramp issue (#118).

Before this PR, whether anyone could install the frozen 1.0 was unverifiable from the repository
alone — confirmed by re-checking: `https://repo.packagist.org/p2/egl/utils.json` returned `404`
as recently as this session, before the registration.

## Changes

- **Verified, not assumed**: in a clean throwaway project —
  ```
  composer require egl/utils:^1.0
  ```
  resolved `v1.0.0` at source commit `be7f34e` — the exact commit the tag points at — installed
  cleanly (`psr/container` ^2.0, `psr/log` ^3.0 as its only dependencies), reported no security
  advisories, and `class_exists('D4np\Utils\Support\Str')` returned `true` after
  `vendor/autoload.php`.
- `docs/releases/v1.0.0.md` — the *"this library has never been installed from Packagist"* line
  is now false; corrected with the evidence, left as it read at cut time rather than rewritten to
  look prescient.
- `docs/workflow/release.md` — the Packagist ↔ GitHub integration prerequisite marked done, dated,
  with the verification method.
- `README.md` — a minimal `## Install` section stating the fact (`composer require egl/utils:^1.0`,
  a link to the Packagist page). **Deliberately not the full on-ramp** — runnable examples, the
  naming map, the rest of the surface stay issue #118's scope; this line only states that the
  package installs.
- `CHANGELOG.md` `[Unreleased]` → `Added`; `ISSUES.md` #121 updated (not ticked — see below).

## What this does NOT close

Issue #121 has three acceptance criteria. Two are done:

- [x] `egl`/`egl/utils` registered with the GitHub integration.
- [x] `composer require egl/utils:^1.0` proven to resolve; recorded in the runbook + README.
- [ ] **Squat-protection for the bridge vendor — not done, and not doable yet.** Packagist needs a
  `composer.json` at a repository root to register a package; the bridge's lives under
  `packages/utils-psr7-bridge/` in this monorepo, not at one. Registering it for real needs the
  split repository issue #120 creates first. Left open in `ISSUES.md` rather than ticked closed.

## Design Patterns

None — build/docs verification, no code changed.

## Verification

- [x] `python tools/consistency_lint.py` passes
- [x] Live re-check before writing this PR: `repo.packagist.org/p2/egl/utils.json` → `200`,
      `packages/egl/utils` array non-empty, `version: v1.0.0`, `source.reference` = `be7f34e…`
- [x] Clean-project `composer require` performed for real (not asserted from the API response
      alone) — lockfile pins `egl/utils` to `be7f34e`, matching the tag
- n/a Unit tests / CS-Fixer / PHPStan / coverage / benchmarks — no `src/main` or `src/test` changes

## Documentation Impact

- [x] README.md updated (minimal Install section; full on-ramp deferred to #118)
- [ ] ROADMAP.md — no mirroring item exists for #121 (issues-only, like #115)
- [ ] ADR — no design decision made
- [x] CHANGELOG.md updated
- [x] `ISSUES.md` #121 updated in place (left unticked — see above)
- [x] PR metadata set — assignee (owner), one type label (`enhancement`, matching the commit's
      `build` type — no dedicated `build` label exists in this repo); no milestone (post-1.0
      docs/build PRs have carried none since M13 was never created as a GitHub milestone)

## Lesson

Verify the claim, not the API response: the Packagist JSON alone would have shown a version list,
but only a real `composer require` in an empty project proves the *tag* — not some other ref —
is what a consumer actually gets.
