### PR TITLE
docs(docs): close #121 — the egl vendor was squat-protected by the registration itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,16 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   `README.md` gains a minimal `## Install` section stating the fact; `docs/releases/v1.0.0.md`'s
   "never been installed from Packagist" line is corrected without being rewritten to look
   prescient; `docs/workflow/release.md`'s prerequisite is marked done with the evidence.
-  **Not closed by this**: the bridge vendor squat-protection this issue also names is blocked on
-  the split repository issue #120 creates — Packagist needs a `composer.json` at a repository
-  root, and the bridge's lives under `packages/` in this monorepo, not at one.
+  **This also closes the issue's squat-protection criterion, at no extra cost.** Packagist
+  protects a vendor namespace as soon as one package under it is published — *"you can not
+  publish packages with a vendor name that already exists on packagist without permission"*,
+  and publishing under an existing vendor requires being maintainer of a package already in it.
+  Registering `egl/utils` therefore locked the whole `egl/` namespace, so `egl/utils-psr7-bridge`
+  cannot be squatted by anyone else and no split repository is needed to defend the name. What
+  the split repository (issue #120) is still needed for is *publishing* the bridge, since
+  Packagist resolves a package from a repository with `composer.json` at its **root** and the
+  bridge's sits under `packages/`. The original acceptance criterion had fused protection and
+  publication into one line; they are independent, and only the second is still open.
 - **Supported-versions window for the post-1.0 line**, defined in
   [`docs/workflow/maintenance.md`](docs/workflow/maintenance.md) and pointed to from `SECURITY.md`:
   the latest release of the current MAJOR, with the previous MAJOR's final release on security

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -21,7 +21,7 @@ replacing it.
 ## Issues (newest → oldest)
 
 - [x] [#122](https://github.com/danielPoloWork/egl-util-php/issues/122) **release: settle the v1.0.0 tag provenance and correct the gate-approved claim** — The flagship release notes assert the opposite of the repository's own audit trail — route: standard / medium
-- [ ] [#121](https://github.com/danielPoloWork/egl-util-php/issues/121) **build: register egl/utils on Packagist and verify the tag resolves** — `egl/utils` registered + resolution verified 2026-08-10; open only on the bridge vendor squat-protection, blocked on #120's split repo — route: fast / low
+- [x] [#121](https://github.com/danielPoloWork/egl-util-php/issues/121) **build: register egl/utils on Packagist and verify the tag resolves** — registered + resolution verified 2026-08-10; the `egl/` vendor is squat-protected by that same registration, so the bridge name needs no split repo to defend — route: fast / low
 - [ ] [#120](https://github.com/danielPoloWork/egl-util-php/issues/120) **release: complete the utils-psr7-bridge publication (split repo, Packagist, first bridge tag)** — The library's entire interop story is implemented and contract-tested but not installable — route: standard / medium
 - [ ] [#119](https://github.com/danielPoloWork/egl-util-php/issues/119) **build: add export-ignore rules and cut a v1.0.1 dist-hygiene patch** — The Packagist dist ships 524 files / 3.6 MB of which 97 are production code — route: fast / medium
 - [ ] [#118](https://github.com/danielPoloWork/egl-util-php/issues/118) **docs: ship the consumer on-ramp (composer require, runnable examples, naming map, full surface)** — ROADMAP 13.2 — unanimous across the review: no path from landing on the repo to a first working call — route: standard / medium

--- a/docs/workflow/release.md
+++ b/docs/workflow/release.md
@@ -94,6 +94,14 @@ Both are the maintainer's, not the agent's, and the first release cannot succeed
    **Done 2026-08-10** (issue #121): `egl/utils` is registered with the integration wired, and
    `composer require egl/utils:^1.0` was verified in a clean throwaway project — it resolves
    `v1.0.0` at source commit `be7f34e`, the exact commit the tag points at.
+
+   **This also protects every other `egl/` name, including the bridge's.** Packagist locks a
+   vendor namespace to the first publisher: a package cannot be published under an existing
+   vendor without permission, and publishing under one requires being maintainer of a package
+   already in it. So `egl/utils-psr7-bridge` cannot be squatted, and **name protection is not a
+   reason to hurry the split repository** — step 3 is about *publishing* the bridge, not about
+   defending its name. Do not conflate the two: the original issue did, and it made a solved
+   problem look blocked.
 3. **For the bridge only** — a **split repository** and a token that can write to it:
    - create the repository (e.g. `danielPoloWork/egl-utils-psr7-bridge`), empty, and treat it as
      **read-only**: it is generated, and accepts no commits or pull requests;


### PR DESCRIPTION
## Summary

Issue #121's last open criterion — squat-protection for the bridge's package name — turns out to
have been satisfied the moment `egl/utils` was registered. No split repository is needed to defend
the name. Closes the issue; changes documentation only.

## Motivation

Closes #121 · follows PR #127, which registered `egl/utils` and left this criterion open on the
assumption that it was blocked by issue #120's split repository.

**That assumption was wrong, and the maintainer's push-back is what surfaced it.** Packagist's own
policy:

> Vendor names on packagist are protected once a package with that name has been published. That
> means you can not publish packages with a vendor name that already exists on packagist without
> permission.

— and publishing under an existing vendor requires being maintainer of a package already in it.
Registering `egl/utils` on 2026-08-10 locked the whole `egl/` namespace. `egl/utils-psr7-bridge`
cannot be squatted by anyone else.

## The mistake worth naming

The acceptance criterion read *"register the vendor for the bridge package too, before its split
repo goes live"* — one line fusing **two independent things**:

| | needs the split repo? | status |
|---|---|---|
| **Protecting** the `egl/utils-psr7-bridge` name | no — vendor-level lock covers it | **done**, as a side effect of #127 |
| **Publishing** the bridge package | yes — Packagist resolves from a repo with `composer.json` at its **root**, and the bridge's is under `packages/` | open, issue #120 |

Reading them as one made a solved problem look blocked, and made the split repository look
urgent for a reason that was never real. Issue #120's actual scope is unaffected.

## Changes

- `docs/workflow/release.md` — the vendor-lock property recorded next to the prerequisite it
  qualifies, stating plainly that **name protection is not a reason to hurry the split
  repository**. This is the part that stops the false blocker being re-derived.
- `CHANGELOG.md` `[Unreleased]` — the "Not closed by this" note replaced with what is actually
  true, including the policy quote and the protection/publication split.
- `ISSUES.md` — #121 ticked.

## Design Patterns

None — documentation correction.

## Verification

- [x] Packagist's published vendor-protection policy read directly, not recalled
- [x] `https://packagist.org/packages/list.json?vendor=egl` → `{"packageNames":["egl\/utils"]}`,
      and `egl/utils`'s maintainer is `danielPoloWork` — i.e. this account holds the vendor
- [x] `python tools/consistency_lint.py` passes
- n/a Unit tests / CS-Fixer / PHPStan / coverage / benchmarks — no `src/` changes

## Documentation Impact

- [x] CHANGELOG.md updated
- [x] `ISSUES.md` #121 ticked
- [ ] README.md — not affected (its Install section is already accurate)
- [ ] ROADMAP.md — no mirroring item exists for #121
- [ ] ADR — no design decision made; this records a property of a third-party service
- [x] PR metadata — assignee (owner), one type label (`documentation`), no milestone (matching
      #83, #123, #124, #127)

## Lesson

An acceptance criterion that names two actions in one sentence can be half-true: check whether its
clauses share a blocker before inheriting one. Here "register the vendor for the bridge too" was
already satisfied by a *different* registration, and only the co-located publication step was ever
blocked.
