### PR TITLE
ci(ci): take .gitignore'd targets out of the link check's scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,18 @@ PR. A release PR moves the `[Unreleased]` entries into a new per-version file un
 
 ### Fixed
 
+- **The `links` check no longer depends on files that exist in no clone.** It merged green and left
+  `master` red (run 32476537522): its six findings were `.eados-core/` factory-bundle paths that
+  `.gitignore` admits only under `learning/runs/`, so they are present on a maintainer's machine and
+  absent everywhere else — the same commit passed locally and failed in CI. A link whose target
+  `.gitignore` excludes is now **out of scope**, exactly as an external URL is, and the number
+  skipped is printed beside the number resolved rather than dropped silently (**ADR-0069** §3b,
+  annotated not rewritten).
+  **Keyed on ignore status, not on the file being missing** — keying on absence would have left the
+  host-dependence in place. Proved three ways rather than argued: a genuinely broken link still
+  fails; a broken link inside the *re-included* `learning/runs/` subtree still fails; and creating
+  one of the ignored files does not move the counts, where before its presence alone flipped `FAIL`
+  to `OK`. The status is asked of `git check-ignore` so the rule cannot drift from `.gitignore`.
 - **`README.md` no longer claims "sanitizers" in its quality bar.** The word named no CI job in this
   repository and collided with the library's own `Security\Sanitizer`, which is a feature rather
   than a check. Replaced with the gates that actually run: the 8.1/8.2/8.3 matrix, PHPStan at max,

--- a/docs/adr/0069-resolve-links-in-the-lint-and-refuse-to-guess-a-numbered-section.md
+++ b/docs/adr/0069-resolve-links-in-the-lint-and-refuse-to-guess-a-numbered-section.md
@@ -1,6 +1,13 @@
 # ADR-0069: Resolve links in the lint, and refuse to guess a numbered section
 
-- **Status:** Accepted
+- **Status:** Accepted — **scope amended** (2026-08-21, same day): a link whose target
+  `.gitignore` excludes is **out of scope**, for the same reason an external URL is. §3's list of
+  stated limits gains that line. **The check's substance is unchanged** — every tracked relative
+  link still resolves, anchors still find headings, and the numbered-`§` refusal stands.
+  The amendment exists because this check **merged green and left `master` red**: its six findings
+  were `.eados-core/` factory-bundle files that `.gitignore` admits only under `learning/runs/`,
+  so they are present on a maintainer's machine and in no clone. The verdict depended on the host.
+  Annotated rather than edited, per ADR-0041's precedent.
 - **Date:** 2026-08-21
 - **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
 - **Related:** ROADMAP item **13.4** · issues
@@ -68,6 +75,31 @@ So the limitation is printed on every run, beside the count of what *was* resolv
 `coverage_gate.py`'s pattern verbatim, and it is worth noting what that pattern produced: ADR-0007
 stated its own limitation in output, and eighteen ADRs later that sentence became issue #109 and got
 closed. **A stated gap is a filed issue waiting to happen; a silent one is not.**
