### PR TITLE
fix(ci): stop the BC gate failing every release by construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,11 @@ jobs:
       # tool's refusal would read as a broken release rather than as prose that needs fixing.
       - name: Verify the Release-body renderer can fail
         run: python tools/tests/verify_release_body.py
+      # And the BC gate's discount (ADR-0031, amended). It runs here rather than only in the
+      # backward-compatibility job because that job is release-PR-only: the discount's narrowness
+      # is exactly what must not rot between releases, and this is where it gets checked.
+      - name: Verify the BC gate's version-constant discount is narrow
+        run: python tools/tests/verify_bc_gate.py
       # ADR-0003's gate. Runs WITH --verify-upstream: the offline half only checks the pin
       # shape, and a version comment that lies is invisible to any purely local check when the
       # error is applied uniformly. CI is where the truthful half must run.
@@ -542,10 +547,15 @@ jobs:
         if: steps.scope.outputs.release_pr == 'true' && steps.scope.outputs.previous != ''
         shell: bash
         run: |
+          # --report is what lets the gate tell the version bump apart from a real break.
+          # Roave reports Version::VERSION changing value as a BC break, and a release PR
+          # changes exactly that constant, so without this the gate fails EVERY release by
+          # construction. Nothing else is discounted (ADR-0031, amended).
           python3 tools/bc_gate.py \
             --previous "${{ steps.scope.outputs.previous }}" \
             --current "${{ steps.scope.outputs.current }}" \
-            --bc-exit "${{ steps.bc.outputs.code }}"
+            --bc-exit "${{ steps.bc.outputs.code }}" \
+            --report bc-report.md
 
       - name: Keep the BC report
         if: always() && steps.scope.outputs.release_pr == 'true' && steps.scope.outputs.previous != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,17 @@ the GitHub Release body. Editing "the release notes" almost always means that on
 
 ### Fixed
 
+- **The backward-compatibility gate no longer fails every release by construction.**
+  `Version::VERSION` is a public constant, so `roave/backward-compatibility-check` reports its
+  value changing as a BC break — and a release PR changes exactly that constant. `bc_gate.py` now
+  reads the checker's report (`--report`) and discounts that **one** finding, printing what it
+  discounted on every run. **Nothing else is discounted**: any other `[BC]` line still fails on
+  ADR-0031's unchanged rules, and `tools/tests/verify_bc_gate.py` (14 cases) pins the one that
+  matters — the version line *alongside* a real break still fails.
+  Found the first time the job ever really ran, on the `v1.1.0` release PR. It self-skips when no
+  tag exists to compare against, so before `v1.0.0` it reported green having compared nothing —
+  the same shape as items 2.7, 10.8, 13.2 and 13.7. **Fifth instance.**
+
 - **Eight generic docblock annotations no longer break the API-docs build.** `@return self<U>` in
   `Errors/Result.php` (five) and `@return self<TItem>` in `Dto/Collection.php` (three) use PHPStan's
   generic `self<T>` form, which phpDocumentor's type parser rejects — *"self is not a collection"* —

--- a/docs/adr/0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md
+++ b/docs/adr/0031-run-the-bc-checker-outside-the-dependency-graph-and-gate-breaks-by-bump.md
@@ -1,6 +1,18 @@
 # ADR-0031: Run the BC checker outside this package's dependency graph, and gate breaks by the bump they arrive in
 
-- **Status:** Accepted
+- **Status:** Accepted — **one narrow discount added** (2026-08-21, the `v1.1.0` release PR): the
+  gate discounts a single finding, `Value of constant D4np\Utils\Version::VERSION changed`, and
+  nothing else. **The decision below is unchanged** — breaks are still gated by the bump they
+  arrive in, and any other `[BC]` line still fails on the same rules.
+  Why it was needed: `Version::VERSION` is a public constant, so Roave reports its value changing
+  as a break — and a release PR changes exactly that constant. **The gate therefore failed every
+  release PR by construction**, and nobody knew, because the job self-skips when no tag exists to
+  compare against: before `v1.0.0` it reported green having compared nothing. The `v1.1.0` PR was
+  the first time it ever really ran, and that one line was its only finding.
+  The discount is keyed on that exact symbol rather than on "constant value changes are fine", it
+  is printed on every run that uses it, and `tools/tests/verify_bc_gate.py` pins the case that
+  matters: the version line **alongside** a real break still fails. Annotated rather than edited,
+  per ADR-0041's precedent.
 - **Date:** 2026-08-05
 - **Deciders:** maintainer (`@danielPoloWork`), agent acting as tech-lead
 - **Related:** ROADMAP item 7.2 · spec **NFR-07**, NFR-08 (dependency policy) · imported spec §8

