### PR TITLE
fix(build): assert the dist's contents, not .gitattributes' rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,10 +10,15 @@
 # contains, never a full `git clone` — nothing here removes a file from the repository
 # or from CI. Everything a consumer needs is: the autoloaded source (`src/main`),
 # `composer.json`, `LICENSE`, and `README.md` for the page Packagist itself renders.
-# Silence rather than a positive list, because the alternative (allowlisting src/main
-# only) breaks the moment a new top-level file is added and nobody remembers this rule.
+# NOTE, and it corrects what this comment used to claim. It argued for a deny-list on the
+# grounds that "allowlisting src/main only breaks the moment a new top-level file is added and
+# nobody remembers this rule". That has the failure direction backwards: a deny-list INCLUDES a
+# new top-level file by default, so it rots the same way and silently, while an allowlist would
+# have failed loudly the first time something legitimate was missing. `phpdoc.dist.xml` proved
+# it — added in #154, after these rules, and it shipped in v1.1.0's dist.
 #
-# Verify with: git archive HEAD | tar -t
+# Neither list is self-maintaining, so the contents are asserted instead of the rules:
+#   python tools/dist_gate.py       (CI runs it on every PR)
 /.eados-core export-ignore
 /.github export-ignore
 /.specs export-ignore
@@ -23,6 +28,7 @@
 /src/test export-ignore
 /tools export-ignore
 /.php-cs-fixer.dist.php export-ignore
+/phpdoc.dist.xml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /AGENTS.md export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,14 @@ jobs:
       # is exactly what must not rot between releases, and this is where it gets checked.
       - name: Verify the BC gate's version-constant discount is narrow
         run: python tools/tests/verify_bc_gate.py