+
+#### 3b. A `.gitignore`'d target is out of scope, and the count is printed too
+
+*(Amendment, 2026-08-21 — see Status.)* A link into a path `.gitignore` excludes is skipped, and the
+number skipped is printed beside the number resolved, in §3's own idiom. Here that is six references
+into the `.eados-core/` factory bundle, which `.gitignore` admits only under `learning/runs/`.
+
+**The rule is keyed on ignore status, not on the file being missing**, and that distinction is the
+whole amendment. Keying on absence would leave the defect in place: the bundle exists on a
+maintainer's machine and in no clone, so the same commit passed locally and failed in CI. Keying on
+ignore status makes the verdict identical on every host — proved by creating one of the ignored files
+and confirming the counts do not move, where before its mere presence flipped FAIL to OK.
+
+The status is asked of `git check-ignore` rather than pattern-matched in the lint, so the rule stays
+where the project already states it and cannot drift from `.gitignore`.
+
+**A note for whoever ports this**: it must be invoked `-z` and over bytes. Text mode translates the
+outgoing newline to `\r\n` on Windows, git receives every path with a trailing carriage return, and
+then C-quotes the reply — `'".eados-core/tools/autotune.py\r"'` — which matches nothing on the way
+back. The first implementation did exactly that and reported nothing ignored.
+
+**And the lesson §5's proof did not cover.** §5 proved this check could fail, which is the standing
+method — but it proved it on a machine holding files the check depends on and CI never sees. So:
+**a checker's first green run is not evidence it will stay green elsewhere.** Prove a new gate on a
+clean clone, or read its CI run, before treating a local green as the verdict.
 
 ### 4. The roll step is amended, and the checker is what enforces it
 

--- a/docs/journal/2026/08/2026-08-21-lint-eados-out-of-scope.md
+++ b/docs/journal/2026/08/2026-08-21-lint-eados-out-of-scope.md
@@ -1,0 +1,84 @@
+# 2026-08-21 — The link checker merged green and left master red
+
+A defect fix rather than a roadmap item, annotating **ADR-0069** (ROADMAP 13.4). Route
+`standard / medium`; session model Opus 5 — matched. Found while working item 13.2 in a worktree,
+which is what surfaced it.
+
+## The defect
+
+`consistency_lint.py`'s new `links` check fails on `master` — run 32476537522, six
+`link target does not exist` findings, all under `.eados-core/`. PR #146 added that check, proved it
+could fail, ran it locally, and merged green.
+
+Both things are true because `.gitignore:82-85` excludes `/.eados-core/*` and re-includes only
+`learning/runs/`. The `.eados-core/` bundle is the EADOS factory tooling, copied in to regenerate
+this repository and deliberately never committed. So the six targets exist on a maintainer's machine
+and in no clone: the check passes for anyone holding the bundle and fails in CI for everyone.
+
+**The verdict depended on the host.** That is the defect — not the six links.
+
+I found it because item 13.2 was done in a `git worktree`, which is a clean checkout of tracked
+files only. Working in the main checkout would have shown green, and I would have pushed and let CI
+tell me. Isolation bought a diagnosis instead of a red build.
+
+## The fix, and the one distinction that matters
+
+A link whose target `.gitignore` excludes is out of scope, for the same reason an external URL is:
+absent from every clone by design, so unresolvable rather than broken. The count of skipped
+references is printed beside the count resolved — §3's own idiom, and ADR-0007's before it.
+
+**Keyed on ignore status, not on the file being missing.** This is the whole fix. "Skip links whose
+target is absent" would have turned master green while leaving the host-dependence exactly where it
+was — and would have gutted the check, since a missing target *is* the thing it looks for. Keying on
+ignore status makes the verdict identical everywhere.
+
+The status is asked of `git check-ignore` rather than pattern-matched in the lint, so the rule lives
+where the project already states it and cannot drift from `.gitignore` as either file is edited.
+
+## Proved three ways, because turning a red check green is the suspicious direction
+
+A change that silences findings has to demonstrate it did not silence *everything*:
+
+1. a genuinely broken link (`docs/adr/9999-this-does-not-exist.md`) — still **FAIL**;
+2. a broken link inside `.eados-core/learning/runs/`, the subtree `.gitignore` **re-includes** —
+   still **FAIL**. So the exclusion follows the ignore rule's real boundary, not "anything under
+   `.eados-core/`";
+3. **the host-independence proof**: create `.eados-core/tools/autotune.py`, one of the six ignored
+   targets, and re-run. Counts identical — 711 resolved, 6 skipped. Before this fix, that file's
+   mere presence flipped the verdict from `FAIL` to `OK`. That is the defect, demonstrated
+   disappearing.
+
+Each plant was reverted and verified by **absence of the original**, not by presence of the
+replacement — item 11.2's rule, since a check for the replacement can pass on text that was already
+there.
+
+Arithmetic checks out too: 717 resolved before, 711 + 6 skipped after.
+
+## The Windows trap, worth carrying
+
+The first implementation reported **nothing** ignored, and the reason is not obvious. It piped
+newline-separated paths to `git check-ignore --stdin` in text mode. On Windows, text mode translates
+the outgoing `\n` to `\r\n`, so git receives every path with a trailing carriage return — and then
+C-quotes the reply, because a name containing `\r` is unusual:
+
+```
+'".eados-core/tools/autotune.py\r"'
+```
+
+It matched the ignore rule and came back unrecognisable. Two bugs, one symptom, both invisible
+without printing the raw set. Fixed with `-z` over bytes, which removes the delimiter translation
+and the quoting together.
+
+## The lesson ADR-0069 §5's proof did not cover
+
+§5 shipped a proof that the check could fail. That is this project's standing method and it is the
+right one. It still missed this, because the proof ran on a machine holding files the check depends
+on and CI never sees.
+
+**A checker's first green run is not evidence it will stay green elsewhere.** Prove a new gate on a
+clean clone — or read its CI run — before treating a local green as the verdict. This is the same
+family as items 10.10/10.11 (a figure inherits the machine it was taken on) and 12.3 (a PHP 8.1
+constraint probed on 8.3), now for a *pass/fail verdict* rather than a number or a language rule.
+
+Filed by the same reasoning: nothing in CI runs a documentation example either, which is item 13.3's
+whole argument. Different check, identical gap.