--- a/docs/journal/2026/08/2026-08-21-bc-gate-version-constant.md
+++ b/docs/journal/2026/08/2026-08-21-bc-gate-version-constant.md
@@ -1,0 +1,92 @@
+# 2026-08-21 — The gate that would have failed every release, forever
+
+A defect fix, annotating **ADR-0031**. Route `standard / medium`; session model Opus 5 — matched.
+Found by the `v1.1.0` release PR (#156), which is still open and blocked on this.
+
+## What happened
+
+The release PR went red on `quality / backward compatibility` in 22 seconds. The checker's sole
+finding:
+
+```
+- [BC] Value of constant D4np\Utils\Version::VERSION changed from '1.0.0' to '1.1.0'
+The checker exited 3 (0 means no backward-incompatible change).
+bc gate: FAIL — backward-incompatible changes in a MINOR bump after 1.0.
+```
+
+That is the version bump. `Version::VERSION` is a public constant, Roave reports a public
+constant's value changing as a break, and **a release PR changes exactly that constant by
+definition**. The gate could never have passed a post-1.0 MINOR or PATCH release. Not "was likely
+to fail" — *could not pass*.
+
+## Why nobody knew
+
+The job self-skips when there is no tag to compare against. Before `v1.0.0` existed it emitted:
+
+```
+##[notice]This repository has no v*.*.* tag, and roave/backward-compatibility-check needs one
+to compare against. The gate self-enables at the first tag.
+```
+
+…and reported green. It also only runs on release PRs, and there had been exactly one — `v1.0.0`,
+whose comparison target had just been deleted. So this was the **first time the job ever actually
+executed**, and its first real act was to refuse the release it exists to protect.
+
+I had written this exact warning into memory after item 10.8: *never cite that check as evidence
+until a tag exists*. The warning was right and still insufficient — knowing a check has not run
+tells you nothing about what it will say when it does.
+
+**Fifth instance of the vacuous-green class on this project**: item 2.7 (a gate wired to nothing),
+10.8 (a mutation gate passing in ~7s on an absent config), 13.2 (a harness printing a PHP block as
+text), 13.7 (phpDocumentor exiting 0 with five ERROR rows), and now this one — a gate that reported
+green because it had nothing to compare, hiding that it would refuse everything once it did.
+
+## The fix, and the line I did not cross
+
+`bc_gate.py` gains `--report` and discounts **one** finding: that exact symbol, anchored to its
+class. Not "constant value changes are fine" — a consumer reading a version string does not break
+when the string changes, but a consumer reading any *other* constant might.
+
+Two properties matter more than the discount itself:
+
+- **It is printed on every run that uses it.** A discount nobody sees is a discount nobody can
+  audit.
+- **It does not swallow company.** The version line *alongside* a real break still fails, and that
+  is the case `tools/tests/verify_bc_gate.py` exists to pin. Fourteen cases; that one is the reason
+  for all the others.
+
+Without `--report` the tool behaves exactly as before, so the change is additive to its contract as
+well as to its behaviour.
+
+## My own test found a robustness hole
+
+Reproducing the CI failure locally, the gate **refused** — `contains no [BC] line this gate
+recognises` — and it was right to. PowerShell 5.1's `Out-File -Encoding utf8` writes a **BOM**,
+which sits in front of `- [BC]` and defeats the line anchor. CI's `tee` writes no BOM, so this
+would never have appeared there.
+
+Reading with `utf-8-sig` instead of `utf-8` costs one word and removes a failure mode that reads as
+*"the report format changed"* when nothing changed. Worth noting that the gate's wrong answer here
+was still the **safe** answer: it refused rather than passed. That is the direction to be wrong in,
+and it is why the refusal branch was written before it was ever needed.
+
+## The other red, which was not this
+
+`quality / infection mutation score` also failed, in 23 seconds. Different diagnosis entirely:
+
+```
+[ERROR] Project tests must be in a passing state before running Infection.
+Failed asserting that 'Request to "http://127.0.0.1:38221/?mode=drip&run=…" produced no response
+```
+
+That is T-07's wall-clock-deadline test against a dripping local origin — a network-timing test,
+and a **flake**. The evidence is not the duration: all three `build` cells (8.1, 8.2, 8.3) ran the
+same suite on the same commit and passed. Two reds on one PR, one real and one noise, and the only
+way to tell was to read both jobs rather than count the failures.
+
+## Sequenced, not folded in
+
+This is a separate PR rather than a commit on the release branch, following the maintainer's own
+earlier call in this session when a broken gate blocked other work. The release PR stays a release:
+bump, roll, notes. This stays a gate fix, with its own proof and ADR annotation. Merge order is
+this one, then rebase #156.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -19,6 +19,7 @@ _(newest first)_
 
 #### August
 
+- [2026-08-21 - The gate that would have failed every release, forever](2026/08/2026-08-21-bc-gate-version-constant.md)
 - [2026-08-21 — The tool said "All done", exited 0, and had five errors](2026/08/2026-08-21-api-docs-gate.md)
 - [2026-08-21 — Two documents, not two copies](2026/08/2026-08-21-one-home-for-release-notes.md)
 - [2026-08-21 — What Packagist ships, measured rather than sampled](2026/08/2026-08-21-dist-hygiene-export-ignore.md)

--- a/tools/bc_gate.py
+++ b/tools/bc_gate.py
@@ -38,6 +38,22 @@ import sys
 
 SEMVER = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
 
+# Every finding line the checker emits, in its markdown format.
+BREAK_LINE = re.compile(r"^\s*-\s*\[BC\]\s*(?P<detail>.+?)\s*$", re.M)
+
+# The ONE finding a release cannot avoid producing. `Version::VERSION` is a public constant, so
+# Roave reports its value changing as a break — and a release PR changes it by definition, which
+# means the gate failed every release PR by construction. Discovered the first time the job ever
+# actually ran: before v1.0.0 existed there was no tag to compare against, so it self-skipped and
+# reported green having compared nothing.
+#
+# Deliberately keyed on this exact symbol, not on "constant value changes are fine". A consumer
+# reading a version string does not break when the string changes; a consumer reading any OTHER
+# constant might. Anchored to the class so a same-named constant elsewhere is still a break.
+VERSION_CONSTANT = re.compile(
+    r"^Value of constant D4np\\Utils\\Version::VERSION changed from ", re.I
+)
+
 
 class GateError(Exception):
     """A condition that must fail the gate rather than be reported as a verdict."""
@@ -80,6 +96,12 @@ def main(argv=None):
         required=True,
         help="exit code from roave/backward-compatibility-check: 0 means no breaks",
     )
