### PR TITLE
docs(docs): track ROADMAP 13.3 as issue #149, the one M13 item without one

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -20,6 +20,7 @@ replacing it.
 
 ## Issues (newest → oldest)
 
+- [ ] [#149](https://github.com/danielPoloWork/egl-util-php/issues/149) **docs: fix endpoint-kernel.md's flagship example and sweep the doc examples nothing has ever run** — ROADMAP 13.3, which never had an issue while its five siblings all did; `new Response()` hits a private constructor, `setHeader()` does not exist, and the static `json()` called through an instance silently drops the `Allow` header RFC 9110 makes mandatory — route: standard / medium
 - [x] [#122](https://github.com/danielPoloWork/egl-util-php/issues/122) **release: settle the v1.0.0 tag provenance and correct the gate-approved claim** — The flagship release notes assert the opposite of the repository's own audit trail — route: standard / medium
 - [x] [#121](https://github.com/danielPoloWork/egl-util-php/issues/121) **build: register egl/utils on Packagist and verify the tag resolves** — registered + resolution verified 2026-08-10; the `egl/` vendor is squat-protected by that same registration, so the bridge name needs no split repo to defend — route: fast / low
 - [ ] [#120](https://github.com/danielPoloWork/egl-util-php/issues/120) **release: complete the utils-psr7-bridge publication (split repo, Packagist, first bridge tag)** — The library's entire interop story is implemented and contract-tested but not installable — route: standard / medium

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1694,6 +1694,15 @@ the release process around it.
       discarding the `Allow` header the example built two lines earlier. Verified against
       `src/main/php/d4np/utils/Http/Response.php` at 1.0.0. Then sweep the remaining doc examples
       for the same rot, since nothing has ever executed them — size: S · route: standard / medium
+      *(now tracked as [issue #149](https://github.com/danielPoloWork/egl-util-php/issues/149) —
+      this item had been the only M13 entry without one. All three findings above **re-verified**
+      against `9ee5ba6` rather than trusted from the 2026-08-09 filing, and the issue adds a fourth
+      the filing missed: `Response` is **immutable**, so `withHeader()` returns a new instance and
+      the example's build-then-poke shape does not fit the class at all — a restructure, not three
+      token substitutions. The sweep is bounded there too: of 26 ` ```php ` blocks in 18 tracked
+      files, 4 are `README.md`'s (proven to run under 13.2) and **11 live in `docs/journal/`, which
+      are dated records — an example there describes the API as it was, and rewriting it would
+      falsify history**. That leaves 11 live blocks in 8 files.)*
 - [x] 13.4 Make documentation cross-references checkable. Item 7.5's load-bearing defect was
       `SECURITY.md` deferring a definition to `maintenance.md`, to a section that did not exist —
       invisible for the entire pre-1.0 line, because the clause above the pointer still applied.


### PR DESCRIPTION
## Summary

Opens [issue #149](https://github.com/danielPoloWork/egl-util-php/issues/149) for ROADMAP item
**13.3** and records it in the two indexes. 13.1, 13.2, 13.4, 13.6 and 13.8 all had GitHub issues;
13.3 lived only in `ROADMAP.md`, which is a good part of why it stayed still while everything around
it moved.

This PR is the index half only — `ISSUES.md` gains its row per the file's own prepend rule, and 13.3
gains the cross-reference. **The example itself is not fixed here**; that is #149's own work.

## Why now

Item 13.2 (#118, PR #147) had to route consumers *around* this page: the new on-ramp deliberately
does not link `docs/patterns/endpoint-kernel.md`, and `README.md` currently says in as many words
that the pattern pages explain *why* rather than supplying copyable code. That sentence should stop
being true, and an untracked roadmap line was not going to make it stop.

## What the issue establishes

**All three of 13.3's findings re-verified against `9ee5ba6`** rather than copied from the 2026-08-09
filing — the same discipline #122 was about:

| Finding | Confirmed at |
|---|---|
| `new Response()` hits a **private** constructor — fatal `Error`, so nothing below it has ever been exercised | `Response.php:32` |
| `setHeader()` does not exist; the API is `withHeader()` | `Response.php:143` |
| `json()` is `public static`, so calling it through an instance builds a **fresh** `Response` and silently discards the `Allow` header set two lines earlier | `Response.php:82` |

That third one is the worst of the three, and the filing undersold it: it does not crash. On the 405
path it drops a header **RFC 9110 §15.5.6 makes mandatory** — the exact thing
`MethodNotAllowedException::allowHeader()` exists to supply.

**And a fourth the filing missed:** `Response` is **immutable**. `withHeader()` returns a new
instance, so even with findings 2 and 3 corrected, a bare `$response->withHeader('Allow', …);`
statement throws the result away. The example's shape — build one mutable response, poke at it inside
`catch` blocks, serialise at the end — does not fit this class at all. **That is a restructure, not
three token substitutions**, and it is the difference between a fix that works and a fix that
compiles.

Also verified as **still correct**, so the fix need not disturb them: `Request::fromGlobals()`,
`Router::matchRequest()`, `MatchedRoute::$handler`, `MatchedRoute::$parameters`,
`MethodNotAllowedException::allowHeader()`.

## The sweep is bounded, and part of it is off-limits

13.3's second half reads *"sweep the remaining doc examples for the same rot"*, which sounds
open-ended. Counted: **26 ` ```php ` blocks across 18 tracked Markdown files**.

- **4** in `README.md` — proven to run under 13.2. Out of scope.
- **11** in `docs/journal/` — **out of scope on principle.** A journal entry is a dated record; its
  example describes the API *as it was on that date*. "Repairing" one would falsify a historical
  record rather than fix rot. Stated in the issue so nobody sweeps them by accident.
- **11** live blocks in 8 files — the actual work.

## Design Patterns

None — issue tracking.

## Verification

- [x] Every claim in the issue read out of the current source, with file and line, not carried over
      from the filing
- [x] `python tools/consistency_lint.py` — OK (726 resolved, 6 skipped, all nine checks)
- [x] Block counts measured, not estimated
- [ ] Builds cleanly on the full CI matrix (Linux (PHP 8.1, 8.2, 8.3))
- n/a Unit tests / CS-Fixer / PHPStan / coverage / benchmarks — no source or test changes

## Documentation Impact

- [x] `ISSUES.md` — one row prepended, per its own stated rule
- [x] `ROADMAP.md` 13.3 — cross-reference plus the fourth finding and the sweep's real boundary;
      **checkbox not flipped**, the item is not done
- [ ] **CHANGELOG — deliberately none.** This documents no user-visible change to the library, only
      the tracker's index. Flagging the judgement rather than leaving it as a silent omission.
- [ ] ADR — none; no decision made
- [x] PR metadata: assignee (owner), one type label (`documentation`), no milestone (matching #83,
      #123, #146, #147 — no M13 milestone exists)

## Lesson

Five of six M13 items were tracked in two places and one in a single place, and that one is the one
that rotted quietly through a 1.0 release. **An index that is almost complete hides its gap better
than no index would** — nothing looked missing, because nothing was looking.