--- a/tools/consistency_lint.py
+++ b/tools/consistency_lint.py
@@ -85,6 +85,41 @@ def git(*args):
         return None
 
 
+def gitignored(paths):
+    """The subset of `paths` (repo-relative, POSIX separators) that `.gitignore` excludes.
+
+    Asked of git rather than pattern-matched here on purpose: the rule then lives wherever the
+    project already states it, and cannot drift from `.gitignore` as this file is edited.
+
+    One batched call — `check-ignore` is invoked once for every link in the tree, and per-path
+    subprocesses would dominate the lint's runtime.
+    """
+    if not paths:
+        return set()
+    # NUL-delimited in BOTH directions, and bytes rather than text, for two reasons that each
+    # broke this on Windows: text mode translates the outgoing "\n" to "\r\n", so git receives
+    # every path with a trailing carriage return; and git then C-quotes any name it considers
+    # unusual, so the reply comes back as '".eados-core/tools/autotune.py\r"' and matches nothing
+    # on the way home. `-z` removes the delimiter ambiguity and the quoting together.
+    try:
+        out = subprocess.run(
+            ["git", "-C", ROOT, "check-ignore", "-z", "--stdin"],
+            input=b"\0".join(p.encode("utf-8") for p in sorted(paths)),
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        return set()
+    # 0 = at least one path is ignored, 1 = none are. Anything else is a real git failure, and
+    # returning empty then is the safe direction: every link stays IN scope and gets checked.
+    if out.returncode not in (0, 1):
+        return set()
+    return {
+        chunk.decode("utf-8", "replace").replace(os.sep, "/")
+        for chunk in out.stdout.split(b"\0")
+        if chunk
+    }
+
+
 def semver_tuple(text):
     m = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
     return tuple(int(g) for g in m.groups()) if m else None
@@ -466,6 +501,30 @@ def check_links():
         except OSError as exc:
             fail(name, f"{rel}: cannot be read ({exc})")
 
+    # A link whose target `.gitignore` excludes is OUT OF SCOPE, for the same reason an external
+    # URL is: the file is deliberately absent from every clone, so the reference is unresolvable
+    # by design rather than broken by accident. Here that is the `.eados-core/` factory bundle,
+    # which `.gitignore` admits only under `learning/runs/`.
+    #
+    # The exclusion is by ignore status and NOT by "the file happens to be missing", because the
+    # whole defect this fixes was a verdict that depended on the host: the bundle is present on a
+    # maintainer's machine and in no clone, so the check passed locally and failed in CI on the
+    # same commit. Keying on ignore status makes the verdict identical everywhere.
+    candidates = set()
+    for rel, raw in bodies.items():
+        base = os.path.dirname(rel)
+        for match in _MD_LINK.finditer(_without_fenced_blocks(raw)):
+            target = match.group(1)
+            if target.startswith(("http://", "https://", "mailto:", "tel:")):
+                continue
+            path = target.partition("#")[0]
+            if not path:
+                continue
+            absolute = os.path.normpath(os.path.join(ROOT, base, path))
+            candidates.add(os.path.relpath(absolute, ROOT).replace(os.sep, "/"))
+    ignored = gitignored(candidates)
+    out_of_scope = 0
+
     resolved = 0
 
     for rel, raw in bodies.items():
@@ -479,16 +538,20 @@ def check_links():
 
             line = body[: match.start()].count("\n") + 1
             path, _, anchor = target.partition("#")
-            resolved += 1
 
             if path:
                 absolute = os.path.normpath(os.path.join(ROOT, base, path))
+                pointee = os.path.relpath(absolute, ROOT).replace(os.sep, "/")
+                if pointee in ignored:
+                    out_of_scope += 1
+                    continue
+                resolved += 1
                 if not os.path.exists(absolute):
                     fail(name, f"{rel}:{line}: link target does not exist — {target}")
                     continue
-                pointee = os.path.relpath(absolute, ROOT).replace(os.sep, "/")
             else:
                 pointee = rel  # a same-file "#anchor"
+                resolved += 1
 
             if not anchor:
                 continue
@@ -535,6 +598,9 @@ def check_links():
           "Markdown file(s).")
     print("          NOT resolved: external URLs, and bare or numeric § references "
           "(`§2`) — see ADR-0069.")