+    ap.add_argument(
+        "--report",
+        help="the checker's markdown report. When given, the version-constant line every release "
+             "necessarily produces is discounted — see DISCOUNTED below. Without it the gate "
+             "behaves exactly as before.",
+    )
     args = ap.parse_args(argv)
 
     try:
@@ -104,11 +126,50 @@ def main(argv=None):
 
     breaks = bc_exit != 0
     pre_one_zero = previous[0] == 0
+    discounted = 0
+
+    if breaks and args.report:
+        try:
+            # utf-8-sig, not utf-8: a BOM would sit in front of the first `- [BC]` and defeat the
+            # line anchor, which reads as "the format changed" when it has not. CI's `tee` writes
+            # no BOM, but a report produced on Windows does, and the gate refusing for that reason
+            # would be a confusing false alarm.
+            with open(args.report, encoding="utf-8-sig", errors="replace") as handle:
+                findings = [m.group("detail") for m in BREAK_LINE.finditer(handle.read())]
+        except OSError as exc:
+            # Absence is failure, as everywhere else here: a report we cannot read is not a
+            # report saying there is nothing to see.
+            print(f"bc gate: FAIL\n\n  cannot read --report {args.report}: {exc}")
+            return 1
+
+        if not findings:
+            print(
+                f"bc gate: FAIL\n\n  the checker exited {bc_exit} (breaks found) but "
+                f"{args.report} contains no `- [BC]` line this gate recognises. Read the report, "
+                "then fix this parser — do not relax the check."
+            )
+            return 1
+
+        remaining = [f for f in findings if not VERSION_CONSTANT.match(f)]
+        discounted = len(findings) - len(remaining)
+        breaks = bool(remaining)
 
     print(
         f"bc gate: {'.'.join(map(str, previous))} -> {'.'.join(map(str, current))} "
         f"({level.upper()} bump), breaks detected: {'yes' if breaks else 'no'}"
     )