+      # The dist's CONTENTS, not .gitattributes' rules (issue #119). A rule list cannot tell you
+      # about a file nobody wrote a rule for, which is exactly how phpdoc.dist.xml shipped in
+      # v1.1.0's archive. Runs on every PR, because the PR that adds a top-level file is the only
+      # moment anyone would think about it.
+      - name: Assert the dist contains only what a consumer needs
+        run: python tools/dist_gate.py
+      - name: Verify the dist gate can fail
+        run: python tools/tests/verify_dist_gate.py
       # ADR-0003's gate. Runs WITH --verify-upstream: the offline half only checks the pin
       # shape, and a version comment that lies is invisible to any purely local check when the
       # error is applied uniformly. CI is where the truthful half must run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,21 @@ the GitHub Release body. Editing "the release notes" almost always means that on
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **`phpdoc.dist.xml` no longer ships in the Packagist dist**, and a gate now asserts the dist's
+  contents rather than trusting the rule list (issue #119). `.gitattributes`' `export-ignore` rules
+  cut the archive from 524 files to 121 at `v1.1.0` — and `phpdoc.dist.xml` shipped inside it
+  anyway, added in a later PR with no rule of its own and unnoticed until the tag was published.
+  **The reasoning that failed was written down as if it were sound**: `.gitattributes` argued a
+  deny-list avoids the rot an allowlist suffers, when a deny-list **includes** a new top-level file
+  by default and so rots the same way, silently. Neither list is self-maintaining. `tools/dist_gate.py`
+  asserts what is actually in `git archive` — everything under `src/main/` plus `LICENSE`,
+  `README.md`, `composer.json`, and nothing else — and refuses (exit 2) an archive it cannot read
+  or one containing no source at all. It found the real leak on its first run, before any synthetic
+  case existed; `tools/tests/verify_dist_gate.py` is the repeatable half.
+  `v1.1.0`'s published dist is unchanged: one 1.5 KB config file does not justify moving a tag.
+
 
 ## Released versions
 

--- a/tools/dist_gate.py
+++ b/tools/dist_gate.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Daniel Polo
+"""Assert the Packagist dist contains only what a consumer needs (issue #119).
+
+`.gitattributes`' `export-ignore` rules cut the archive from 524 files to 121 at `v1.1.0`. Then
+`phpdoc.dist.xml` shipped in it anyway — added in #154, *after* #152 wrote those rules, with no
+rule of its own. Nobody noticed until the tag was already published.
+
+**The reasoning that failed is worth naming, because it was written down as if it were sound.**
+`.gitattributes` argued for a deny-list on the grounds that "allowlisting `src/main` only breaks
+the moment a new top-level file is added and nobody remembers this rule". That has the failure
+direction backwards: a deny-list **includes** a new top-level file by default, so it rots the same
+way and *silently*, while an allowlist would have failed loudly the first time something legitimate
+was missing. Neither list is self-maintaining. A check is.
+
+So this asserts the *contents*, not the rules:
+
+    python tools/dist_gate.py [--ref HEAD]
+
+Exit 0 when the archive holds only the permitted set; 1 when anything else is in it, naming each
+file; **2** when the archive cannot be produced or read — because an archive nobody could inspect
+is not an archive that passed.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# What a consumer needs: the autoloaded source, the manifest, the licence, and the page Packagist
+# renders. `composer.json`'s own `autoload.psr-4` is the authority for the first one, so a future
+# move of the source root fails here loudly rather than silently shipping nothing.
+ALLOWED_FILES = {"LICENSE", "README.md", "composer.json"}
+ALLOWED_PREFIX = "src/main/"
+
+
+def out(message):
+    sys.stdout.buffer.write((message + "\n").encode("utf-8"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ref", default="HEAD", help="the ref to archive (default: HEAD)")
+    args = ap.parse_args()
+
+    handle, archive = tempfile.mkstemp(suffix=".tar")
+    os.close(handle)
+    try:
+        proc = subprocess.run(
+            ["git", "-C", ROOT, "archive", args.ref, "-o", archive],
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            out(f"dist gate: FAIL — `git archive {args.ref}` failed: {proc.stderr.strip()}")
+            return 2
+
+        try:
+            with tarfile.open(archive) as tar:
+                members = [m.name.replace(os.sep, "/") for m in tar.getmembers() if m.isfile()]
+        except (tarfile.TarError, OSError) as exc:
+            out(f"dist gate: FAIL — cannot read the archive: {exc}")
+            return 2
+    finally:
+        os.unlink(archive)
+
+    if not members:
+        # An empty archive would pass every "nothing unexpected is present" test ever written.
+        out(f"dist gate: FAIL — `git archive {args.ref}` produced no files at all.")
+        return 2
+
+    source = [m for m in members if m.startswith(ALLOWED_PREFIX)]
+    if not source:
+        out(f"dist gate: FAIL — the archive contains nothing under {ALLOWED_PREFIX}. "
+            "A dist with no source is not a dist.")
+        return 2
+
+    unexpected = sorted(
+        m for m in members
+        if not m.startswith(ALLOWED_PREFIX) and m not in ALLOWED_FILES
+    )
+
+    if unexpected:
+        out(f"dist gate: FAIL — {len(unexpected)} file(s) in the dist that a consumer does not "
+            "need:")
+        for name in unexpected:
+            out(f"  {name}")
+        out("")
+        out("  Permitted: everything under src/main/, plus " + ", ".join(sorted(ALLOWED_FILES)) + ".")
+        out("  Add an `export-ignore` line in .gitattributes, or extend this gate if the file is "
+            "genuinely part of the package.")
+        return 1
+
+    out(f"dist gate: OK — {len(members)} file(s), {len(source)} under {ALLOWED_PREFIX} plus "
+        + ", ".join(sorted(ALLOWED_FILES)) + ".")
+    out("  Asserted on the archive's CONTENTS, not on .gitattributes' rules: a rule list cannot "
+        "tell you about a file nobody wrote a rule for.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/verify_dist_gate.py
+++ b/tools/tests/verify_dist_gate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Daniel Polo
+"""Prove `dist_gate.py` can fail (issue #119).
+
+Its strongest evidence is already spent and was never synthetic: run against `master` before the
+missing rule was added, it named `phpdoc.dist.xml` — a file that had shipped in `v1.1.0`'s published
+archive and that nobody had noticed. Once the rule lands that demonstration is gone, so the
+repeatable half lives here, the way `verify_link_check.py`, `verify_diff_coverage_gate.py`,
+`verify_release_body.py`, `verify_bc_gate.py` and `verify_api_docs_gate.py` do.
+
+Each case builds a throwaway git repository with its own `.gitattributes`, copies the real gate in
+so `ROOT` resolves there, and runs it. The cases that matter are the refusals: a stray top-level
+file fails, and an archive with **no source at all** fails rather than passing — because "nothing
+unexpected is present" is trivially true of an empty archive, and that is the shape every one of
+this project's five vacuous-green defects took.
+
+    python tools/tests/verify_dist_gate.py
+
+Exits 0 when every case behaves as specified, 1 otherwise.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(os.path.dirname(HERE), "dist_gate.py")
+
+failures = []
+
+
+def check(name, condition, detail=""):
+    if condition:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name}{(' — ' + detail) if detail else ''}")
+        failures.append(name)
+
+
+def run_case(files, gitattributes):
+    """Build a throwaway repo, commit it, and run the real gate inside it."""
+    root = tempfile.mkdtemp(prefix="distgate-")
+    try:
+        os.makedirs(os.path.join(root, "tools"))
+        shutil.copy(GATE, os.path.join(root, "tools", "dist_gate.py"))
+        for rel in files:
+            full = os.path.join(root, rel.replace("/", os.sep))
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            with open(full, "w", encoding="utf-8") as handle:
+                handle.write("x\n")
+        with open(os.path.join(root, ".gitattributes"), "w", encoding="utf-8") as handle:
+            handle.write(gitattributes)
+
+        quiet = {"capture_output": True, "text": True, "cwd": root}
+        subprocess.run(["git", "init", "-q"], **quiet)
+        subprocess.run(["git", "config", "user.email", "t@t.test"], **quiet)
+        subprocess.run(["git", "config", "user.name", "T"], **quiet)
+        subprocess.run(["git", "add", "-A"], **quiet)
+        subprocess.run(["git", "commit", "-qm", "c"], **quiet)
+
+        proc = subprocess.run(
+            [sys.executable, os.path.join(root, "tools", "dist_gate.py")],
+            capture_output=True, text=True, encoding="utf-8", cwd=root,
+        )
+        return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+IGNORE_TOOLING = "/tools export-ignore\n/.gitattributes export-ignore\n"
+
+print("verify_dist_gate.py")
+
+# 1. The permitted set exactly.
+code, out = run_case(
+    ["src/main/php/A.php", "LICENSE", "README.md", "composer.json"],
+    IGNORE_TOOLING,
+)
+check("the permitted set alone passes", code == 0, f"exit {code}: {out.strip()[:120]}")
+check("...and says the verdict came from the contents, not the rules",
+      "CONTENTS" in out, out.strip()[:140])
+
+# 2. ★ A stray top-level file — the phpdoc.dist.xml shape.
+code, out = run_case(
+    ["src/main/php/A.php", "LICENSE", "README.md", "composer.json", "phpdoc.dist.xml"],
+    IGNORE_TOOLING,
+)
+check("a stray top-level config file FAILS", code == 1, f"exit {code}")
+check("...and names it", "phpdoc.dist.xml" in out, out.strip()[:160])
+
+# 3. A whole directory nobody excluded.
+code, out = run_case(
+    ["src/main/php/A.php", "LICENSE", "README.md", "composer.json", "src/test/php/ATest.php"],
+    IGNORE_TOOLING,
+)
+check("an un-excluded source subtree FAILS", code == 1, f"exit {code}")
+check("...and names the file inside it", "src/test/php/ATest.php" in out, out.strip()[:200])
+
+# 4. ★ THE ONE THAT MATTERS MOST: no source at all must not pass.
+code, out = run_case(
+    ["src/main/php/A.php", "LICENSE", "README.md", "composer.json"],
+    IGNORE_TOOLING + "/src export-ignore\n",
+)
+check("an archive with NO source exits 2 rather than passing", code == 2, f"exit {code}")
+check("...and says a dist with no source is not a dist",
+      "not a dist" in out, out.strip()[:200])
+
+# 5. Everything excluded — the empty-archive degenerate case.
+code, out = run_case(
+    ["src/main/php/A.php", "LICENSE"],
+    IGNORE_TOOLING + "/src export-ignore\n/LICENSE export-ignore\n",
+)
+check("an empty archive exits 2 rather than passing", code == 2, f"exit {code}")
+
+print()
+if failures:
+    print(f"{len(failures)} case(s) failed: {', '.join(failures)}")
+    sys.exit(1)
+print("all cases behaved as specified")


### PR DESCRIPTION
## Summary

Closing #119 meant measuring the dist at the tag, and the measurement found a leak: **`phpdoc.dist.xml`
shipped in `v1.1.0`'s published archive.** Added in #154, *after* #152 wrote the `export-ignore`
rules, with no rule of its own.

This adds the missing rule — and, more importantly, a gate that asserts the archive's **contents**
so a rule list can no longer rot unnoticed.

## The reasoning that failed, and it was written down as if it were sound

`.gitattributes` argued for a deny-list on these grounds:

> Silence rather than a positive list, because the alternative (allowlisting `src/main` only) breaks
> the moment a new top-level file is added and nobody remembers this rule.

**That has the failure direction backwards.** A deny-list **includes** a new top-level file by
default, so it rots the same way — and *silently*. An allowlist would have failed loudly the first
time something legitimate went missing.

`phpdoc.dist.xml` proved it, and the comment is corrected in place rather than quietly deleted:
being wrong in a comment that reads as confident is worth leaving a trace of.

## The fix asserts contents, not rules

`tools/dist_gate.py` — everything under `src/main/` plus `LICENSE`, `README.md`, `composer.json`,
and nothing else:

```
dist gate: OK — 120 file(s), 117 under src/main/ plus LICENSE, README.md, composer.json.
  Asserted on the archive's CONTENTS, not on .gitattributes' rules: a rule list cannot
  tell you about a file nobody wrote a rule for.
```

It **refuses (exit 2)** on an archive it cannot produce or read, one containing **no source at
all**, and an empty one. That last case is the point: *"nothing unexpected is present"* is trivially
true of an empty archive, and that is the shape all **five** of this project's vacuous-green defects
took (items 2.7, 10.8, 13.2, 13.7, and the BC gate in #157).

**It found the real leak on its first run against `master`**, before any synthetic case existed.

## The proof

`tools/tests/verify_dist_gate.py` — **9/9**, each case a throwaway git repository:

```
  ok   the permitted set alone passes
  ok   ...and says the verdict came from the contents, not the rules
  ok   a stray top-level config file FAILS          ← the phpdoc.dist.xml shape
  ok   ...and names it
  ok   an un-excluded source subtree FAILS
  ok   ...and names the file inside it
  ok   an archive with NO source exits 2 rather than passing   ← the one that matters most
  ok   ...and says a dist with no source is not a dist
  ok   an empty archive exits 2 rather than passing
```

Wired into the `consistency` job on every PR, because **the PR that adds a top-level file is the only
moment anyone would think about this.**

## One mechanic worth recording

`git archive` reads `.gitattributes` from the **committed** tree, not the working tree. The gate kept
reporting the leak after I added the rule, until the rule was committed.

Same family as the links check reading `git ls-files`: a tool that consults git's index or history
does not see your unstaged edit, and reading its verdict before committing invites the wrong
conclusion. Twice in one session now.

## `v1.1.0`'s dist is deliberately unchanged

One 1.5 KB config file does not justify moving a published tag — and the frozen-dist reasoning is
#119's own: *every later tag benefits*. The next tag ships 120 files.

## Design Patterns

None.

## Verification

- [x] `python tools/dist_gate.py` — **OK**, 120 files (121 before this change)
- [x] Confirmed it **fails** on the real defect: run against `master` it named `phpdoc.dist.xml`
- [x] `python tools/tests/verify_dist_gate.py` — **9/9**
- [x] `python tools/consistency_lint.py` — OK (run after staging)
- [x] `ci.yml` parses as valid YAML
- [ ] Builds cleanly on the full CI matrix (Linux (PHP 8.1, 8.2, 8.3))
- n/a Unit tests / CS-Fixer / PHPStan / coverage / benchmarks — no PHP source or test changes

## Documentation Impact

- [x] `.gitattributes` — missing rule added, and the comment's backwards reasoning corrected
- [x] CHANGELOG `[Unreleased]` → `Fixed`
- [ ] ADR — none. No decision is made here; #119's bar was already the criterion, and this enforces
      it rather than choosing it
- [ ] ROADMAP / journal — none; a fix-forward on a closed issue
- [x] PR metadata: assignee (owner), one type label (`build`), no milestone

## Note on #119

Already closed, with the leak and the *"through the full release gate"* clause both stated in the
closing comment rather than glossed — that second clause was **not** met, because the unsigned tag
skipped `verify-tag`, the matrix and the draft job. That remains #115.
