### PR TITLE
ci(ci): name the uncovered lines even when the diff gate passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,20 +295,10 @@ jobs:
         run: |
           python tools/diff_coverage_gate.py build/logs/clover.xml \
             --base '${{ github.event.pull_request.base.sha }}' --min 90
-      # TEMPORARY, and removable once the floor is confirmed. There is no coverage driver on the
-      # maintainer's machine (a standing local quirk), so the first real per-diff readings this
-      # project has ever had can only come from a runner. This prints the figure for the three
-      # most recent merged PHP items against today's report, so the 90% floor above is confirmed
-      # or revised on evidence rather than on the argument that it is NFR-07's own number.
-      # Report-only: it must not fail a PR on the coverage of somebody else's merge.
-      - name: Measure per-diff coverage of recent merges (informational, remove after #109)
-        if: github.event_name == 'pull_request'
-        run: |
-          for ref in e781934 3a42911 1dea68c; do
-            echo "--- ${ref} ($(git log -1 --format=%s "${ref}" | cut -c1-60)) ---"
-            python tools/diff_coverage_gate.py build/logs/clover.xml \
-              --base "${ref}^" --head "${ref}" --min 90 --report-only || true
-          done
+      # The temporary measurement step that stood here is gone: it did its job on run
+      # 32464266232 and the 90% floor above is now confirmed on evidence rather than on the
+      # argument that it is NFR-07's own number. The three readings, recorded in ADR-0068:
+      # Hmac 62/62 (100%), RetryPolicy 89/89 (100%), the rate limiter 167/175 (95.43%).
 
   # Reproducible performance gate — runs only when the project has a benchmark suite.
   #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,16 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
   - **Absence is failure.** A missing report, an unparseable one, or a base ref git cannot resolve
     all exit 2. A change touching no coverable statement passes, saying so rather than dividing by
     zero in either direction.
+  - **Uncovered changed lines are named even when the gate passes.** A run that knows exactly which
+    lines are dead and reports only a percentage is withholding the actionable half of its own
+    measurement.
   - **The proof that it can fail ships with it.** `tools/tests/verify_diff_coverage_gate.py` is the
-    first executable check for any `tools/*.py` here — fifteen cases over throwaway git
+    first executable check for any `tools/*.py` here — seventeen cases over throwaway git
     repositories, four of them the ones that matter, and CI runs it in the `consistency` job. Every
     previous tool on this project was verified by hand and the outcome written into an ADR.
+  - **Measured, not asserted.** The floor is confirmed by the first real readings this project has
+    ever had (run 32464266232): item 14.4 `Hmac` 62/62 = 100%, item 14.5 `RetryPolicy` 89/89 = 100%,
+    item 14.7's rate limiter 167/175 = 95.43%, against 94.05% total tree coverage.
 - **`Security\RateLimiter` — a token bucket per key, behind a compare-and-swap store** (spec
   **r22 FR-50**, RFC-0003; roadmap items **14.6**/**14.7**; **ADR-0061** design + **ADR-0067**
   implementation; closes issue #91). Additive under ADR-0059. With it:
@@ -134,6 +140,12 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Fixed
 
+- **Three classes' default-clock construction path is now exercised.** `RateLimiter`,
+  `ArrayRateLimitStore` and `FileRateLimitStore` each accept an optional `Psr\Clock\ClockInterface`
+  and fall back to `SystemClock` — the path **every production caller takes**, and the one no test
+  reached, because they all inject a `FrozenClock`. No behaviour changed; what changed is that it is
+  now asserted. Found by reading the new per-diff coverage gate's first real output rather than by
+  anyone reporting it (ADR-0068).
 - **The constant-time comparison registry had been blind to every call in the library**
   ([BUG-0001](docs/bugs/2026/08/BUG-0001-constant-time-registry-blind-to-prefixed-calls.md), the
   bug ledger's first record; found by item 14.4 and fixed in the same PR).

--- a/docs/adr/0068-intersect-the-report-with-the-diff-and-ship-the-proof-it-can-fail.md
+++ b/docs/adr/0068-intersect-the-report-with-the-diff-and-ship-the-proof-it-can-fail.md
@@ -159,13 +159,28 @@ script, it is not.
   both events.
 - **ADR-0007 is annotated, not rewritten** — its decision (total coverage, measured once, against
   NFR-07's 90%) is untouched, and the per-diff gate reuses that same number.
-- **A temporary measurement step ships with this**, and it is the honest way around a local
-  constraint: there is no coverage driver on the maintainer's machine, so the first per-diff readings
-  this project has ever had can only come from a runner. The step prints the figure for the three most
-  recent merged PHP items (`e781934`, `3a42911`, `1dea68c`) against today's report, report-only, so
-  the 90% floor is **confirmed or revised on evidence** rather than on §2's argument alone. It is
-  labelled for removal once that is settled — the same shape as item 11.5's draft-PR-for-real-numbers
-  method, which exists because local figures on this machine are not evidence.
+- **A temporary measurement step shipped with this and has since been removed**, having done its
+  job. It was the honest way around a local constraint: there is no coverage driver on the
+  maintainer's machine, so the first per-diff readings this project has ever had could only come from
+  a runner — item 11.5's draft-PR-for-real-numbers method, applied to a gate. **Run 32464266232**:
+
+  | commit | item | changed statements covered |
+  |---|---|---|
+  | `e781934` | 14.4 `Hmac` | 62 / 62 — **100.00%** |
+  | `3a42911` | 14.5 `RetryPolicy` | 89 / 89 — **100.00%** |
+  | `1dea68c` | 14.7 rate limiter | 167 / 175 — **95.43%** |
+
+  Total tree coverage on the same run: 2 515 / 2 674 = **94.05%**. **The 90% floor is therefore
+  confirmed on evidence, not on §2's argument alone** — the worst of three real items clears it by
+  5.4 points, and the two before it were exact. §2's reasoning stands as the justification for the
+  *number*; this is the justification for it being *affordable*.
+- **The 95.43% reading changed the tool.** Eight statements in the rate limiter are never executed,
+  and the first version of this gate **declined to name them because it had passed** — it enumerated
+  uncovered lines only on failure. That is withholding the actionable half of its own measurement: a
+  passing run that knows exactly which lines are dead should say so. It now does, on success as well
+  as on failure, with a verification case for each direction (and one asserting a fully covered run
+  stays quiet). Found by reading the gate's own first output rather than by anybody reporting it —
+  which is the argument for having made it print real numbers on run one.
 - **What this does not measure**, stated so nobody reads more into a green square than it carries: that
   an executed line was *asserted* about. Item 14.7's two tests that passed without reaching their own
   branch would have satisfied this gate the moment any test touched those lines. Coverage is a floor

--- a/docs/journal/2026/08/2026-08-21-per-diff-coverage-gate.md
+++ b/docs/journal/2026/08/2026-08-21-per-diff-coverage-gate.md
@@ -99,3 +99,39 @@ This change adds Python and YAML, so its diff contains no coverable PHP statemen
 "nothing to measure" on itself. **The first real reading arrives on the next PHP change** — stated in
 the PR rather than left for someone to discover, because a gate that has never returned a number is not
 yet a gate that works.
+
+## Postscript — the numbers arrived, and they changed the tool
+
+`#144` merged, and the temporary step delivered on run **32464266232**:
+
+| commit | item | changed statements covered |
+|---|---|---|
+| `e781934` | 14.4 `Hmac` | 62 / 62 — **100.00%** |
+| `3a42911` | 14.5 `RetryPolicy` | 89 / 89 — **100.00%** |
+| `1dea68c` | 14.7 rate limiter | 167 / 175 — **95.43%** |
+
+Total tree coverage on the same run: 2 515 / 2 674 = **94.05%**. And on the PR itself, exactly as
+predicted: *"no coverable statements changed"*.
+
+**The floor is confirmed on evidence.** The worst of three real items clears 90% by 5.4 points, and the
+two before it were exact. §2's reasoning justified the *number*; this justifies it being *affordable*,
+which is the part an argument alone could not settle.
+
+**But the 95.43% is the useful part, and it exposed a defect in my own tool.** Eight statements in the
+rate limiter are never executed — and the gate *declined to name them, because it had passed*. It
+enumerated uncovered lines only on failure. That is withholding the actionable half of its own
+measurement: a run that knows precisely which lines are dead and reports a percentage instead is doing
+less than it could for free. Fixed; it now names them on success too, with a verification case for
+each direction and one asserting a fully covered run stays quiet (17 cases).
+
+**And then the named lines were worth having.** `$clock ?? new SystemClock()` in `RateLimiter`,
+`ArrayRateLimitStore` and `FileRateLimitStore` — **the path every production caller takes**, and the
+one no test reached, because every test injects a `FrozenClock`. No behaviour was wrong; what was
+missing was any assertion that the default wiring works at all. Three tests added.
+
+The transferable bit: **the gate's first output was worth reading as carefully as a test failure.** It
+passed, it was green, and it still contained two findings — a hole in the tool and a hole in the
+suite. This session started with BUG-0001 (a guard green on an empty set) and item 14.7 (two tests
+green without reaching their own branch). Green is not the end of the sentence.
+
+The temporary measurement step is gone, its readings recorded in ADR-0068.

--- a/src/test/php/d4np/utils/Security/RateLimitStoreTest.php
+++ b/src/test/php/d4np/utils/Security/RateLimitStoreTest.php
@@ -319,6 +319,25 @@ final class RateLimitStoreTest extends TestCase
         );
     }
 
+    /**
+     * Both stores on the system clock — the default-clock path no other test here reaches.
+     *
+     * Same gap as `RateLimiterTest::testItWorksWithoutAnInjectedClock()`, and found the same way:
+     * the per-diff coverage gate's first real reading (ADR-0068) named eight never-executed
+     * statements on this item, and `$clock ?? new SystemClock()` was one of them in each class.
+     * A generous TTL keeps the assertion independent of what time it actually is.
+     */
+    public function testBothStoresWorkWithoutAnInjectedClock(): void
+    {
+        foreach ([new ArrayRateLimitStore(), new FileRateLimitStore($this->directory)] as $store) {
+            self::assertTrue($store->writeIfVersion(self::key(), 'state', 3_600_000_000, null));
+
+            $record = $store->read(self::key());
+            self::assertNotNull($record, \get_class($store) . ' lost the state it just wrote');
+            self::assertSame('state', $record->state());
+        }
+    }
+
     public function testTheArrayStoreEnforcesNothingAcrossInstances(): void
     {
         $first = new ArrayRateLimitStore($this->clock);

--- a/src/test/php/d4np/utils/Security/RateLimiterTest.php
+++ b/src/test/php/d4np/utils/Security/RateLimiterTest.php
@@ -242,6 +242,34 @@ final class RateLimiterTest extends TestCase
         self::assertTrue($limiter->attempt('login', 'grace')->allowed());
     }
 
+    /**
+     * The default-clock path — the one every production caller takes.
+     *
+     * Every other test here injects a {@see FrozenClock}, so `$clock ?? new SystemClock()` was
+     * never executed by anything. The per-diff coverage gate's first real reading (issue #109,
+     * ADR-0068: 167/175 changed statements on this item) is what surfaced it: eight never-executed
+     * statements, of which this was one in each of three classes. A wiring path that only
+     * consumers reach, and no test does, is worth one assertion each.
+     *
+     * Real wall-clock time, and that is fine: nothing here depends on *which* instant it is, only
+     * that a clock exists and the bucket works against it. No sleeping either.
+     */
+    public function testItWorksWithoutAnInjectedClock(): void
+    {
+        $limiter = new RateLimiter(
+            RateLimitPolicy::perWindow(2, new DateInterval('PT1H')),
+            new ArrayRateLimitStore(),
+        );
+
+        self::assertTrue($limiter->attempt('login', 'ada')->allowed());
+        self::assertTrue($limiter->attempt('login', 'ada')->allowed());
+        self::assertFalse(
+            $limiter->attempt('login', 'ada')->allowed(),
+            'the bucket must behave identically on the system clock; an hour-long window means '
+            . 'no refill can arrive inside this test',
+        );
+    }
+
     // -----------------------------------------------------------------------------------------
     // Clock skew — a behind-clock node must not mint tokens
     // -----------------------------------------------------------------------------------------

--- a/tools/diff_coverage_gate.py
+++ b/tools/diff_coverage_gate.py
@@ -251,6 +251,19 @@ def main(argv=None):
 
     if pct + 1e-9 >= args.min:
         print("diff coverage gate: OK")
+        # Named even on success, and that is the point. The first three real readings this gate
+        # ever produced were 100%, 100% and 95.43% — and the 95.43% meant eight statements in the
+        # rate limiter were never executed, which nobody could see because the first version of
+        # this tool enumerated the lines only when it failed. A passing run that knows exactly
+        # which lines are dead and says nothing is withholding the actionable half of its own
+        # measurement.
+        if uncovered:
+            print(f"\n  {len(uncovered)} changed statement(s) inside the floor are still never "
+                  "executed:")
+            for path, line in uncovered[:40]:
+                print(f"    {path}:{line}")
+            if len(uncovered) > 40:
+                print(f"    … and {len(uncovered) - 40} more")
         return 0
 
     print(f"\ndiff coverage gate: {'FAIL' if not args.report_only else 'BELOW FLOOR (report-only)'} "

--- a/tools/tests/verify_diff_coverage_gate.py
+++ b/tools/tests/verify_diff_coverage_gate.py
@@ -54,7 +54,8 @@ def clover(files):
     return '\n'.join(parts) + '\n'
 
 
-def scenario(name, base_files, head_files, report, extra_args=(), expect=None, expect_in=None):
+def scenario(name, base_files, head_files, report, extra_args=(), expect=None, expect_in=None,
+             expect_not_in=None):
     work = tempfile.mkdtemp(prefix='dcg-')
     try:
         git(['init', '-q', '-b', 'master'], work)
@@ -89,6 +90,9 @@ def scenario(name, base_files, head_files, report, extra_args=(), expect=None, e
         if expect_in is not None and expect_in not in r.stdout:
             ok = False
             detail = f' (missing text: {expect_in!r})'
+        if expect_not_in is not None and expect_not_in in r.stdout:
+            ok = False
+            detail = f' (unexpected text: {expect_not_in!r})'
         print(f'  [{"ok " if ok else "FAIL"}] exit {r.returncode} (want {expect}){detail}  {name}')
         if not ok:
             FAILED.append(name)
@@ -131,6 +135,19 @@ scenario('9 of 10 covered (90%) -> pass, the floor is inclusive',
          {SRC: '<?php\n' + ''.join(f'$x{i} = {i};\n' for i in range(1, 11))},
          clover({SRC: {**{i: 1 for i in range(2, 11)}, 11: 0}}), expect=0,
          expect_in='9/10 changed statements covered = 90.00%')
+
+# The reason this case exists: the gate's first three real readings were 100%, 100% and 95.43%,
+# and the 95.43% meant eight never-executed statements that the tool declined to name because it
+# had passed. A passing run must still say which lines are dead.
+scenario('a passing run still names the uncovered lines',
+         {SRC: '<?php\n'},
+         {SRC: '<?php\n' + ''.join(f'$x{i} = {i};\n' for i in range(1, 11))},
+         clover({SRC: {**{i: 1 for i in range(2, 11)}, 11: 0}}), expect=0,
+         expect_in=f'{SRC}:11')
+
+scenario('a fully covered run says nothing about uncovered lines',
+         BASE, GREW, clover({SRC: {3: 5, 4: 1, 5: 1, 6: 1, 7: 1}}), expect=0,
+         expect_not_in='never executed')
 
 scenario('a docs-only change -> pass, saying nothing was measurable',
          {'README.md': 'a\n', SRC: '<?php\n$a = 1;\n'},


### PR DESCRIPTION
## Summary

Follow-up to #144, finishing what it started. Its temporary measurement step did its job and is
removed; the readings go into ADR-0068. Two things came out of reading that output, and both are in
here.

## The first real per-diff readings this project has ever had

Run **32464266232**:

| commit | item | changed statements covered |
|---|---|---|
| `e781934` | 14.4 `Hmac` | 62 / 62 — **100.00%** |
| `3a42911` | 14.5 `RetryPolicy` | 89 / 89 — **100.00%** |
| `1dea68c` | 14.7 rate limiter | 167 / 175 — **95.43%** |

Total tree coverage on the same run: 2 515 / 2 674 = **94.05%**. And on #144 itself, exactly as
predicted: *"no coverable statements changed"*.

**The 90% floor is confirmed on evidence.** The worst of three real items clears it by 5.4 points and
the two before it were exact. ADR-0068 §2 justified the *number* (it is NFR-07's own, not a new one);
this justifies it being *affordable*, which an argument alone could not settle.

## ★ The 95.43% exposed a defect in the tool I had just shipped

Eight statements in the rate limiter are never executed — and **the gate declined to name them
because it had passed.** It enumerated uncovered lines only on failure.

That is withholding the actionable half of its own measurement. A run that knows precisely which
lines are dead and reports a percentage instead is doing less than it could, for free. It now names
them on success as well, with a verification case for each direction plus one asserting a fully
covered run stays quiet — **17 cases**, up from 15.

## ★ And the named lines were worth having

`$clock ?? new SystemClock()` in `RateLimiter`, `ArrayRateLimitStore` and `FileRateLimitStore` — **the
path every production caller takes**, and the one no test reached, because every test injects a
`FrozenClock`.

No behaviour was wrong. What was missing was any assertion that the default wiring works at all — a
class that only ever ran under a test double, in three places. Three tests added, using real
wall-clock time with windows long enough (`PT1H`, a one-hour TTL) that no refill can arrive mid-test,
so nothing sleeps and nothing races the machine.

## Verification

- [x] `python tools/tests/verify_diff_coverage_gate.py` — **17/17** cases as specified, including the
      two new ones and the four that prove the gate fails
- [x] 97 rate-limit tests pass (+3); PHPStan max and PHP-CS-Fixer clean
- [x] `consistency_lint.py` and `action_pin_lint.py` clean; `ci.yml` parses, and the `coverage` job
      is back to three steps
- [ ] Builds cleanly on the full CI matrix

## Documentation Impact

- [x] ADR-0068's consequences now carry the measured table and record that the 95.43% reading changed
      the tool — replacing the forward-looking "will be measured" language
- [x] The temporary CI step is gone, with a comment in its place naming the run and the figures so
      the removal is not a silent deletion
- [x] CHANGELOG: the gate's `Added` bullet gains the naming-on-success behaviour and the measured
      figures; a `Fixed` bullet records the default-clock paths now being exercised
- [x] Journal entry gains a postscript
- [x] PR metadata: assignee (owner), one type label (`enhancement`), no milestone

## Lesson

**The gate's first output deserved reading as carefully as a test failure.** It passed, it was green,
and it still held two findings — a hole in the tool and a hole in the suite.

This session opened with BUG-0001 (a guard green on an empty set for ten items) and item 14.7 (two
tests green without ever reaching the branch they were named after). Three for three: green is not the
end of the sentence.