+
+    if discounted:
+        # Printed on every run that uses it. A discount nobody sees is a discount nobody can
+        # audit, and this one is narrow enough to be worth reading each time.
+        print(
+            f"\n  DISCOUNTED {discounted} finding(s): the value of "
+            "`D4np\\Utils\\Version::VERSION` changed.\n"
+            "  Roave reports a public constant's value changing as a break, and a release PR\n"
+            "  changes exactly that constant — so this one finding is what a release IS, not\n"
+            "  something a release does to a consumer. Nothing else is discounted: any other\n"
+            "  `[BC]` line still fails this gate on the same rules as before."
+        )
 
     if not breaks:
         print("\nbc gate: OK — no backward-incompatible change since the previous release.")

--- a/tools/tests/verify_bc_gate.py
+++ b/tools/tests/verify_bc_gate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Daniel Polo
+"""Prove `bc_gate.py`'s version-constant discount is narrow (ADR-0031, amended).
+
+The gate failed **every release PR by construction**, and nobody knew, because the job that runs
+it self-skips when no tag exists to compare against — so before `v1.0.0` it reported green having
+compared nothing, exactly the shape items 2.7, 10.8, 13.2 and 13.7 took. The first time it ever
+really ran, on the `v1.1.0` release PR, its sole finding was:
+
+    - [BC] Value of constant D4np\\Utils\\Version::VERSION changed from '1.0.0' to '1.1.0'
+
+That is the version bump. Discounting it is correct; discounting anything *else* would gut the
+only gate standing between a MINOR and a silent break, so the two cases that matter here are the
+third and fourth: the version line **alongside** a real break still fails, and a real break alone
+still fails.
+
+    python tools/tests/verify_bc_gate.py
+
+Exits 0 when every case behaves as specified, 1 otherwise.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(os.path.dirname(HERE), "bc_gate.py")
+
+VERSION_ONLY = (
+    "# Backward compatibility check\n\n"
+    "- [BC] Value of constant D4np\\Utils\\Version::VERSION changed from '1.0.0' to '1.1.0'\n"
+)
+REAL_BREAK = (
+    "- [BC] Method D4np\\Utils\\Errors\\Result#orElseThrow() was removed\n"
+)
+UNRECOGNISED = "the checker said something this gate has never seen\n"
+
+failures = []
+
+
+def check(name, condition, detail=""):
+    if condition:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name}{(' — ' + detail) if detail else ''}")
+        failures.append(name)
+
+
+def run(previous, current, bc_exit, report=None):
+    args = [sys.executable, GATE, "--previous", previous, "--current", current,
+            "--bc-exit", str(bc_exit)]
+    path = None
+    if report is not None:
+        fd, path = tempfile.mkstemp(suffix=".md")
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(report)
+        args += ["--report", path]
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, encoding="utf-8")
+        return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+    finally:
+        if path:
+            os.unlink(path)
+
+
+print("verify_bc_gate.py")
+
+# 1. The case that was failing every release: a post-1.0 MINOR whose only finding is the bump.
+code, out = run("1.0.0", "1.1.0", 3, VERSION_ONLY)
+check("a post-1.0 MINOR whose only break is Version::VERSION passes", code == 0, f"exit {code}")
+check("...and says so, rather than discounting silently", "DISCOUNTED 1 finding" in out,
+      out.strip()[:160])
+
+# 2. Unchanged behaviour without --report: the old contract still holds.
+code, out = run("1.0.0", "1.1.0", 3)
+check("without --report a post-1.0 MINOR with breaks still FAILS", code == 1, f"exit {code}")
+
+# 3. ★ THE ONE THAT MATTERS: the version line alongside a real break must still fail.
+code, out = run("1.0.0", "1.1.0", 3, VERSION_ONLY + REAL_BREAK)
+check("the version line ALONGSIDE a real break still FAILS", code == 1, f"exit {code}")
+check("...and still reports the discount, so the real break is not hidden by it",
+      "DISCOUNTED 1 finding" in out, out.strip()[:160])
+
+# 4. A real break on its own, post-1.0 MINOR.
+code, out = run("1.0.0", "1.1.0", 3, REAL_BREAK)
+check("a real break alone still FAILS a post-1.0 MINOR", code == 1, f"exit {code}")
+check("...with no discount claimed", "DISCOUNTED" not in out, out.strip()[:160])
+
+# 5. A PATCH may never break, version constant or not — a PATCH bump changes it too.
+code, out = run("1.0.0", "1.0.1", 3, VERSION_ONLY)
+check("a PATCH whose only break is the version constant passes", code == 0, f"exit {code}")
+code, out = run("1.0.0", "1.0.1", 3, VERSION_ONLY + REAL_BREAK)
+check("a PATCH with a real break still FAILS", code == 1, f"exit {code}")
+
+# 6. Pre-1.0 is unaffected: SemVer §4 already permitted these.
+code, out = run("0.7.0", "0.8.0", 3, REAL_BREAK)
+check("a pre-1.0 MINOR with a real break still passes (SemVer §4)", code == 0, f"exit {code}")
+
+# 7. Absence is failure. An unreadable or unrecognisable report is not a clean one.
+code, out = run("1.0.0", "1.1.0", 3, UNRECOGNISED)
+check("a report with no recognisable [BC] line FAILS", code == 1, f"exit {code}")
+check("...and tells the reader to fix the parser, not relax the check",
+      "do not relax" in out, out.strip()[:200])
+
+code, out = run("1.0.0", "1.1.0", 3)
+missing = [sys.executable, GATE, "--previous", "1.0.0", "--current", "1.1.0",
+           "--bc-exit", "3", "--report", os.path.join(HERE, "no-such-report.md")]
+proc = subprocess.run(missing, capture_output=True, text=True, encoding="utf-8")
+check("a missing report FAILS rather than passing", proc.returncode == 1,
+      f"exit {proc.returncode}")
+
+# 8. No breaks at all: --report is irrelevant and must not be consulted.
+code, out = run("1.0.0", "1.1.0", 0, REAL_BREAK)
+check("bc-exit 0 passes regardless of what the report file contains", code == 0, f"exit {code}")
+
+print()
+if failures:
+    print(f"{len(failures)} case(s) failed: {', '.join(failures)}")
+    sys.exit(1)
+print("all cases behaved as specified")


### PR DESCRIPTION
## Summary

**The backward-compatibility gate could never have passed a release.** Found by the `v1.1.0`
release PR ([#156](https://github.com/danielPoloWork/egl-util-php/pull/156)), which is blocked on
this. ADR-0031 annotated.

That PR went red on `quality / backward compatibility` in 22 seconds, with one finding:

```
- [BC] Value of constant D4np\Utils\Version::VERSION changed from '1.0.0' to '1.1.0'
The checker exited 3 (0 means no backward-incompatible change).
bc gate: FAIL — backward-incompatible changes in a MINOR bump after 1.0.
```

That is the version bump. `Version::VERSION` is a **public constant**, Roave reports a public
constant's value changing as a break, and a release PR changes exactly that constant by definition.

Not "was likely to fail" — **could not pass**, for any post-1.0 MINOR or PATCH, ever.

## Why nobody knew

The job self-skips when there is no tag to compare against, and it only runs on release PRs. Before
`v1.0.0` existed it printed:

```
##[notice]This repository has no v*.*.* tag, and roave/backward-compatibility-check needs one
to compare against. The gate self-enables at the first tag.
```

…and reported **green**. The one release PR since — `v1.0.0` — had its comparison target deleted in
the same change. So this was the **first time the job ever actually executed**, and its first real
act was to refuse the release it exists to protect.

**Fifth instance of the vacuous-green class on this project**: items 2.7 (a gate wired to nothing),
10.8 (a mutation gate passing in ~7s on an absent config), 13.2 (a harness printing a PHP block as
text, exit 0), 13.7 (phpDocumentor exiting 0 with five ERROR rows), and this one.

The warning for *this specific job* was already written down after 10.8 — *never cite it as evidence
until a tag exists*. It was right and still insufficient: **knowing a check has not run tells you
nothing about what it will say when it does.**

## The fix, and the line I did not cross

`bc_gate.py` gains `--report` and discounts **one** finding: that exact symbol, anchored to its
class.

**Not** "constant value changes are fine". A consumer reading a version string does not break when
the string changes; a consumer reading any *other* constant might.

Two properties matter more than the discount itself:

- **It is printed on every run that uses it** — a discount nobody sees is a discount nobody can
  audit.
- **It does not swallow company.** The version line *alongside* a real break still fails.

Without `--report`, the tool behaves exactly as before — the change is additive to its contract as
well as to its behaviour.

Applied to the real report from #156's failing run:

```
bc gate: 1.0.0 -> 1.1.0 (MINOR bump), breaks detected: no

  DISCOUNTED 1 finding(s): the value of `D4np\Utils\Version::VERSION` changed.
  Roave reports a public constant's value changing as a break, and a release PR
  changes exactly that constant — so this one finding is what a release IS, not
  something a release does to a consumer. Nothing else is discounted: any other
  `[BC]` line still fails this gate on the same rules as before.

bc gate: OK — no backward-incompatible change since the previous release.
```

## The proof, and the case it exists for

`tools/tests/verify_bc_gate.py` — **14/14**:

```
  ok   a post-1.0 MINOR whose only break is Version::VERSION passes
  ok   ...and says so, rather than discounting silently
  ok   without --report a post-1.0 MINOR with breaks still FAILS
  ok   the version line ALONGSIDE a real break still FAILS        ← the reason for all the others
  ok   ...and still reports the discount, so the real break is not hidden by it
  ok   a real break alone still FAILS a post-1.0 MINOR
  ok   ...with no discount claimed
  ok   a PATCH whose only break is the version constant passes
  ok   a PATCH with a real break still FAILS
  ok   a pre-1.0 MINOR with a real break still passes (SemVer §4)
  ok   a report with no recognisable [BC] line FAILS
  ok   ...and tells the reader to fix the parser, not relax the check
  ok   a missing report FAILS rather than passing
  ok   bc-exit 0 passes regardless of what the report file contains
```

It runs in the `consistency` job on **every** PR, not only in the release-PR-only BC job: the
discount's narrowness is exactly what must not rot between releases, and releases are rare.

## A robustness hole my own test found

Reproducing the CI failure locally, the gate **refused** — `contains no [BC] line this gate
recognises` — and it was right to. PowerShell 5.1's `Out-File -Encoding utf8` writes a **BOM**,
which sits in front of `- [BC]` and defeats the line anchor. CI's `tee` writes none, so this would
never have surfaced there.

`utf-8-sig` instead of `utf-8` costs one word and removes a failure mode that reads as *"the report
format changed"* when nothing changed.

Worth naming: the gate's wrong answer here was still the **safe** answer — it refused rather than
passed. That is the direction to be wrong in, and it is why the refusal branch was written before it
was ever needed.

## ⚠️ The other red on #156 is not this

`quality / infection mutation score` also failed, in 23 seconds:

```
[ERROR] Project tests must be in a passing state before running Infection.
Failed asserting that 'Request to "http://127.0.0.1:38221/?mode=drip&run=…" produced no response'
Tests: 141, Assertions: 303, Failures: 1.
```

That is **T-07's dripping-origin wall-clock test** — a network-timing **flake**. The evidence is not
the 23 seconds: all three `build` cells (8.1, 8.2, 8.3) ran the same suite on the same commit and
**passed**. It should clear on a re-run.

Two reds on one PR, one real and one noise, and the only way to tell was reading both jobs instead
of counting failures.

## Design Patterns

None — a gate correction.

## Verification

- [x] `tools/tests/verify_bc_gate.py` — **14/14**
- [x] Run against **#156's actual failing report**: now passes, with the discount printed
- [x] Confirmed unchanged without `--report`: a post-1.0 MINOR with breaks still fails
- [x] `python tools/consistency_lint.py` — OK (808 links, run *after* staging)
- [x] `python tools/action_pin_lint.py` — OK; `ci.yml` parses as valid YAML
- [ ] Builds cleanly on the full CI matrix (Linux (PHP 8.1, 8.2, 8.3)) — note this branch is **not**
      a release PR, so the BC job will self-skip on it; the fix is exercised by the proof script,
      which does run here
- n/a Unit tests / CS-Fixer / PHPStan / coverage / benchmarks — no PHP source or test changes

## Documentation Impact

- [x] **ADR-0031** — Status annotation recording the one discount; the decision itself unchanged
      (annotated, not edited — ADR-0041's precedent)
- [x] CHANGELOG `[Unreleased]` → `Fixed`
- [x] Journal entry added and indexed
- [ ] ROADMAP — no item maps to this; it is a defect fix found in passing
- [x] PR metadata: assignee (owner), one type label (`fix`), no milestone

## Merge order

**This one first**, then #156 rebases onto it and its BC check goes green. Sequenced as a separate
PR rather than folded into the release branch, following your own call earlier this session when a
broken gate was blocking other work: the release PR stays a release, this stays a gate fix.
