### PR TITLE
docs(docs): RFC-0003, the post-1.0 functional scope for Milestone 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,16 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   `README.md` gains a minimal `## Install` section stating the fact; `docs/releases/v1.0.0.md`'s
   "never been installed from Packagist" line is corrected without being rewritten to look
   prescient; `docs/workflow/release.md`'s prerequisite is marked done with the evidence.
-  **Not closed by this**: the bridge vendor squat-protection this issue also names is blocked on
-  the split repository issue #120 creates — Packagist needs a `composer.json` at a repository
-  root, and the bridge's lives under `packages/` in this monorepo, not at one.
+  **This also closes the issue's squat-protection criterion, at no extra cost.** Packagist
+  protects a vendor namespace as soon as one package under it is published — *"you can not
+  publish packages with a vendor name that already exists on packagist without permission"*,
+  and publishing under an existing vendor requires being maintainer of a package already in it.
+  Registering `egl/utils` therefore locked the whole `egl/` namespace, so `egl/utils-psr7-bridge`
+  cannot be squatted by anyone else and no split repository is needed to defend the name. What
+  the split repository (issue #120) is still needed for is *publishing* the bridge, since
+  Packagist resolves a package from a repository with `composer.json` at its **root** and the
+  bridge's sits under `packages/`. The original acceptance criterion had fused protection and
+  publication into one line; they are independent, and only the second is still open.
 - **Supported-versions window for the post-1.0 line**, defined in
   [`docs/workflow/maintenance.md`](docs/workflow/maintenance.md) and pointed to from `SECURITY.md`:
   the latest release of the current MAJOR, with the previous MAJOR's final release on security

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -21,7 +21,7 @@ replacing it.
 ## Issues (newest → oldest)
 
 - [x] [#122](https://github.com/danielPoloWork/egl-util-php/issues/122) **release: settle the v1.0.0 tag provenance and correct the gate-approved claim** — The flagship release notes assert the opposite of the repository's own audit trail — route: standard / medium
-- [ ] [#121](https://github.com/danielPoloWork/egl-util-php/issues/121) **build: register egl/utils on Packagist and verify the tag resolves** — `egl/utils` registered + resolution verified 2026-08-10; open only on the bridge vendor squat-protection, blocked on #120's split repo — route: fast / low
+- [x] [#121](https://github.com/danielPoloWork/egl-util-php/issues/121) **build: register egl/utils on Packagist and verify the tag resolves** — registered + resolution verified 2026-08-10; the `egl/` vendor is squat-protected by that same registration, so the bridge name needs no split repo to defend — route: fast / low
 - [ ] [#120](https://github.com/danielPoloWork/egl-util-php/issues/120) **release: complete the utils-psr7-bridge publication (split repo, Packagist, first bridge tag)** — The library's entire interop story is implemented and contract-tested but not installable — route: standard / medium
 - [ ] [#119](https://github.com/danielPoloWork/egl-util-php/issues/119) **build: add export-ignore rules and cut a v1.0.1 dist-hygiene patch** — The Packagist dist ships 524 files / 3.6 MB of which 97 are production code — route: fast / medium
 - [ ] [#118](https://github.com/danielPoloWork/egl-util-php/issues/118) **docs: ship the consumer on-ramp (composer require, runnable examples, naming map, full surface)** — ROADMAP 13.2 — unanimous across the review: no path from landing on the repo to a first working call — route: standard / medium

--- a/docs/rfc/0003-post-1-0-functional-scope.md
+++ b/docs/rfc/0003-post-1-0-functional-scope.md
@@ -1,0 +1,298 @@
+# RFC-0003: Post-1.0 functional scope — the seams a frozen library still owes
+
+- **Status:** Draft
+- **Author:** tech-lead (agent-drafted) · **Reviewers:** reviewer, enterprise-architect ·
+  **Approver:** tech-lead
+- **Date:** 2026-08-10
+- **Related:** [RFC-0001](0001-egl-utils-library.md) · [RFC-0002](0002-application-layer-groups-from-legacy-intake.md)
+  (both Accepted and fully implemented) · frozen spec
+  [`01_spec_utils.md`](../specs/01_spec_utils.md) r16 ·
+  [ADR-0059](../adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md)
+  (the API freeze this RFC must live inside) · [ADR-0049](../adr/0049-tls-options-per-request-and-a-wall-clock-deadline-the-wrapper-cannot-give.md)
+  (the wall-clock lesson FR-49 inherits) · [ADR-0054](../adr/0054-authenticated-encryption-with-a-versioned-compact-token.md)
+  (the versioned token prefix FR-48 reuses) · [ADR-0040](../adr/0040-install-the-mutation-tester-outside-the-graph-and-let-the-spec-own-its-numbers.md)
+  (the spec owns its numbers) · GitHub issues #84 (this planning item), #91–#97 (the candidates),
+  #114 (SecretKeyRing) · feeds **Milestone 14**
+
+## Context
+
+`v1.0.0` froze the public API with M1–M12 delivered and both prior RFCs closed. The 2026-08-09
+release review board recorded the consequence in its Product Manager seat's finding: **the post-1.0
+roadmap contains zero functional direction.** Milestone 13 is documentation and release hygiene
+end to end, and no functional backlog exists. The API was frozen at the exact moment the story for
+"what is next" became empty.
+
+Seven candidates were filed (#91–#97). A plan pass over them (issue #84) stopped before writing
+`ROADMAP.md`, on a blocker this RFC exists to clear: the plan protocol requires every roadmap item
+to reference an approved RFC, **all seven require a spec amendment by their own acceptance
+criteria**, and no RFC covers them. Milestone 13 is the only RFC-less milestone in the file and it
+bought that exemption by declaring itself *"Not spec work"* in its own preamble — a claim M14
+cannot make.
+
+**What forces the decision now** is not feature pressure. It is that three of the seven candidates
+name the same missing thing as their dependency, and it is absent from the library entirely:
+
+```
+$ grep -rn "ClockInterface\|psr/clock" src/main/ composer.json
+(no matches)
+```
+
+There is no time abstraction anywhere in `src/main`. Retry-with-backoff (#94), rate limiting (#91)
+and signature expiry (#92) each need one, and each would otherwise invent its own. A library that
+ships three private clocks has made the same mistake three times; the review board's Developer
+Platform seat filed the clock separately (#97) precisely because it is a seam, not a feature.
+
+The second force is the freeze itself. Everything below must be **additive** — ADR-0059 permits new
+public surface in a MINOR and forbids altering existing signatures. A design pass now is cheaper
+than discovering at implementation that a chosen shape cannot be corrected without a MAJOR.
+
+## Decision
+
+Add five functional units across three milestones' worth of work, all additive, all behind
+explicit seams. Two of the seven candidates are **deferred with recorded reasons** rather than
+accepted.
+
+### The governing constraint
+
+Every item here is bound by ADR-0059: **new symbols only, never a changed signature.** Where an
+existing class gains behaviour (`Str`), it gains new static methods and no existing one moves.
+Where new dependencies arrive, they are interface-only — the posture `psr/container` and `psr/log`
+already established and NFR-08's rule requires.
+
+### Scope: accepted
+
+| FR | Component | Group | Source issue |
+|---|---|---|---|
+| **FR-45** | `SystemClock`, `FrozenClock` (PSR-20) | `Support` | #97 |
+| **FR-46** | `Str::ulid()`, `Str::uuidV7()` | `Support` | #96 |
+| **FR-47** | `PageRequest`, `Page<T>` + gateway/repository reads | `Persistence` | #95 |
+| **FR-48** | `Hmac` — sign / verify | `Security` | #92 |
+| **FR-49** | `RetryPolicy` | `Support` | #94 |
+
+### Scope: deferred, with the reason recorded
+
+- **#91 rate-limiting primitive — deferred.** A token bucket is only a control if its state is
+  shared by every node that enforces it. This library owns no shared-state component and no
+  storage abstraction beyond the session seam, so the shippable version is single-node. A
+  single-node rate limiter deployed behind a load balancer **looks like protection and is not** —
+  strictly worse than none, because it removes the pressure to install a real one. Reconsider when
+  a storage seam exists and can carry the multi-node honesty statement the issue itself asks for.
+- **#93 `utils-psr18-bridge` — deferred.** It reuses the ADR-0033 split-publication machinery,
+  which **has never executed**: `bridge-release.yml`'s cross-repository push, release-mode install
+  and subtree split are all unexercised (ADR-0035 Consequences records this), and the PSR-7
+  bridge's own publication (#120) is currently paused by the maintainer. Building a second consumer
+  of an unproven pipeline before the first one has run once is the wrong order.
+
+### New components by group
+
+- **FR-45 `Support\SystemClock` + `Support\FrozenClock`** — both implementing
+  `Psr\Clock\ClockInterface`. `SystemClock::now()` returns `new DateTimeImmutable('now')`;
+  `FrozenClock` holds a fixed instant with an explicit `advance(DateInterval)`. `psr/clock` joins
+  `require` as the third interface-only dependency. **This is the sanctioned time seam**: every
+  time-touching API added from here on accepts `ClockInterface`, and the two shipped
+  implementations mean a consumer never writes a test double for it.
+
+- **FR-46 `Str::ulid()` and `Str::uuidV7()`** — time-sortable identifiers under the existing
+  `Str::random()` CSPRNG discipline (`random_bytes`, never `rand`). Both take an optional
+  `?ClockInterface $clock = null` so conformance vectors can be pinned against a fixed instant;
+  passing nothing uses the system clock. **Monotonicity within a single millisecond is explicitly
+  out of scope** — see the algorithm sketch for why, and for what is guaranteed instead.
+
+- **FR-47 `Persistence\PageRequest` + `Persistence\Page<T>`** — readonly value objects.
+  `PageRequest` carries page number and size with clamping refused rather than silent (a size of
+  zero or a negative page throws, per the group's stance), plus `withTotal(bool)` defaulting to
+  **true**. `Page<T>` carries `items`, `total`, and the derived page count, with `@template`
+  generics matching the `TableGateway<T>` discipline — static-analysis only, as `Collection<T>`
+  already is. `Repository` and `TableGateway` gain read methods accepting a `PageRequest`.
+  **No new SQL door**: `QueryBuilder` already has `limit()`/`offset()` with non-negative validation
+  (`QueryBuilder.php:258-274`), so composition stays inside the existing `Identifier` allowlist and
+  `SqlStatement::fromQueryBuilder()`.
+
+- **FR-48 `Security\Hmac`** — `sign()` / `verify()` over a **versioned compact token**, the exact
+  shape ADR-0054 established for `Crypto`: a `v1.` prefix plus base64url payload. Key material is
+  `SecretKey` only — the type is the enforcement, as it already is for `Crypto`. Comparison is
+  `hash_equals()`, asserted as a **mechanism** per ADR-0027 because no behavioural test can observe
+  a timing-unsafe comparator. Algorithms are an explicit allowlist, never a caller-supplied string.
+  Optional expiry is embedded in the signed payload and validated against an injected
+  `ClockInterface` (FR-45), so expiry is testable without sleeping.
+
+- **FR-49 `Support\RetryPolicy`** — an explicit policy value object: maximum attempts, jittered
+  exponential delay, a retryable-exception allowlist, and — the part ADR-0049 already paid for
+  once — a **total wall-clock deadline**. That ADR's finding was that PHP's per-phase timeout
+  re-arms and therefore bounds no request; attempt-count alone bounds no retry loop for the same
+  reason. Delay is consumed through the clock seam so tests never sleep. Consumed **opt-in** by
+  `HttpClient` and transaction callers; never implicit, because a library that silently retries has
+  changed a caller's failure semantics without being asked.
+
+### API contract (`api` / `systemdesign`)
+
+- **Operations** — the FR-45…FR-49 surfaces above, under the existing namespace scheme
+  (`D4np\Utils\{Support,Persistence,Security}\`). No existing signature is touched.
+- **Payloads** — value objects are `readonly` with named constructors, the shape every group here
+  already uses (`SqlStatement`, `ApiEnvelope`, `EmailAddress`). `Page<T>`/`Collection<T>` genericity
+  is `@template` + PHPStan max, with no runtime enforcement — stated, as `docs/releases/v1.0.0.md`
+  already states it for `Collection<T>`.
+- **Error model** — every failure is a typed exception from the existing hierarchy. FR-47 raises
+  `DatabaseException` (the Persistence group's no-silent-`[]` rule, FR-34); FR-48 raises
+  `CryptoException` for a failed verify, never a boolean — the `bool|string` return RFC-0002 named
+  as the anti-requirement applies identically here; FR-45/46/49 raise `UtilsException` descendants.
+  **`ExceptionHierarchyTest` pins both the discovered-class list and the finality lists**, so any
+  new exception type updates both.
+- **Versioning** — all additive: a MINOR each. A MAJOR would be required only to *remove* or
+  *alter* one of these, which ADR-0059's deprecation window governs. FR-48's token carries its own
+  `v1.` prefix, so the token format has a migration path independent of the package version.
+
+### Scalability budgets (`scalability`)
+
+Following ADR-0040, **the spec owns its numbers and this RFC does not invent them.** It names the
+axes that get a budget and the method; the values are set from measurement on the reference runner
+at implementation, never from this document and never from a developer machine — local timing on
+the project's Windows box has overstated CPU-bound work by 2×–5× on every occasion it was checked
+(items 10.11, 10.12, 12.3).
+
+- **NFR-15 — identifier generation (FR-46).** The one plausibly hot path here: identifiers are
+  generated per inserted row. Gets an absolute budget, measured with a control subject in the same
+  job (item 12.4's rule: one control per CI job catches a run-wide slowdown).
+- **No budget for FR-45.** `SystemClock::now()` is one `DateTimeImmutable` allocation. NFR-14's
+  experience is instructive: its control subject measured 57% of the subject, meaning that budget
+  mostly bounds PHP's own method dispatch. A clock budget would measure the same thing and assert
+  nothing about this library.
+- **FR-47's cost is architectural, not a code-speed axis.** `withTotal(true)` issues a **second
+  statement**. That is a round trip, not microseconds, and no `src/bench` subject can express it;
+  it is documented as the price of the default and opted out of per request.
+
+**Item 10.10's lesson is a precondition on every number above**: when two requirements constrain
+nested scopes on one axis, the outer must be satisfiable *given* the inner's own allowance. NFR-01
+and NFR-09 were unsatisfiable from the day they were drafted because nobody performed that
+division. Any FR-46 budget is checked against `Str::random()`'s existing cost before it is written
+down.
+
+### Algorithm sketch (`pseudocode`)
+
+The one non-obvious decision, and issue #96 names it as the reason for its effort rating:
+**monotonicity within the same millisecond.**
+
+```
+ulid(clock):
+    ms      <- clock.now() as milliseconds since epoch     # 48 bits, time-ordered
+    entropy <- CSPRNG(80 bits)                             # Str::random() discipline
+    return base32_crockford(ms || entropy)                 # 26 chars, lexicographically sortable
+```
+
+Two ULIDs drawn in the same millisecond share a timestamp prefix and are ordered **only by their
+random tails** — i.e. not ordered at all. Guaranteeing otherwise requires remembering the previous
+call's timestamp and entropy and incrementing it, which means **cross-call mutable state**.
+
+**Decision: guaranteed intra-millisecond monotonicity is out of scope, and the boundary is
+tested rather than left to inference.** Reasons, in order of weight:
+
+1. A `static` method holding cross-call state is a global mutable — the shape this library refuses
+   everywhere else (`NativeMailer` takes its configuration through a constructor precisely so it
+   does not mutate `ini` globals, FR-44).
+2. The stated problem is **B-tree index fragmentation**. Millisecond-granular ordering already
+   delivers index locality; two rows inserted in the same millisecond land in the same page
+   regardless of their relative order. The motivating benefit does not require the guarantee.
+3. Wanting the guarantee implies a stateful generator with a lifecycle — a different object, and
+   an additive one, so deferring costs nothing later.
+
+What is guaranteed and pinned by test: identifiers from *different* milliseconds sort in time
+order; format conformance against the RFC 9562 / ULID specification vectors; the CSPRNG source.
+What is pinned as explicitly *not* guaranteed: the relative order of two identifiers from the same
+millisecond.
+
+### Cross-cutting
+
+**Security.** FR-48 is the security-surface item and carries the routing floor to prove it
+(`os/routing`'s `security-surface` rule is a **protected** floor nothing may lower). Two mechanism
+assertions per ADR-0027, because behaviour cannot see either property: that the comparator is
+`hash_equals()`, and that the algorithm allowlist is consulted rather than the caller's string.
+FR-48 coordinates with the SecretKeyRing issue (#114) on key identifiers — **but does not block on
+it**, because ADR-0054's versioned prefix already absorbs the change: key-id-bearing tokens become
+`v2.`, and `v1.` tokens keep verifying. The prefix was designed for exactly this and this RFC
+spends it rather than inventing a second mechanism.
+
+**Performance.** FR-49's jitter is not decoration: without it, N clients that failed together retry
+together, and the retry storm is the outage. Jitter is part of the requirement, not an option.
+
+**Non-goals — the standing answer to scope-creep requests.** Recorded here so it has a citable
+home (issue #84's third acceptance criterion): **no money/decimal arithmetic** (`brick/math` is the
+right answer and is a third-party pick, not a reimplementation), **no ORM features** (identity map,
+change tracking, lazy loading and JOINs are already refused by FR-35's non-goals), **no SMTP
+client** (FR-44 states `Mailer` is the seam a `symfony/mailer` adapter plugs into), **no console
+or i18n helpers** (neither is a utility concern for a library at this layer).
+
+## Alternatives
+
+1. **Do nothing — let the post-1.0 backlog stay empty.** Rejected: the review board found the gap
+   unanimously enough to file eight issues, and the clock's absence is already forcing every
+   consumer to hand-roll a test seam. Doing nothing is a decision to keep paying that.
+2. **Accept all seven candidates into one milestone.** Rejected on two concrete grounds, not on
+   size: the rate limiter would ship a single-node control that misrepresents itself as protection,
+   and the PSR-18 bridge would be the second consumer of a publication pipeline that has never run
+   once.
+3. **A private clock inside each consumer** (no FR-45; retry, HMAC and rate limiting each read the
+   system time directly). Rejected: it makes all three untestable without sleeping, and PSR-20
+   exists precisely so a library does not invent this. It also violates NFR-08's posture less
+   visibly than it violates common sense — three private clocks is the same mistake three times.
+4. **`Support\UlidFactory` as a stateful object instead of `Str::ulid()`.** Rejected for the
+   default case: it splits identifier generation across two places for a consumer who only wants a
+   sortable key, and `Str::uuid()` (v4) already established where consumers look. Recorded as the
+   shape a future guaranteed-monotonic generator would take, if demand appears.
+5. **Window-function pagination totals** (`COUNT(*) OVER ()`, one statement instead of two).
+   Rejected on portability: the project's database proof is **SQLite-only** — no MySQL or
+   PostgreSQL CI leg exists (an open review-board finding, issue #110) — so a construct with
+   version-dependent support across three engines cannot be claimed to work. Revisit if #110 lands.
+6. **`Page<T>` without a total** (no second query ever). Rejected: consumers then hand-roll the
+   count query, which is the exact duplication this library exists to remove. The cost is made
+   visible and opt-out-able instead of hidden by omission.
+7. **Retry bounded by attempt count alone.** Rejected on evidence already paid for: ADR-0049
+   established that a per-phase bound re-arms and therefore bounds nothing overall. Attempts
+   without a deadline reproduce that defect in a new place.
+
+## Consequences
+
+**Made easier.** Every future time-dependent API has one sanctioned seam and two shipped
+implementations. Signed URLs and webhook verification stop being the hand-rolled `===`-and-`sha1`
+snippet the security seat flagged. Paging stops being re-derived per estate. Retry gets a shape
+that cannot silently run forever.
+
+**Made harder.** A third `require` dependency (`psr/clock`), interface-only and consistent with the
+existing two, but it is one more line in the install footprint the dist-hygiene issue (#119) is
+already trying to shrink. Five new public surfaces are five more things the freeze forbids
+altering — the deprecation window (ADR-0059, `maintenance.md`) is the only exit, and it is
+deliberately slow.
+
+**Migration path.** None required: every item is additive and every consumer of `v1.x` is
+unaffected until it opts in. The one caller-visible default worth naming is FR-47's
+`withTotal(true)` — a consumer paging a large table pays a second query unless it opts out, and
+that is stated in the notes rather than discovered in a slow log.
+
+**Follow-up roadmap items.** This RFC feeds **Milestone 14**; the plan pass (issue #84) turns
+FR-45…FR-49 into numbered items with sizes and routes. Two prerequisites belong to that pass and
+not to this document: **#86** (apply the GitHub type labels — until it lands, `route_advice.py`
+resolves every one of these issues to `fast / low` because none carries a label, and no route in
+the tracker is machine-verifiable), and a **milestone-item → RFC gate**, since `traceability.py` is
+one-directional and verified green today on a roadmap whose M13 references no RFC at all. Deferred
+candidates #91 and #93 keep their issues open with the reasons above recorded.
+
+## Approval
+
+Filled by the approver **after** review (this is the `rfc-approved` gate's record):
+
+```
+approved-by: <pending>
+```
+
+Reviewers (structured findings addressed): reviewer — ▢ · enterprise-architect — ▢.
+
+## References
+
+- Issues [#84](https://github.com/danielPoloWork/egl-util-php/issues/84) (planning),
+  [#91](https://github.com/danielPoloWork/egl-util-php/issues/91)–[#97](https://github.com/danielPoloWork/egl-util-php/issues/97)
+  (candidates), [#114](https://github.com/danielPoloWork/egl-util-php/issues/114) (SecretKeyRing),
+  [#110](https://github.com/danielPoloWork/egl-util-php/issues/110) (real-engine DB leg),
+  [#86](https://github.com/danielPoloWork/egl-util-php/issues/86) (type labels)
+- [PSR-20 Clock](https://www.php-fig.org/psr/psr-20/) · [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562)
+  (UUIDv7) · [ULID specification](https://github.com/ulid/spec)
+- `docs/specs/01_spec_utils.md` r16 (FR-01…FR-44, NFR-01…NFR-14, T-01…T-15 — this RFC's surface
+  continues at FR-45, NFR-15, T-16)

--- a/docs/rfc/0003-post-1-0-functional-scope.md
+++ b/docs/rfc/0003-post-1-0-functional-scope.md
@@ -1,6 +1,6 @@
 # RFC-0003: Post-1.0 functional scope — the seams a frozen library still owes
 
-- **Status:** Draft
+- **Status:** Accepted
 - **Author:** tech-lead (agent-drafted) · **Reviewers:** reviewer, enterprise-architect ·
   **Approver:** tech-lead
 - **Date:** 2026-08-10
@@ -277,13 +277,23 @@ candidates #91 and #93 keep their issues open with the reasons above recorded.
 
 ## Approval
 
-Filled by the approver **after** review (this is the `rfc-approved` gate's record):
+Recorded on the maintainer's approval of PR #129 (2026-08-11), the same shape RFC-0002's record
+takes:
 
 ```
-approved-by: <pending>
+approved-by: tech-lead (2026-08-11)
 ```
 
-Reviewers (structured findings addressed): reviewer — ▢ · enterprise-architect — ▢.
+Reviewers (structured findings addressed): **no separate peer-review pass was run.** The protocol's
+`reviewer` and `enterprise-architect` seats did not return structured findings on this RFC; the
+maintainer read it as opened and approved it directly. Recorded as it happened rather than as two
+resolved review marks, because a tick standing for a review that never ran is the failure this
+project has already corrected once — `docs/releases/v1.0.0.md` claimed a release gate's approval
+that the gate had refused (item 13.1, issue #122). **What that costs, stated:** the design folds
+below carry the author's confidence tags and nothing independent has challenged them. The two
+decisions most exposed to a missing second opinion are the out-of-scope ruling on
+intra-millisecond ULID monotonicity and the deferral of the rate limiter — both argued from stated
+premises, neither adversarially tested.
 
 ## References
 

--- a/docs/workflow/release.md
+++ b/docs/workflow/release.md
@@ -94,6 +94,14 @@ Both are the maintainer's, not the agent's, and the first release cannot succeed
    **Done 2026-08-10** (issue #121): `egl/utils` is registered with the integration wired, and
    `composer require egl/utils:^1.0` was verified in a clean throwaway project — it resolves
    `v1.0.0` at source commit `be7f34e`, the exact commit the tag points at.
+
+   **This also protects every other `egl/` name, including the bridge's.** Packagist locks a
+   vendor namespace to the first publisher: a package cannot be published under an existing
+   vendor without permission, and publishing under one requires being maintainer of a package
+   already in it. So `egl/utils-psr7-bridge` cannot be squatted, and **name protection is not a
+   reason to hurry the split repository** — step 3 is about *publishing* the bridge, not about
+   defending its name. Do not conflate the two: the original issue did, and it made a solved
+   problem look blocked.
 3. **For the bridge only** — a **split repository** and a token that can write to it:
    - create the repository (e.g. `danielPoloWork/egl-utils-psr7-bridge`), empty, and treat it as
      **read-only**: it is generated, and accepts no commits or pull requests;


### PR DESCRIPTION
## Summary

**RFC-0003** — the post-1.0 functional scope. Accepts five of the review board's seven candidates
into what becomes Milestone 14, defers two with recorded reasons, and settles the design questions
their issues left open. **Approved** on your instruction (2026-08-11); `rfc_check` green.

## Motivation

Issue #84 asked for a plan pass over #91–#97. It stopped before writing `ROADMAP.md`, on a blocker
worth stating plainly:

- The plan protocol requires *"no roadmap item without a design behind it"* — each item references
  an approved RFC.
- `refs.rfcs` is `['RFC-0001','RFC-0002']`. Both Accepted, both fully implemented (M1–M12).
- **All seven candidates require a spec amendment by their own acceptance criteria** — five say
  *"ADR + spec amendment"* verbatim. The spec is a frozen contract at r16 (FR-01…FR-44); this is
  FR-45 upward.
- M13 is the only RFC-less milestone and bought that exemption by declaring itself *"**Not spec
  work**"* in its preamble. M14 is spec work seven times over.

The maintainer was given the fork and chose the design route. This PR is its output.

**A gap found on the way**: `traceability.py` is **one-directional** — it asserts RFC → ≥1
milestone, never milestone item → RFC. It reports green today on a roadmap whose M13 references no
RFC at all. The protocol's rule is enforced by no gate in this repository. Recorded in the RFC's
follow-ups.

## What the RFC decides

**Accepted** — all additive under ADR-0059's freeze:

| FR | Component | Group | Issue |
|---|---|---|---|
| FR-45 | `SystemClock` / `FrozenClock` (PSR-20) | `Support` | #97 |
| FR-46 | `Str::ulid()` / `Str::uuidV7()` | `Support` | #96 |
| FR-47 | `PageRequest` / `Page<T>` + gateway reads | `Persistence` | #95 |
| FR-48 | `Security\Hmac` | `Security` | #92 |
| FR-49 | `RetryPolicy` | `Support` | #94 |

**Deferred, on reasons rather than size:**

- **#91 rate limiting** — this library owns no shared state, so the shippable version is
  single-node. Behind a load balancer that **looks like protection and is not** — strictly worse
  than none, because it removes the pressure to install a real one.
- **#93 PSR-18 bridge** — it would be the second consumer of ADR-0033's split-publication
  pipeline, whose cross-repository push, release-mode install and subtree split **have never
  executed** (ADR-0035 records this), and whose first consumer (#120) is paused.

## The load-bearing findings

**The clock is why this is urgent, not the features.**

```
$ grep -rn "ClockInterface\|psr/clock" src/main/ composer.json
(no matches)
```

No time abstraction exists anywhere. Three of the seven candidates name one as their dependency.
Three private clocks is the same mistake three times — which is why the board filed #97 separately.

**Intra-millisecond ULID monotonicity: explicitly out of scope.** Issue #96 asked for this to be
decided rather than left implicit. Guaranteeing it requires cross-call mutable state inside a
`static` method — the shape this library refuses everywhere else (FR-44 takes configuration through
a constructor precisely so it does not mutate globals). And the *stated problem* is B-tree index
fragmentation, which millisecond granularity already solves: two rows inserted in the same
millisecond land in the same page regardless of their order. Pinned by test in **both** directions.

**FR-48 does not block on SecretKeyRing (#114).** ADR-0054's versioned token prefix already absorbs
key identifiers — they arrive as `v2.` while `v1.` tokens keep verifying. The prefix was designed
for this; the RFC spends it rather than inventing a second mechanism.

**FR-47 rejects window-function totals on portability, not taste.** This project's database proof
is **SQLite-only** — no MySQL/PostgreSQL CI leg exists (#110) — so `COUNT(*) OVER ()`, whose
support is version-dependent across three engines, cannot be claimed to work here.

**No budget numbers are invented.** Per ADR-0040 the spec owns its numbers; the RFC names the axes
and the method and defers the values to CI measurement. It also carries item 10.10's lesson forward
as a precondition: NFR-01 and NFR-09 were unsatisfiable from the day they were drafted because
nobody checked the outer scope against the inner's own allowance.

## Design Patterns

None adopted here — an RFC states the contract; pattern adoptions land with their implementing
items and their own ADRs.

## Verification

- [x] `python .eados-core/tools/authority_check.py tech-lead docs/rfc/0003-...md` → OK
- [x] `python tools/consistency_lint.py` → OK
- [x] Every premise checked in the tree, not assumed: the empty clock grep; `QueryBuilder`'s
      existing `limit()`/`offset()` (`QueryBuilder.php:258-274`) so FR-47 opens no new SQL door;
      `Str::uuid()`/`Str::random()` at `Str.php:65,94`; spec ceilings FR-44 / NFR-14 / T-15 so the
      new surface numbers from FR-45, NFR-15, T-16
- [x] `python .eados-core/tools/rfc_check.py` → **OK** after the approval commit
- [x] `roadmap-covers-rfcs` → **FAIL: `no milestone addresses RFC-0003`** — correct and expected.
      That is the *plan → scaffold* gate, and the plan pass has not run; it turns green when M14
      references this RFC. Approving the RFC is what gave that gate something to check
- n/a Unit tests / PHPStan / CS-Fixer / benchmarks — no `src/` changes

## Documentation Impact

- [x] New `docs/rfc/0003-post-1-0-functional-scope.md`
- [ ] ROADMAP.md — **not touched**: writing M14 is the plan pass, and it is legal only once this
      RFC is approved
- [ ] CHANGELOG.md — no entry, matching RFC-0002's PR (#49): an RFC is a governance artifact, not
      a user-visible change
- [ ] Spec — unchanged; FR-45…FR-49 land with their implementing items
- [x] PR metadata — assignee (owner), one type label (`documentation`), no milestone

## What is left for you

**Approved** — you asked for the record and it is written: `approved-by: tech-lead (2026-08-11)`,
Status `Draft → Accepted`.

The reviewers line records that **no separate peer-review pass ran**, rather than ticking two
resolved marks for reviews that never happened. A tick standing for a review that did not run is
the exact failure corrected three days ago in `docs/releases/v1.0.0.md` (item 13.1 / issue #122);
reproducing it inside a governance record would be worse than the original. What it costs is stated
in the record — the two decisions most exposed to the missing second opinion are named there.

Two steps follow that are **not** in this PR:

1. the architect records `RFC-0003` in `delivery_state.refs.rfcs`;
2. the `design → plan` transition is proposed for your confirmation.

Then the plan pass writes M14 and `roadmap-covers-rfcs` goes green.

## Lesson

A one-directional traceability gate reads exactly like a two-directional one when it is green.
`roadmap-covers-rfcs` has been passing for thirteen milestones while never once checking the
direction that mattered here.
