### PR TITLE
docs(docs): make README's install section version-independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ the GitHub Release body. Editing "the release notes" almost always means that on
 
 ### Fixed
 
+- **`README.md`'s install section no longer describes a one-release world.** It said `^1.0` resolves
+  v1.0.0, *"the only published release"*, and carried a warning box announcing that Milestone 14 was
+  *"merged but unreleased"*. Both were true when written in #147 and were made false by v1.1.0 — and
+  `README.md` is the page Packagist renders, so they were the first thing a consumer read.
+  Rewritten to be **version-independent** rather than re-pinned to the newest tag: the constraint
+  advice no longer names a resolving version, the dependency list says which package arrives when
+  instead of counting them, and the box now explains that `master` runs ahead of the newest tag by
+  design, pointing at `[Unreleased]` as the part you cannot install yet. A claim that has to be
+  edited on every release is a claim that will be wrong between them.
+
 - **`phpdoc.dist.xml` no longer ships in the Packagist dist**, and a gate now asserts the dist's
   contents rather than trusting the rule list (issue #119). `.gitattributes`' `export-ignore` rules
   cut the archive from 524 files to 121 at `v1.1.0` — and `phpdoc.dist.xml` shipped inside it

--- a/README.md
+++ b/README.md
@@ -60,25 +60,30 @@ composer require egl/utils
 ```
 
 It resolves from **[Packagist](https://packagist.org/packages/egl/utils)** — no VCS repository
-entry needed. `^1.0` resolves **v1.0.0** today, the only published release; the API is frozen for
-the whole 1.x line ([ADR-0059](docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md)).
-Installing pulls three packages in total — this one plus the interface-only `psr/container` and
-`psr/log`.
+entry needed. The API is frozen for the whole 1.x line
+([ADR-0059](docs/adr/0059-freeze-the-api-at-1-0-0-with-internal-symbols-outside-the-frozen-surface.md)),
+so `^1.0` is a safe constraint and picks up every release in it. Its only hard dependencies are
+interface-only packages — `psr/container`, `psr/log`, and `psr/clock` from v1.1.0 onward.
+
+Released so far: **v1.1.0** (M14's five additive seams and M13's close-out) and **v1.0.0** (the
+first release and the freeze). What each contains is in [`CHANGELOG.md`](CHANGELOG.md); why you
+might upgrade is in [`docs/releases/`](docs/releases/).
 
 **Requires** PHP ≥ 8.1 with `ext-pdo` and `ext-fileinfo`. Two things are *suggested* rather than
 required, and each refuses at the call site when absent rather than degrading silently:
 `ext-iconv` (for `Str::transcode()`) and `symfony/html-sanitizer` (for `Sanitizer::richText()`).
 
-> **`master` is ahead of what installs.** Milestone 14 is merged but unreleased, so
-> `SystemClock`/`FrozenClock`, `Str::ulid()`/`uuidV7()`, `Hmac`, `RateLimiter`, `PageRequest`/`Page`
-> and `RetryPolicy` are in this repository but **not in v1.0.0**. Read the surface tables above as
-> the repository's; read [`CHANGELOG.md`](CHANGELOG.md) for what a given version contains.
+> **`master` runs ahead of the newest tag, by design.** Work lands on `master` continuously and is
+> released in batches, so the surface tables above describe the *repository*. For what a given
+> version actually contains, read [`CHANGELOG.md`](CHANGELOG.md) — `[Unreleased]` is exactly the
+> part you cannot install yet.
 
 ## Quickstart
 
-Four tasks, each a complete program. Every example below was executed against `egl/utils` **v1.0.0
-installed from Packagist** — not against this working tree — and the output shown is what it
-printed.
+Four tasks, each a complete program. Every example below was executed against `egl/utils`
+**installed from Packagist** — not against this working tree — and the output shown is what it
+printed. They were verified at **v1.0.0** and the 1.x freeze keeps them valid: nothing they use has
+changed shape since.
 
 ### Hydrate a DTO
 


### PR DESCRIPTION
## Summary

**`v1.1.0` made two `README.md` claims false, and `README.md` is the page Packagist renders** — so
they were the first thing a consumer read.

| Claim | Status |
|---|---|
| *"`^1.0` resolves **v1.0.0** today, the only published release"* | false since `v1.1.0` |
| *"**`master` is ahead of what installs.** Milestone 14 is merged but unreleased … **not in v1.0.0**"* | false since `v1.1.0` |

Both were **true when I wrote them in #147**. The release falsified them. Same shape as #122's
*"the one the gate approved"*: accurate at the moment of writing, read later as a fact.

## Fixed by removing the dependence on "today", not by re-pinning

Re-pointing these at `v1.1.0` would buy correctness until the next tag and then break again. So:

- **The constraint advice names no resolving version.** `^1.0` is safe *because the 1.x API is
  frozen*, which is a property of the line rather than of whichever tag is newest.
- **The dependency list says which package arrives when** instead of counting them —
  `psr/container`, `psr/log`, and `psr/clock` **from v1.1.0 onward**. The old text said "three
  packages", which was right for v1.0.0 and wrong for v1.1.0; a count is exactly the kind of fact
  that rots.
- **The warning box explains the standing arrangement**: `master` runs ahead of the newest tag by
  design, and `[Unreleased]` is the part you cannot install yet. That stays true release after
  release.
- A short *Released so far* line names v1.1.0 and v1.0.0 and points at `CHANGELOG.md` for contents
  and `docs/releases/` for whether to upgrade — the two-document split #106 established.

**The Quickstart's provenance line is kept and made precise rather than bumped.** The four examples
were executed at **v1.0.0**; the 1.x freeze is what keeps them valid. Saying which version they ran
against is more useful — and more honest — than implying they were re-run at v1.1.0.

## Design Patterns

None.

## Verification

- [x] `psr/clock` confirmed present in `composer.json`'s `require` before claiming it
- [x] `python tools/consistency_lint.py` — OK (run after staging)
- [x] `python tools/dist_gate.py` — OK, 120 files (the new gate from #160, exercised here)
- [ ] Builds cleanly on the full CI matrix (Linux (PHP 8.1, 8.2, 8.3))
- n/a Unit tests / CS-Fixer / PHPStan / coverage / benchmarks — documentation only

## Documentation Impact

- [x] `README.md` — Install section, warning box, Quickstart provenance
- [x] CHANGELOG `[Unreleased]` → `Fixed`
- [ ] ADR / ROADMAP / journal — none; correcting a claim, not deciding anything
- [x] PR metadata: assignee (owner), one type label (`documentation`), no milestone

## ⚠️ Two things this does **not** fix, and one is blocking

Found while checking the README's claims against reality:

1. **Packagist still serves only `v1.0.0`.** `repo.packagist.org/p2/egl/utils.json` lists one
   version, at `be7f34e`. The tag `v1.1.0` exists on GitHub, but **`composer require egl/utils:^1.1`
   cannot resolve today** — so v1.1.0 is tagged and not installable, which is the problem the release
   was meant to end. Either the GitHub→Packagist auto-update is not wired (v1.0.0 arrived via the
   one-time manual registration in #121) or it has not fired. A manual **Update** on the Packagist
   package page settles it either way; wiring the hook is the durable fix. **Your account, not
   mine.**
2. **No GitHub Release for `v1.1.0`.** `draft-release` was skipped when `verify-tag` refused the
   unsigned tag, so `gh release list` shows only v1.0.0. The body is ready:

   ```bash
   python tools/release_body.py --tag v1.1.0
   ```

Neither is in this PR's scope, and neither is something I can do from here.