+    if out_of_scope:
+        print(f"          {out_of_scope} reference(s) skipped as .gitignore'd targets — absent "
+              "from every clone by design, so unresolvable rather than broken.")
 
 
 CHECKS = [


### PR DESCRIPTION
## Summary

**`master` is red.** The `links` check added in #146 fails on it — run
[32476537522](https://github.com/danielPoloWork/egl-util-php/actions/runs/32476537522), six
`link target does not exist` findings, all under `.eados-core/`. Every open PR inherits the failure.

It merged green because [`.gitignore:82-85`](.gitignore) excludes `/.eados-core/*` and re-includes
only `learning/runs/`. The factory bundle is present on a maintainer's machine and **in no clone**,
so the same commit passes locally and fails in CI.

**The verdict depended on the host.** That is the defect, not the six links.

## Motivation

ROADMAP item **13.4** / **ADR-0069** §3b. Found while item 13.2 (#118, PR #147) was being done in a
`git worktree` — a clean checkout of tracked files only. The main checkout shows green, so this would
otherwise have been discovered by pushing and reading a red build.

## The fix, and the one distinction that matters

A link whose target `.gitignore` excludes is now **out of scope**, for the same reason an external URL
is: absent from every clone by design, so unresolvable rather than broken. The number skipped is
**printed beside the number resolved** rather than dropped silently — §3's own idiom, and ADR-0007's
before it.

```
  [links] 711 relative reference(s) resolved across 208 tracked Markdown file(s).
          NOT resolved: external URLs, and bare or numeric § references (`§2`) — see ADR-0069.
          6 reference(s) skipped as .gitignore'd targets — absent from every clone by design,
          so unresolvable rather than broken.
Consistency lint: OK — all congruence invariants hold.
```

**Keyed on ignore status, not on the file being missing.** This is the whole fix. *"Skip links whose
target is absent"* would have turned master green while leaving the host-dependence exactly where it
was — and would have gutted the check, since a missing target **is** the thing it looks for.

The status is asked of `git check-ignore` rather than pattern-matched in the lint, so the rule lives
where the project already states it and cannot drift from `.gitignore` as either file is edited.

## Proved three ways, because turning a red check green is the suspicious direction

A change that silences findings has to show it did not silence everything:

| Plant | Verdict |
|---|---|
| a genuinely broken link (`docs/adr/9999-this-does-not-exist.md`) | **FAIL** ✅ |
| a broken link *inside* `.eados-core/learning/runs/` — the subtree `.gitignore` **re-includes** | **FAIL** ✅ |
| creating `.eados-core/tools/autotune.py`, one of the six ignored targets | counts **unmoved** (711 + 6) ✅ |

The third is the one that matters: before this fix, that file's *mere presence* flipped the verdict
from `FAIL` to `OK`. Here is the defect, demonstrated disappearing.

Each plant was reverted and verified by **absence of the original**, not presence of the replacement
(item 11.2's rule — a check for the replacement can pass on text that was already there).

Arithmetic holds: **717** resolved before, **711 + 6 skipped** after.

## One implementation note worth keeping

The first version reported **nothing** ignored. It piped newline-separated paths to
`git check-ignore --stdin` in text mode; on Windows that translates the outgoing `\n` to `\r\n`, so
git received every path with a trailing carriage return — and then C-quoted the reply, because a name
containing `\r` is unusual:

```
'".eados-core/tools/autotune.py\r"'
```

It matched the ignore rule and came back unrecognisable. Two bugs, one symptom, neither visible
without printing the raw set. Fixed with `-z` over bytes, which removes the delimiter translation and
the quoting together. The comment in the source says so, for whoever ports this.

## Design Patterns

None — a scope correction to an existing check.

## Verification

- [x] `python tools/consistency_lint.py` — **OK**, all nine checks, on a clean worktree
- [x] The check proved still failable, three ways (table above), each plant reverted and verified by
      absence of the original
- [x] Host-independence proved directly, not argued
- [ ] Builds cleanly on the full CI matrix (Linux (PHP 8.1, 8.2, 8.3)) — **this is the PR that makes
      `consistency / lint` green again**; please read that job's log rather than its colour
- n/a Unit tests / CS-Fixer / PHPStan / coverage / benchmarks — no PHP source or test changes

## Documentation Impact

- [x] **ADR-0069** — Status annotation plus a new §3b; annotated not rewritten (ADR-0041's
      precedent), and nothing it decided changes
- [x] CHANGELOG `[Unreleased]` → `Fixed`
- [x] Journal entry added
- [ ] ROADMAP — no checkbox moves; 13.4 is already closed and this is a defect fix against it
- [ ] README / spec / patterns catalogue — not affected
- [x] PR metadata: assignee (owner), one type label, no milestone (precedent: items 10.9, 10.10, 12.6
      — CI-tooling fixes skip both milestone and the Spec Coverage Map)

## Lesson

ADR-0069 §5 shipped a proof that its check could fail — this project's standing method, and the right
one. It still missed this, because the proof ran on a machine holding files the check depends on and
CI never sees.

**A checker's first green run is not evidence it will stay green elsewhere.** Prove a new gate on a
clean clone, or read its CI run, before treating a local green as the verdict. Same family as items
10.10/10.11 (a figure inherits the machine it was taken on) and 12.3 (a PHP 8.1 constraint probed on
8.3) — now for a pass/fail verdict rather than a number or a language rule.

## Note on ordering

This is a second open PR alongside #147, which the one-PR-at-a-time rule normally forbids — done at
the maintainer's explicit direction, because #147 (and everything else) stays red until this lands.
**Merge this first**; #147's `consistency / lint` should then go green on a re-run without any change
to it.
